### PR TITLE
Extracts Structs from sql to go builder to transaction objects

### DIFF
--- a/internal/common/builder/sql_to_go_builder.go
+++ b/internal/common/builder/sql_to_go_builder.go
@@ -32,7 +32,6 @@
 package builder
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -41,38 +40,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
-// AssetAdministrationShellDescriptorRow represents a single SQL result row
-// for an Asset Administration Shell (AAS) descriptor. It carries nullable
-// string/integer columns from the database and foreign-key references to
-// related records such as administrative information, display names, and
-// descriptions.
-type AssetAdministrationShellDescriptorRow struct {
-	DescID        int64
-	AssetKindStr  sql.NullString
-	AssetType     sql.NullString
-	GlobalAssetID sql.NullString
-	IDShort       sql.NullString
-	IDStr         string
-	AdminInfoID   sql.NullInt64
-	DisplayNameID sql.NullInt64
-	DescriptionID sql.NullInt64
-}
-
-// SubmodelDescriptorRow represents a single SQL result row for a Submodel
-// descriptor that is associated with an AAS descriptor. It includes the
-// database identifiers of the AAS and Submodel descriptors as well as
-// optional columns and foreign-key references such as semantic reference
-// and administrative information.
-type SubmodelDescriptorRow struct {
-	AasDescID     int64
-	SmdDescID     int64
-	IDShort       sql.NullString
-	ID            sql.NullString
-	SemanticRefID sql.NullInt64
-	AdminInfoID   sql.NullInt64
-	DescriptionID sql.NullInt64
-	DisplayNameID sql.NullInt64
-}
 // ParseReferredReferencesFromRows parses referred reference data from already unmarshalled ReferredReferenceRow objects.
 //
 // This function handles the complex case where references point to other references (referred references).

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
-	"github.com/eclipse-basyx/basyx-go-components/internal/common/builder"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	persistence_utils "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence/utils"
 	"golang.org/x/sync/errgroup"
@@ -427,9 +426,9 @@ func ListAssetAdministrationShellDescriptors(
 		_ = rows.Close()
 	}()
 
-	descRows := make([]builder.AssetAdministrationShellDescriptorRow, 0, peekLimit)
+	descRows := make([]model.AssetAdministrationShellDescriptorRow, 0, peekLimit)
 	for rows.Next() {
-		var r builder.AssetAdministrationShellDescriptorRow
+		var r model.AssetAdministrationShellDescriptorRow
 		if err := rows.Scan(
 			&r.DescID,
 			&r.AssetKindStr,

--- a/internal/common/descriptors/ReadSubmodulDescriptor.go
+++ b/internal/common/descriptors/ReadSubmodulDescriptor.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/doug-martin/goqu/v9"
-	"github.com/eclipse-basyx/basyx-go-components/internal/common/builder"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/lib/pq"
 	"golang.org/x/sync/errgroup"
@@ -106,7 +105,7 @@ func ReadSubmodelDescriptorsByAASDescriptorIDs(
 		_ = rows.Close()
 	}()
 
-	perAAS := make(map[int64][]builder.SubmodelDescriptorRow, len(uniqAASDesc))
+	perAAS := make(map[int64][]model.SubmodelDescriptorRow, len(uniqAASDesc))
 	allSmdDescIDs := make([]int64, 0, 10000)
 	semRefIDs := make([]int64, 0, 10000)
 	adminInfoIDs := make([]int64, 0, 10000)
@@ -114,7 +113,7 @@ func ReadSubmodelDescriptorsByAASDescriptorIDs(
 	displayNameIDs := make([]int64, 0, 10000)
 
 	for rows.Next() {
-		var r builder.SubmodelDescriptorRow
+		var r model.SubmodelDescriptorRow
 		if err := rows.Scan(
 			&r.AasDescID,
 			&r.SmdDescID,

--- a/internal/common/model/transactionObjects.go
+++ b/internal/common/model/transactionObjects.go
@@ -529,3 +529,36 @@ type BlobElementValueRow struct {
 	// Value contains the blob data as a byte array
 	Value string `json:"value"`
 }
+
+// AssetAdministrationShellDescriptorRow represents a single SQL result row
+// for an Asset Administration Shell (AAS) descriptor. It carries nullable
+// string/integer columns from the database and foreign-key references to
+// related records such as administrative information, display names, and
+// descriptions.
+type AssetAdministrationShellDescriptorRow struct {
+	DescID        int64
+	AssetKindStr  sql.NullString
+	AssetType     sql.NullString
+	GlobalAssetID sql.NullString
+	IDShort       sql.NullString
+	IDStr         string
+	AdminInfoID   sql.NullInt64
+	DisplayNameID sql.NullInt64
+	DescriptionID sql.NullInt64
+}
+
+// SubmodelDescriptorRow represents a single SQL result row for a Submodel
+// descriptor that is associated with an AAS descriptor. It includes the
+// database identifiers of the AAS and Submodel descriptors as well as
+// optional columns and foreign-key references such as semantic reference
+// and administrative information.
+type SubmodelDescriptorRow struct {
+	AasDescID     int64
+	SmdDescID     int64
+	IDShort       sql.NullString
+	ID            sql.NullString
+	SemanticRefID sql.NullInt64
+	AdminInfoID   sql.NullInt64
+	DescriptionID sql.NullInt64
+	DisplayNameID sql.NullInt64
+}


### PR DESCRIPTION
## Description of Changes
This pull request refactors the location of two key SQL result row types (`AssetAdministrationShellDescriptorRow` and `SubmodelDescriptorRow`) by moving them from the `builder` package to the `model` package. The change ensures that these data structures are defined closer to where the domain models are managed, improving code organization and clarity. All usages of these types are updated accordingly in the codebase.

**Type relocation and code organization:**

* Moved the definitions of `AssetAdministrationShellDescriptorRow` and `SubmodelDescriptorRow` from `internal/common/builder/sql_to_go_builder.go` to `internal/common/model/transactionObjects.go`, centralizing model-related types in the `model` package. [[1]](diffhunk://#diff-6c0bf8071e90caa7d28b37b74530ba77072ab571d353136d6ed596131ae8b221L44-L75) [[2]](diffhunk://#diff-830c745ac0eaaa5bd0e78f360bebd7dc625a75c3fa6957491f5c077ebea7ea13R532-R564)

**Dependency updates:**

* Removed the import of the `builder` package from files that previously relied on these types, including `AssetAdminShellDescriptorHandler.go` and `ReadSubmodulDescriptor.go`. [[1]](diffhunk://#diff-e7efa46672cdb7c8674437564c4856d237c6a8afaa31eb3423db876483de29bfL27) [[2]](diffhunk://#diff-8830f0c3cd43c9d72894bc26a56a7bd69596cb61cb8c5f7aa552b061bff48880L9)

**Code usage updates:**

* Updated all references and variable declarations for `AssetAdministrationShellDescriptorRow` and `SubmodelDescriptorRow` in the affected handlers and functions to use the types from the `model` package instead of the `builder` package. [[1]](diffhunk://#diff-e7efa46672cdb7c8674437564c4856d237c6a8afaa31eb3423db876483de29bfL430-R431) [[2]](diffhunk://#diff-8830f0c3cd43c9d72894bc26a56a7bd69596cb61cb8c5f7aa552b061bff48880L109-R116)

## Related Issue
closes #79 

## BaSyx Configuration for Testing

AAS Registry Integration Tests

## AAS Files Used for Testing

--
## Additional Information

--