### PR TITLE
fixed externalSubjectId in secured example

### DIFF
--- a/examples/BaSyxSecuredExample/security_env/access-rules.json
+++ b/examples/BaSyxSecuredExample/security_env/access-rules.json
@@ -28,11 +28,17 @@
       { "USEACL": "read_anonymous", "USEOBJECTS": ["description"], "USEFORMULA": "always_true" },
       { "USEACL": "write_admin", "USEOBJECTS": ["all_shell_descriptors", "all_assetlinks"], "USEFORMULA": "role_is_admin" },
       { "USEACL": "read_role", "USEOBJECTS": ["all_shell_descriptors", "all_assetlinks"], "FORMULA": 
-        {"$and": [
-          {"$eq": [ { "$attribute": { "CLAIM": "role" } }, { "$strVal": "viewer" } ] },
-          {"$starts-with": [{"$field": "$aasdesc#globalAssetId"}, {"$strVal": "https://htw-berlin.de"}]}
-        ]
-      }}
+
+            {"$eq": [ { "$attribute": { "CLAIM": "role" } }, { "$strVal": "viewer" } ] },
+
+        "FILTER": {
+          "FRAGMENT": "$aasdesc#specificAssetIds[].externalSubjectId",
+          "CONDITION": 
+           {
+            "$boolean": false
+          }
+        }
+      }
     ]
   }
 }

--- a/examples/BaSyxSecuredExample/security_env/trustlist.json
+++ b/examples/BaSyxSecuredExample/security_env/trustlist.json
@@ -1,6 +1,6 @@
 [
   {
-    "issuer": "http://keycloak.basyx.localhost/realms/basyx",
+    "issuer": "http://keycloak.basyx.localhost:8080/realms/basyx",
     "audience": "discovery-service",
     "scopes": ["email", "profile"]
   }

--- a/internal/common/descriptors/ReadSpecificAssetId.go
+++ b/internal/common/descriptors/ReadSpecificAssetId.go
@@ -65,7 +65,8 @@ var expMapper = []auth.ExpressionIdentifiableMapper{
 		Exp: tSpecificAssetID.Col(colSemanticID),
 	},
 	{
-		Exp: tSpecificAssetID.Col(colExternalSubjectRef),
+		Exp:      tSpecificAssetID.Col(colExternalSubjectRef),
+		Fragment: fragPtr("$aasdesc#specificAssetIds[].externalSubjectId"),
 	},
 }
 


### PR DESCRIPTION
fixed secured example:
- added missing fragment in SpecificAssetIds
- some configs