### PR TITLE
Fixes wrong thumbnail field in asset-information

### DIFF
--- a/internal/aasrepository/integration_tests/aasrepository_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_integration_test.go
@@ -329,7 +329,7 @@ func TestThumbnailAttachmentOperations(t *testing.T) {
 		t.Logf("Thumbnail content verified: %d bytes", len(content))
 	})
 
-	t.Run("3_Get_AAS_By_ID_Includes_Thumbnail_In_AssetInformation", func(t *testing.T) {
+	t.Run("3_Get_AAS_By_ID_Includes_DefaultThumbnail_In_AssetInformation", func(t *testing.T) {
 		aasEndpoint := fmt.Sprintf("%s/shells/%s", baseURL, aasIdentifier)
 		payload, getStatus, getErr := getJSONResponse(aasEndpoint)
 		require.NoError(t, getErr, "AAS retrieval failed")
@@ -338,8 +338,8 @@ func TestThumbnailAttachmentOperations(t *testing.T) {
 		assetInformation, ok := payload["assetInformation"].(map[string]any)
 		require.True(t, ok, "assetInformation should be present")
 
-		thumbnail, ok := assetInformation["thumbnail"].(map[string]any)
-		require.True(t, ok, "assetInformation.thumbnail should be present")
+		thumbnail, ok := assetInformation["defaultThumbnail"].(map[string]any)
+		require.True(t, ok, "assetInformation.defaultThumbnail should be present")
 
 		thumbnailPath, ok := thumbnail["path"].(string)
 		require.True(t, ok, "thumbnail.path should be a string")
@@ -350,7 +350,7 @@ func TestThumbnailAttachmentOperations(t *testing.T) {
 		assert.Equal(t, "image/gif", thumbnailContentType, "thumbnail.contentType should match uploaded file")
 	})
 
-	t.Run("4_Get_AAS_List_Includes_Thumbnail_In_AssetInformation", func(t *testing.T) {
+	t.Run("4_Get_AAS_List_Includes_DefaultThumbnail_In_AssetInformation", func(t *testing.T) {
 		listEndpoint := fmt.Sprintf("%s/shells", baseURL)
 		payload, getStatus, getErr := getJSONResponse(listEndpoint)
 		require.NoError(t, getErr, "AAS list retrieval failed")
@@ -373,8 +373,8 @@ func TestThumbnailAttachmentOperations(t *testing.T) {
 			assetInformation, ok := aasMap["assetInformation"].(map[string]any)
 			require.True(t, ok, "assetInformation should be present in listed AAS")
 
-			thumbnail, ok := assetInformation["thumbnail"].(map[string]any)
-			require.True(t, ok, "assetInformation.thumbnail should be present in listed AAS")
+			thumbnail, ok := assetInformation["defaultThumbnail"].(map[string]any)
+			require.True(t, ok, "assetInformation.defaultThumbnail should be present in listed AAS")
 
 			thumbnailPath, ok := thumbnail["path"].(string)
 			require.True(t, ok, "thumbnail.path should be a string in listed AAS")

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -968,7 +968,7 @@ func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellMapByDBID(
 		assetInfo["assetType"] = assetType.String
 	}
 	if thumbnailMap := buildThumbnailMap(thumbnailPath, thumbnailContentType); len(thumbnailMap) > 0 {
-		assetInfo["thumbnail"] = thumbnailMap
+		assetInfo["defaultThumbnail"] = thumbnailMap
 	}
 
 	specificAssetIDs, specificErr := s.readSpecificAssetIDsByAssetInformationID(ctx, aasDBID)
@@ -1154,7 +1154,7 @@ func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellMapsByDBID
 			assetInfo["assetType"] = row.assetType.String
 		}
 		if thumbnailMap := buildThumbnailMap(row.thumbnailPath, row.thumbnailContentType); len(thumbnailMap) > 0 {
-			assetInfo["thumbnail"] = thumbnailMap
+			assetInfo["defaultThumbnail"] = thumbnailMap
 		}
 
 		specificAssetIDs := specificAssetIDsByAASID[aasDBID]


### PR DESCRIPTION
This pull request updates the handling and naming of thumbnail information within asset information structures in both the codebase and the integration tests. The main change is the renaming of the `thumbnail` field to `defaultThumbnail` for conformance to the spec.

**Thumbnail field renaming:**

* The field `thumbnail` in the `assetInformation` map is renamed to `defaultThumbnail` in the output of both `getAssetAdministrationShellMapByDBID` and `getAssetAdministrationShellMapsByDBID` functions in `aas_database.go`. [[1]](diffhunk://#diff-af55fb3206d849fbeed2ec4e2934767d31424b03cce0506ad20142af577f9e55L971-R971) [[2]](diffhunk://#diff-af55fb3206d849fbeed2ec4e2934767d31424b03cce0506ad20142af577f9e55L1157-R1157)

**Test updates for new field name:**

* All relevant integration tests in `aasrepository_integration_test.go` are updated to expect `assetInformation.defaultThumbnail` instead of `assetInformation.thumbnail`, including test names and assertions. [[1]](diffhunk://#diff-ffc7a290cff4f6f40eff51ab025da635965d73c0d960e3016e6153bd6d5783a4L332-R332) [[2]](diffhunk://#diff-ffc7a290cff4f6f40eff51ab025da635965d73c0d960e3016e6153bd6d5783a4L341-R342) [[3]](diffhunk://#diff-ffc7a290cff4f6f40eff51ab025da635965d73c0d960e3016e6153bd6d5783a4L353-R353) [[4]](diffhunk://#diff-ffc7a290cff4f6f40eff51ab025da635965d73c0d960e3016e6153bd6d5783a4L376-R377)