### PR TITLE
Fixes Docker Release Workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -83,10 +83,10 @@ jobs:
             
             # Build tag list
             TAGS="${{ matrix.service.image }}:${VERSION}"
-            TAGS="${TAGS},${{ matrix.service.image }}:${MAJOR}.${MINOR}.${PATCH}"
             
             # Only add major/minor/latest tags for non-prerelease versions
             if [ -z "$PRERELEASE" ]; then
+              TAGS="${TAGS},${{ matrix.service.image }}:${MAJOR}.${MINOR}.${PATCH}"
               TAGS="${TAGS},${{ matrix.service.image }}:${MAJOR}.${MINOR}"
               TAGS="${TAGS},${{ matrix.service.image }}:${MAJOR}"
               TAGS="${TAGS},${{ matrix.service.image }}:latest"


### PR DESCRIPTION
This pull request makes a small adjustment to the Docker image tagging logic in the `.github/workflows/docker-release.yml` workflow. The change ensures that the `${MAJOR}.${MINOR}.${PATCH}` tag is only added for non-prerelease versions, aligning it with the other stable tags. 

* Updated the Docker release workflow to only add the `${MAJOR}.${MINOR}.${PATCH}` tag for non-prerelease versions, preventing prerelease images from receiving stable tags. (`.github/workflows/docker-release.yml`)