### PR TITLE
Improves POST/PUT Performance

### DIFF
--- a/basyxschema.sql
+++ b/basyxschema.sql
@@ -567,9 +567,11 @@ CREATE INDEX IF NOT EXISTS ix_bee_lastupd ON basic_event_element(last_update);
 
 CREATE INDEX IF NOT EXISTS ix_qual_type     ON qualifier(type);
 CREATE INDEX IF NOT EXISTS ix_qual_position ON qualifier(position);
+CREATE INDEX IF NOT EXISTS ix_smeq_sme_id      ON submodel_element_qualifier(sme_id);
 CREATE INDEX IF NOT EXISTS ix_smeq_qualifier_id ON submodel_element_qualifier(qualifier_id);
 CREATE INDEX IF NOT EXISTS ix_smq_submodel_id   ON submodel_qualifier(submodel_id);
 CREATE INDEX IF NOT EXISTS ix_smq_qualifier_id  ON submodel_qualifier(qualifier_id);
+CREATE INDEX IF NOT EXISTS ix_operation_variable_operation_id ON operation_variable(operation_id);
 CREATE INDEX IF NOT EXISTS ix_operation_variable_value_sme ON operation_variable(value_sme);
 
 CREATE UNIQUE INDEX IF NOT EXISTS ix_aas_identifier_aasid ON aas_identifier(aasId);

--- a/internal/submodelrepository/persistence/submodel_database.go
+++ b/internal/submodelrepository/persistence/submodel_database.go
@@ -50,7 +50,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	jose "gopkg.in/go-jose/go-jose.v2"
 
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 )
 
 // SubmodelDatabase is the implementation of the SubmodelRepositoryDatabase interface using PostgreSQL as the underlying database.
@@ -294,21 +294,6 @@ func (s *SubmodelDatabase) CreateSubmodel(ctx context.Context, submodel types.IS
 func (s *SubmodelDatabase) createSubmodelInTransaction(tx *sql.Tx, submodel types.ISubmodel) error {
 	dialect := goqu.Dialect("postgres")
 
-	var count int
-	query := dialect.From("submodel").Prepared(true).Select(goqu.COUNT("id")).Where(goqu.C("submodel_identifier").Eq(submodel.ID()))
-	sqlQuery, args, err := query.ToSQL()
-	if err != nil {
-		return common.NewInternalServerError("SMREPO-NEWSM-CREATE-EXISTSQL " + err.Error())
-	}
-	err = tx.QueryRow(sqlQuery, args...).Scan(&count)
-
-	if err != nil {
-		return common.NewInternalServerError("SMREPO-NEWSM-CREATE-EXISTS " + err.Error())
-	}
-	if count > 0 {
-		return common.NewErrConflict("SMREPO-NEWSM-CREATE-CONFLICT submodel identifier already exists")
-	}
-
 	ids, args, err := buildSubmodelQuery(&dialect, submodel)
 	if err != nil {
 		return common.NewInternalServerError("SMREPO-NEWSM-CREATE-INSERTSQL " + err.Error())
@@ -316,6 +301,9 @@ func (s *SubmodelDatabase) createSubmodelInTransaction(tx *sql.Tx, submodel type
 
 	var submodelDBID int64
 	if err := tx.QueryRow(ids, args...).Scan(&submodelDBID); err != nil {
+		if mappedErr := mapCreateSubmodelInsertError(err); mappedErr != nil {
+			return mappedErr
+		}
 		return common.NewInternalServerError("SMREPO-NEWSM-CREATE-EXECSQL " + err.Error())
 	}
 
@@ -380,6 +368,24 @@ func (s *SubmodelDatabase) createSubmodelInTransaction(tx *sql.Tx, submodel type
 		if err != nil {
 			return common.NewInternalServerError("SMREPO-NEWSM-CREATESM-INSERTSME " + err.Error())
 		}
+	}
+
+	return nil
+}
+
+// mapCreateSubmodelInsertError maps database uniqueness violations to submodel conflict errors.
+func mapCreateSubmodelInsertError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	pqErr, ok := err.(*pq.Error)
+	if !ok {
+		return nil
+	}
+
+	if pqErr.Code == "23505" {
+		return common.NewErrConflict("SMREPO-NEWSM-CREATE-CONFLICT submodel identifier already exists")
 	}
 
 	return nil
@@ -1198,48 +1204,26 @@ func (s *SubmodelDatabase) replaceSubmodelInTransaction(tx *sql.Tx, submodelID s
 func cleanupSubmodelLargeObjects(tx *sql.Tx, submodelDatabaseID int64) error {
 	dialect := goqu.Dialect("postgres")
 
-	selectOIDQuery, selectOIDArgs, err := dialect.From(goqu.T("submodel_element").As("sme")).
+	unlinkSubquery := dialect.From(goqu.T("submodel_element").As("sme")).
+		Prepared(true).
 		Join(goqu.T("file_data").As("fd"), goqu.On(goqu.I("fd.id").Eq(goqu.I("sme.id")))).
-		Select(goqu.I("fd.file_oid")).
+		Select(goqu.Func("lo_unlink", goqu.I("fd.file_oid")).As("unlink_result")).
 		Where(
 			goqu.I("sme.submodel_id").Eq(submodelDatabaseID),
 			goqu.I("fd.file_oid").IsNotNull(),
-		).
+		)
+
+	unlinkQuery, unlinkArgs, err := dialect.From(unlinkSubquery.As("unlink_results")).
+		Prepared(true).
+		Select(goqu.COUNT("*")).
 		ToSQL()
 	if err != nil {
-		return common.NewInternalServerError("SMREPO-DELSM-LISTFILEOIDS " + err.Error())
+		return common.NewInternalServerError("SMREPO-DELSM-BUILDUNLINKQUERY " + err.Error())
 	}
 
-	rows, err := tx.Query(selectOIDQuery, selectOIDArgs...)
-	if err != nil {
-		return common.NewInternalServerError("SMREPO-DELSM-LISTFILEOIDS " + err.Error())
-	}
-	defer func() {
-		_ = rows.Close()
-	}()
-
-	for rows.Next() {
-		var oid sql.NullInt64
-		if err := rows.Scan(&oid); err != nil {
-			return common.NewInternalServerError("SMREPO-DELSM-SCANFILEOID " + err.Error())
-		}
-
-		if !oid.Valid {
-			continue
-		}
-
-		unlinkQuery, unlinkArgs, unlinkErr := dialect.Select(goqu.Func("lo_unlink", oid.Int64)).ToSQL()
-		if unlinkErr != nil {
-			return common.NewInternalServerError("SMREPO-DELSM-BUILDUNLINKQUERY " + unlinkErr.Error())
-		}
-
-		if _, unlinkExecErr := tx.Exec(unlinkQuery, unlinkArgs...); unlinkExecErr != nil {
-			return common.NewInternalServerError("SMREPO-DELSM-UNLINKLO " + unlinkExecErr.Error())
-		}
-	}
-
-	if err := rows.Err(); err != nil {
-		return common.NewInternalServerError("SMREPO-DELSM-LISTFILEOIDSROWS " + err.Error())
+	var unlinkedCount int64
+	if err = tx.QueryRow(unlinkQuery, unlinkArgs...).Scan(&unlinkedCount); err != nil {
+		return common.NewInternalServerError("SMREPO-DELSM-UNLINKLO " + err.Error())
 	}
 
 	return nil

--- a/internal/submodelrepository/persistence/submodel_database_delete_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_delete_sqlmock_test.go
@@ -51,9 +51,7 @@ func TestDeleteSubmodelSuccessCleansLargeObjectsAndDeletesSubmodel(t *testing.T)
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(submodelDatabaseID))
 	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"file_oid"}).AddRow(int64(9001)))
-	mock.ExpectExec(`SELECT .*lo_unlink`).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
 	mock.ExpectExec(`DELETE FROM .*submodel`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
@@ -98,7 +96,7 @@ func TestDeleteSubmodelDeleteFailsRollsBack(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(submodelDatabaseID))
 	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"file_oid"}))
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
 	mock.ExpectExec(`DELETE FROM .*submodel`).
 		WillReturnError(errors.New("delete failed"))
 	mock.ExpectRollback()
@@ -125,7 +123,7 @@ func TestDeleteSubmodelCommitFailsReturnsInternalError(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(submodelDatabaseID))
 	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"file_oid"}))
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
 	mock.ExpectExec(`DELETE FROM .*submodel`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
@@ -152,8 +150,6 @@ func TestDeleteSubmodelOrphanCleanupFailsRollsBack(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(submodelDatabaseID))
 	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"file_oid"}).AddRow(int64(9999)))
-	mock.ExpectExec(`SELECT .*lo_unlink`).
 		WillReturnError(errors.New("unlink failed"))
 	mock.ExpectRollback()
 

--- a/internal/submodelrepository/persistence/submodel_database_patch_put_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_patch_put_sqlmock_test.go
@@ -89,11 +89,9 @@ func TestPatchSubmodelSuccessReplacesSubmodel(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(100))
 	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"file_oid"}))
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
 	mock.ExpectExec(`DELETE FROM .*submodel`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectQuery(`SELECT COUNT\("id"\) FROM "submodel" WHERE \("submodel_identifier" = \$1\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(200))
 	mock.ExpectExec(`INSERT INTO .*submodel_payload`).
@@ -137,8 +135,6 @@ func TestPutSubmodelCreatePathReturnsFalse(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnError(sql.ErrNoRows)
-	mock.ExpectQuery(`SELECT COUNT\("id"\) FROM "submodel" WHERE \("submodel_identifier" = \$1\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(300))
 	mock.ExpectExec(`INSERT INTO .*submodel_payload`).
@@ -167,11 +163,9 @@ func TestPutSubmodelUpdatePathReturnsTrue(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(400))
 	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"file_oid"}))
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
 	mock.ExpectExec(`DELETE FROM .*submodel`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectQuery(`SELECT COUNT\("id"\) FROM "submodel" WHERE \("submodel_identifier" = \$1\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(401))
 	mock.ExpectExec(`INSERT INTO .*submodel_payload`).

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	gen "github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,8 +107,6 @@ func TestCreateSubmodelInsertFailureRollsBack(t *testing.T) {
 	submodel.SetIDShort(&idShort)
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT COUNT\("id"\) FROM "submodel" WHERE \("submodel_identifier" = \$1\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
 		WillReturnError(errors.New("insert failed"))
 	mock.ExpectRollback()
@@ -134,8 +133,8 @@ func TestCreateSubmodelDuplicateIdentifierReturnsConflict(t *testing.T) {
 	submodel.SetIDShort(&idShort)
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT COUNT\("id"\) FROM "submodel" WHERE \("submodel_identifier" = \$1\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
+		WillReturnError(&pq.Error{Code: "23505"})
 	mock.ExpectRollback()
 
 	err = sut.CreateSubmodel(contextWithABACDisabled(t), submodel)


### PR DESCRIPTION
This pull request refactors the submodel repository's database logic to improve error handling, optimize large object cleanup, and simplify submodel creation logic. The changes remove redundant existence checks before submodel insertion, handle uniqueness violations directly via database errors, and streamline the cleanup of large objects using a single SQL statement. Corresponding unit tests have been updated to reflect these changes.

**Database logic improvements:**

* Removed the pre-insert existence check for submodels in `createSubmodelInTransaction`, instead handling uniqueness violations by mapping PostgreSQL error code `23505` to a conflict error using the new `mapCreateSubmodelInsertError` function. (`internal/submodelrepository/persistence/submodel_database.go`) [[1]](diffhunk://#diff-968d41449c725fa2e6d8b5159e03fd95967ceb5885a40a04be0e60ee1c3e9266L297-R306) [[2]](diffhunk://#diff-968d41449c725fa2e6d8b5159e03fd95967ceb5885a40a04be0e60ee1c3e9266R376-R393)
* Optimized large object cleanup in `cleanupSubmodelLargeObjects` by replacing row-by-row unlinking with a single SQL statement that calls `lo_unlink` for all relevant objects and counts the results. (`internal/submodelrepository/persistence/submodel_database.go`)

**Testing updates:**

* Updated tests to match the new logic: removed expectations for the existence check query and adjusted mocks to expect a single count result from the large object cleanup query. (`internal/submodelrepository/persistence/submodel_database_delete_sqlmock_test.go`, `internal/submodelrepository/persistence/submodel_database_patch_put_sqlmock_test.go`, `internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go`) [[1]](diffhunk://#diff-cd9a7ed770865e399a3b0fd054319afe704b557b536312c1beeb2d237c538b4eL54-R54) [[2]](diffhunk://#diff-cd9a7ed770865e399a3b0fd054319afe704b557b536312c1beeb2d237c538b4eL101-R99) [[3]](diffhunk://#diff-cd9a7ed770865e399a3b0fd054319afe704b557b536312c1beeb2d237c538b4eL128-R126) [[4]](diffhunk://#diff-cd9a7ed770865e399a3b0fd054319afe704b557b536312c1beeb2d237c538b4eL155-L156) [[5]](diffhunk://#diff-0e1c71757e0188cce3fe9eb7716bcd223283b3cdc75f7bc8e84e1989c0023cc7L92-L96) [[6]](diffhunk://#diff-0e1c71757e0188cce3fe9eb7716bcd223283b3cdc75f7bc8e84e1989c0023cc7L140-L141) [[7]](diffhunk://#diff-0e1c71757e0188cce3fe9eb7716bcd223283b3cdc75f7bc8e84e1989c0023cc7L170-L174) [[8]](diffhunk://#diff-22525e062c28e65f562b3649f5cfdb6ddb5c19cce433f8e5888e53348c93f693L109-L110) [[9]](diffhunk://#diff-22525e062c28e65f562b3649f5cfdb6ddb5c19cce433f8e5888e53348c93f693L137-R137)

**Dependency and schema updates:**

* Changed the import of `github.com/lib/pq` from blank to explicit to allow error type assertions. (`internal/submodelrepository/persistence/submodel_database.go`, `internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go`) [[1]](diffhunk://#diff-968d41449c725fa2e6d8b5159e03fd95967ceb5885a40a04be0e60ee1c3e9266L53-R53) [[2]](diffhunk://#diff-22525e062c28e65f562b3649f5cfdb6ddb5c19cce433f8e5888e53348c93f693R41)
* Added new indexes to improve query performance on `submodel_element_qualifier` and `operation_variable` tables. (`basyxschema.sql`)