### PR TITLE
Improves mime handling for thumbnail and attachments

### DIFF
--- a/internal/aasrepository/integration_tests/aasrepository_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_integration_test.go
@@ -111,6 +111,39 @@ func createAASForThumbnailTest(baseURL string, aasID string) (int, error) {
 	return resp.StatusCode, nil
 }
 
+func createAASForThumbnailTestWithDeclaredContentType(baseURL string, aasID string, thumbnailPath string, contentType string) (int, error) {
+	body := fmt.Sprintf(`{"id":"%s","modelType":"AssetAdministrationShell","assetInformation":{"assetKind":"Instance","defaultThumbnail":{"path":"%s","contentType":"%s"}}}`,
+		aasID,
+		thumbnailPath,
+		contentType,
+	)
+
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/shells", strings.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode, nil
+}
+
+func createTemporaryBinaryTestFile(t *testing.T, fileName string, payload []byte) string {
+	t.Helper()
+
+	filePath := filepath.Join(t.TempDir(), fileName)
+	err := os.WriteFile(filePath, payload, 0o600)
+	require.NoError(t, err, "failed to create temporary test file")
+
+	return filePath
+}
+
 func uploadThumbnail(endpoint string, filePath string, fileName string) (int, error) {
 	file, err := os.Open(filepath.Clean(filePath))
 	if err != nil {
@@ -463,6 +496,44 @@ func TestContractThumbnailGetReturnsDetectedContentType(t *testing.T) {
 	require.Equal(t, http.StatusOK, getStatusCode, "Expected 200 OK for thumbnail download")
 	assert.Equal(t, expectedContent, content, "Downloaded thumbnail content should match uploaded payload")
 	assert.Equal(t, expectedContentType, contentType, "Thumbnail GET content type should match detected uploaded content type")
+}
+
+func TestThumbnailUploadUsesDeclaredContentTypeFallback(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	aasID := fmt.Sprintf("https://example.com/ids/aas/thumbnail_declared_fallback_%d", time.Now().UnixNano())
+	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+	thumbnailEndpoint := fmt.Sprintf("%s/shells/%s/asset-information/thumbnail", baseURL, aasIdentifier)
+
+	statusCode, err := createAASForThumbnailTestWithDeclaredContentType(baseURL, aasID, "declared-thumbnail", "image/tiff")
+	require.NoError(t, err, "AAS creation failed")
+	require.Equal(t, http.StatusCreated, statusCode, "Expected 201 Created for AAS creation")
+
+	weakPayload := []byte{0x01, 0x02, 0x03, 0x04}
+	weakFilePath := createTemporaryBinaryTestFile(t, "thumbnail-weak", weakPayload)
+
+	uploadStatusCode, uploadErr := uploadThumbnail(thumbnailEndpoint, weakFilePath, "blue_tiff_jpeg_comp.tif")
+	require.NoError(t, uploadErr, "Thumbnail upload failed")
+	require.Equal(t, http.StatusNoContent, uploadStatusCode, "Expected 204 No Content for thumbnail upload")
+
+	content, contentType, getStatusCode, getErr := downloadThumbnail(thumbnailEndpoint)
+	require.NoError(t, getErr, "Thumbnail download failed")
+	require.Equal(t, http.StatusOK, getStatusCode, "Expected 200 OK for thumbnail download")
+	assert.Equal(t, weakPayload, content, "Downloaded thumbnail content should match uploaded payload")
+	assert.Equal(t, "image/tiff", contentType, "Weak MIME detection should fall back to TIFF content type")
+
+	payload, aasStatusCode, aasErr := getJSONResponse(fmt.Sprintf("%s/shells/%s", baseURL, aasIdentifier))
+	require.NoError(t, aasErr, "AAS retrieval failed")
+	require.Equal(t, http.StatusOK, aasStatusCode, "Expected 200 OK for AAS retrieval")
+
+	assetInformation, ok := payload["assetInformation"].(map[string]any)
+	require.True(t, ok, "assetInformation should be present")
+
+	thumbnail, ok := assetInformation["defaultThumbnail"].(map[string]any)
+	require.True(t, ok, "assetInformation.defaultThumbnail should be present")
+
+	thumbnailContentType, ok := thumbnail["contentType"].(string)
+	require.True(t, ok, "thumbnail.contentType should be a string")
+	assert.Equal(t, "image/tiff", thumbnailContentType, "AAS payload should expose fallback-resolved thumbnail contentType")
 }
 
 // TestMain handles setup and teardown

--- a/internal/aasrepository/persistence/thumbnail_file_handler.go
+++ b/internal/aasrepository/persistence/thumbnail_file_handler.go
@@ -28,6 +28,7 @@ package persistence
 import (
 	"database/sql"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -189,6 +190,24 @@ func (h *PostgreSQLThumbnailFileHandler) uploadThumbnailByAASIDInTransaction(tx 
 		return common.NewErrBadRequest("AASREPO-PUTTHUMBNAIL-MISSINGFILE file payload is required")
 	}
 
+	dialect := goqu.Dialect("postgres")
+
+	existingElementSQL, existingElementArgs, existingElementBuildErr := dialect.
+		From("thumbnail_file_element").
+		Select("content_type", "file_name").
+		Where(goqu.I("id").Eq(aasDBID)).
+		ToSQL()
+	if existingElementBuildErr != nil {
+		return common.NewInternalServerError("AASREPO-PUTTHUMBNAIL-BUILDEXISTINGELEMENTSQL " + existingElementBuildErr.Error())
+	}
+
+	var existingContentType sql.NullString
+	var existingFileName sql.NullString
+	existingElementErr := tx.QueryRow(existingElementSQL, existingElementArgs...).Scan(&existingContentType, &existingFileName)
+	if existingElementErr != nil && existingElementErr != sql.ErrNoRows {
+		return common.NewInternalServerError("AASREPO-PUTTHUMBNAIL-EXECEXISTINGELEMENTSQL " + existingElementErr.Error())
+	}
+
 	if _, seekErr := file.Seek(0, 0); seekErr != nil {
 		return common.NewInternalServerError("AASREPO-PUTTHUMBNAIL-SEEKFILE " + seekErr.Error())
 	}
@@ -203,11 +222,20 @@ func (h *PostgreSQLThumbnailFileHandler) uploadThumbnailByAASIDInTransaction(tx 
 		detectedContentType = http.DetectContentType(contentTypeBuffer[:readBytes])
 	}
 
+	fallbackFileName := fileName
+	if strings.TrimSpace(fallbackFileName) == "" && existingFileName.Valid {
+		fallbackFileName = existingFileName.String
+	}
+
+	resolvedContentType, mismatchDetectedVsDeclared := common.ResolveUploadedContentType(detectedContentType, existingContentType.String, fallbackFileName)
+	if mismatchDetectedVsDeclared {
+		log.Printf("[WARN] AASREPO-PUTTHUMBNAIL-RESOLVEMIME detected content type differs from declared content type; using detected content type")
+	}
+
 	if _, seekErr := file.Seek(0, 0); seekErr != nil {
 		return common.NewInternalServerError("AASREPO-PUTTHUMBNAIL-SEEKFILE " + seekErr.Error())
 	}
 
-	dialect := goqu.Dialect("postgres")
 	oldOIDQuery, oldOIDArgs, oldOIDBuildErr := dialect.
 		From("thumbnail_file_data").
 		Select("file_oid").
@@ -277,7 +305,7 @@ func (h *PostgreSQLThumbnailFileHandler) uploadThumbnailByAASIDInTransaction(tx 
 		ensureElementSQL, ensureElementArgs, ensureElementBuildErr := dialect.Insert("thumbnail_file_element").
 			Rows(goqu.Record{
 				"id":           aasDBID,
-				"content_type": detectedContentType,
+				"content_type": resolvedContentType,
 				"file_name":    fileName,
 				"value":        "",
 			}).
@@ -304,12 +332,12 @@ func (h *PostgreSQLThumbnailFileHandler) uploadThumbnailByAASIDInTransaction(tx 
 	upsertElementSQL, upsertElementArgs, upsertElementBuildErr := dialect.Insert("thumbnail_file_element").
 		Rows(goqu.Record{
 			"id":           aasDBID,
-			"content_type": detectedContentType,
+			"content_type": resolvedContentType,
 			"file_name":    fileName,
 			"value":        strconv.FormatInt(newOID, 10),
 		}).
 		OnConflict(goqu.DoUpdate("id", goqu.Record{
-			"content_type": detectedContentType,
+			"content_type": resolvedContentType,
 			"file_name":    fileName,
 			"value":        strconv.FormatInt(newOID, 10),
 		})).

--- a/internal/aasrepository/persistence/thumbnail_file_handler.go
+++ b/internal/aasrepository/persistence/thumbnail_file_handler.go
@@ -222,12 +222,12 @@ func (h *PostgreSQLThumbnailFileHandler) uploadThumbnailByAASIDInTransaction(tx 
 		detectedContentType = http.DetectContentType(contentTypeBuffer[:readBytes])
 	}
 
-	fallbackFileName := fileName
-	if strings.TrimSpace(fallbackFileName) == "" && existingFileName.Valid {
-		fallbackFileName = existingFileName.String
+	resolvedFileName := strings.TrimSpace(fileName)
+	if resolvedFileName == "" && existingFileName.Valid {
+		resolvedFileName = existingFileName.String
 	}
 
-	resolvedContentType, mismatchDetectedVsDeclared := common.ResolveUploadedContentType(detectedContentType, existingContentType.String, fallbackFileName)
+	resolvedContentType, mismatchDetectedVsDeclared := common.ResolveUploadedContentType(detectedContentType, existingContentType.String, resolvedFileName)
 	if mismatchDetectedVsDeclared {
 		log.Printf("[WARN] AASREPO-PUTTHUMBNAIL-RESOLVEMIME detected content type differs from declared content type; using detected content type")
 	}
@@ -306,7 +306,7 @@ func (h *PostgreSQLThumbnailFileHandler) uploadThumbnailByAASIDInTransaction(tx 
 			Rows(goqu.Record{
 				"id":           aasDBID,
 				"content_type": resolvedContentType,
-				"file_name":    fileName,
+				"file_name":    resolvedFileName,
 				"value":        "",
 			}).
 			OnConflict(goqu.DoNothing()).
@@ -333,12 +333,12 @@ func (h *PostgreSQLThumbnailFileHandler) uploadThumbnailByAASIDInTransaction(tx 
 		Rows(goqu.Record{
 			"id":           aasDBID,
 			"content_type": resolvedContentType,
-			"file_name":    fileName,
+			"file_name":    resolvedFileName,
 			"value":        strconv.FormatInt(newOID, 10),
 		}).
 		OnConflict(goqu.DoUpdate("id", goqu.Record{
 			"content_type": resolvedContentType,
-			"file_name":    fileName,
+			"file_name":    resolvedFileName,
 			"value":        strconv.FormatInt(newOID, 10),
 		})).
 		ToSQL()

--- a/internal/common/mime_resolver.go
+++ b/internal/common/mime_resolver.go
@@ -1,0 +1,89 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"mime"
+	"path/filepath"
+	"strings"
+)
+
+const fallbackBinaryContentType = "application/octet-stream"
+
+// ResolveUploadedContentType resolves a stable content type for uploaded files.
+//
+// Precedence:
+//  1. Detected content type when it is specific (not empty and not fallback binary)
+//  2. Declared content type
+//  3. Filename extension mapping
+//  4. application/octet-stream
+//
+// mismatchDetectedVsDeclared is true if both detected and declared are specific and differ.
+func ResolveUploadedContentType(detectedContentType, declaredContentType, fileName string) (resolved string, mismatchDetectedVsDeclared bool) {
+	normalizedDetected := normalizeContentType(detectedContentType)
+	normalizedDeclared := normalizeContentType(declaredContentType)
+
+	if isSpecificContentType(normalizedDetected) {
+		return normalizedDetected, isSpecificContentType(normalizedDeclared) && normalizedDetected != normalizedDeclared
+	}
+
+	if normalizedDeclared != "" {
+		return normalizedDeclared, false
+	}
+
+	if extensionContentType := contentTypeFromExtension(fileName); extensionContentType != "" {
+		return extensionContentType, false
+	}
+
+	return fallbackBinaryContentType, false
+}
+
+func normalizeContentType(rawContentType string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(rawContentType))
+	if trimmed == "" {
+		return ""
+	}
+
+	mediaType, _, err := mime.ParseMediaType(trimmed)
+	if err != nil {
+		return ""
+	}
+
+	return strings.ToLower(strings.TrimSpace(mediaType))
+}
+
+func isSpecificContentType(contentType string) bool {
+	return contentType != "" && contentType != fallbackBinaryContentType
+}
+
+func contentTypeFromExtension(fileName string) string {
+	ext := strings.ToLower(strings.TrimSpace(filepath.Ext(fileName)))
+	if ext == "" {
+		return ""
+	}
+
+	return normalizeContentType(mime.TypeByExtension(ext))
+}

--- a/internal/common/mime_resolver_test.go
+++ b/internal/common/mime_resolver_test.go
@@ -1,0 +1,68 @@
+package common
+
+import "testing"
+
+func TestResolveUploadedContentType(t *testing.T) {
+	tests := []struct {
+		name                string
+		detected            string
+		declared            string
+		fileName            string
+		expectedContentType string
+		expectedMismatch    bool
+	}{
+		{
+			name:                "detected specific wins",
+			detected:            "image/gif",
+			declared:            "image/png",
+			fileName:            "demo.bin",
+			expectedContentType: "image/gif",
+			expectedMismatch:    true,
+		},
+		{
+			name:                "weak detected falls back to declared",
+			detected:            "application/octet-stream",
+			declared:            "image/tiff",
+			fileName:            "demo.bin",
+			expectedContentType: "image/tiff",
+			expectedMismatch:    false,
+		},
+		{
+			name:                "weak detected with invalid declared falls back to extension",
+			detected:            "application/octet-stream",
+			declared:            "not/a valid content type",
+			fileName:            "picture.tif",
+			expectedContentType: "image/tiff",
+			expectedMismatch:    false,
+		},
+		{
+			name:                "all weak falls back to binary",
+			detected:            "application/octet-stream",
+			declared:            "",
+			fileName:            "",
+			expectedContentType: "application/octet-stream",
+			expectedMismatch:    false,
+		},
+		{
+			name:                "detected with parameters normalized",
+			detected:            "text/plain; charset=utf-8",
+			declared:            "text/plain",
+			fileName:            "doc.txt",
+			expectedContentType: "text/plain",
+			expectedMismatch:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, mismatch := ResolveUploadedContentType(tt.detected, tt.declared, tt.fileName)
+
+			if resolved != tt.expectedContentType {
+				t.Fatalf("expected content type %q, got %q", tt.expectedContentType, resolved)
+			}
+			if mismatch != tt.expectedMismatch {
+				t.Fatalf("expected mismatch %t, got %t", tt.expectedMismatch, mismatch)
+			}
+		})
+	}
+}

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -109,6 +109,16 @@ func uploadFileAttachment(endpoint string, filePath string, fileName string) (in
 	return resp.StatusCode, nil
 }
 
+func createTemporaryBinaryTestFile(t *testing.T, fileName string, payload []byte) string {
+	t.Helper()
+
+	filePath := filepath.Join(t.TempDir(), fileName)
+	err := os.WriteFile(filePath, payload, 0o600)
+	require.NoError(t, err, "Failed to create temporary test file")
+
+	return filePath
+}
+
 // downloadFileAttachment downloads a file from the attachment endpoint and returns content and content-type
 func downloadFileAttachment(endpoint string) ([]byte, string, int, error) {
 	req, err := http.NewRequest("GET", endpoint, nil)
@@ -532,6 +542,7 @@ func TestFileAttachmentOperations(t *testing.T) {
 	baseURL := "http://localhost:6004"
 	submodelID := "aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q" // base64 encoded: http://iese.fraunhofer.de/id/sm/OnlyFileSubmodel_Test
 	testFilePath := "testFiles/marcus.gif"
+	weakFileContent := []byte{0x00, 0x01, 0x02, 0x03}
 
 	// Read the test file content for later comparison
 	originalFileContent, err := os.ReadFile(testFilePath)
@@ -552,8 +563,7 @@ func TestFileAttachmentOperations(t *testing.T) {
 		require.NoError(t, err, "File download failed")
 		assert.Equal(t, http.StatusOK, statusCode, "Expected 200 OK for file download")
 
-		// Verify Content-Type is set (should be auto-detected as image/png)
-		assert.NotEmpty(t, contentType, "Content-Type should be set")
+		assert.Equal(t, "image/gif", contentType, "Content-Type should match detected MIME type for uploaded GIF")
 		t.Logf("Downloaded file Content-Type: %s", contentType)
 
 		// Verify file content matches uploaded file byte-by-byte
@@ -591,25 +601,43 @@ func TestFileAttachmentOperations(t *testing.T) {
 			"Should redirect to external URL or return 404 after value update")
 	})
 
-	t.Run("5_Reupload_File_Attachment", func(t *testing.T) {
+	t.Run("5_Upload_Weak_File_Attachment_Uses_Declared_ContentType", func(t *testing.T) {
+		weakFilePath := createTemporaryBinaryTestFile(t, "weak-attachment", weakFileContent)
+		endpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/DemoFile/attachment", baseURL, submodelID)
+		statusCode, err := uploadFileAttachment(endpoint, weakFilePath, "")
+		require.NoError(t, err, "Weak file upload failed")
+		assert.Equal(t, http.StatusNoContent, statusCode, "Expected 204 No Content for weak file upload")
+	})
+
+	t.Run("6_Verify_Weak_File_Attachment_Uses_Declared_ContentType", func(t *testing.T) {
+		time.Sleep(2 * time.Second)
+		endpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/DemoFile/attachment", baseURL, submodelID)
+		content, contentType, statusCode, err := downloadFileAttachment(endpoint)
+		require.NoError(t, err, "Weak file download failed")
+		assert.Equal(t, http.StatusOK, statusCode, "Expected 200 OK for weak file download")
+		assert.Equal(t, weakFileContent, content, "Weak file content should match uploaded payload")
+		assert.Equal(t, "image/png", contentType, "Weak MIME detection should fall back to declared File contentType")
+	})
+
+	t.Run("7_Reupload_File_Attachment", func(t *testing.T) {
 		endpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/DemoFile/attachment", baseURL, submodelID)
 		statusCode, err := uploadFileAttachment(endpoint, testFilePath, "test-image-reupload.png")
 		require.NoError(t, err, "File reupload failed")
 		assert.Equal(t, http.StatusNoContent, statusCode, "Expected 204 No Content for file reupload")
 	})
 
-	t.Run("6_Verify_Reuploaded_File", func(t *testing.T) {
+	t.Run("8_Verify_Reuploaded_File", func(t *testing.T) {
 		// Wait a moment to ensure the file is available
 		time.Sleep(2 * time.Second)
 		endpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/DemoFile/attachment", baseURL, submodelID)
 		content, contentType, statusCode, err := downloadFileAttachment(endpoint)
 		require.NoError(t, err, "File download failed")
 		assert.Equal(t, http.StatusOK, statusCode, "Expected 200 OK for file download")
-		assert.NotEmpty(t, contentType, "Content-Type should be set")
+		assert.Equal(t, "image/gif", contentType, "Content-Type should match detected MIME type for uploaded GIF")
 		assert.Equal(t, originalFileContent, content, "Reuploaded file content should match original")
 	})
 
-	t.Run("7_Delete_File_Attachment", func(t *testing.T) {
+	t.Run("9_Delete_File_Attachment", func(t *testing.T) {
 		endpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/DemoFile/attachment", baseURL, submodelID)
 		req, err := http.NewRequest("DELETE", endpoint, nil)
 		require.NoError(t, err, "Failed to create DELETE request")
@@ -622,7 +650,7 @@ func TestFileAttachmentOperations(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode, "Expected 200 OK for file deletion")
 	})
 
-	t.Run("8_Verify_File_Deleted", func(t *testing.T) {
+	t.Run("10_Verify_File_Deleted", func(t *testing.T) {
 		endpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/DemoFile/attachment", baseURL, submodelID)
 		_, _, statusCode, _ := downloadFileAttachment(endpoint)
 		assert.Equal(t, http.StatusNotFound, statusCode, "Expected 404 Not Found after file deletion")

--- a/internal/submodelrepository/persistence/submodelElements/FileHandler.go
+++ b/internal/submodelrepository/persistence/submodelElements/FileHandler.go
@@ -31,9 +31,11 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/aas-core-works/aas-core3.1-golang/types"
 	"github.com/doug-martin/goqu/v9"
@@ -365,23 +367,6 @@ func (p PostgreSQLFileHandler) UploadFileAttachment(submodelID string, idShortPa
 		_ = reopenedFile.Close()
 	}()
 
-	// Detect content type from file content
-	contentTypeBuffer := make([]byte, 512)
-	n, err := reopenedFile.Read(contentTypeBuffer)
-	if err != nil && err != io.EOF {
-		return fmt.Errorf("failed to read file for content type detection: %w", err)
-	}
-	detectedContentType := "application/octet-stream" // Default
-	if n > 0 {
-		detectedContentType = http.DetectContentType(contentTypeBuffer[:n])
-	}
-
-	// Seek back to the beginning of the file
-	_, err = reopenedFile.Seek(0, 0)
-	if err != nil {
-		return fmt.Errorf("failed to seek file: %w", err)
-	}
-
 	// Start a transaction for atomic operation
 	tx, err := p.db.Begin()
 	if err != nil {
@@ -401,22 +386,55 @@ func (p PostgreSQLFileHandler) UploadFileAttachment(submodelID string, idShortPa
 		return fmt.Errorf("failed to get submodel database ID: %w", err)
 	}
 
-	// Get the submodel element ID
+	// Get the submodel element metadata
 	var submodelElementID int64
+	var existingContentType sql.NullString
+	var existingFileName sql.NullString
 	query, args, err := dialect.From("submodel_element").
-		Select("id").
+		InnerJoin(
+			goqu.T("file_element"),
+			goqu.On(goqu.I("submodel_element.id").Eq(goqu.I("file_element.id"))),
+		).
+		Select("submodel_element.id", "file_element.content_type", "file_element.file_name").
 		Where(goqu.C("submodel_id").Eq(submodelDatabaseID), goqu.C("idshort_path").Eq(idShortPath)).
 		ToSQL()
 	if err != nil {
 		return fmt.Errorf("failed to build query: %w", err)
 	}
 
-	err = tx.QueryRow(query, args...).Scan(&submodelElementID)
+	err = tx.QueryRow(query, args...).Scan(&submodelElementID, &existingContentType, &existingFileName)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return common.NewErrNotFound("submodel element not found")
 		}
 		return fmt.Errorf("failed to get submodel element ID: %w", err)
+	}
+
+	// Detect content type from file content
+	contentTypeBuffer := make([]byte, 512)
+	n, err := reopenedFile.Read(contentTypeBuffer)
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("failed to read file for content type detection: %w", err)
+	}
+	detectedContentType := "application/octet-stream"
+	if n > 0 {
+		detectedContentType = http.DetectContentType(contentTypeBuffer[:n])
+	}
+
+	fallbackFileName := fileName
+	if strings.TrimSpace(fallbackFileName) == "" && existingFileName.Valid {
+		fallbackFileName = existingFileName.String
+	}
+
+	resolvedContentType, mismatchDetectedVsDeclared := common.ResolveUploadedContentType(detectedContentType, existingContentType.String, fallbackFileName)
+	if mismatchDetectedVsDeclared {
+		log.Printf("[WARN] SMREPO-UPLOADATTACHMENT-RESOLVEMIME detected content type differs from declared content type; using detected content type")
+	}
+
+	// Seek back to the beginning of the file
+	_, err = reopenedFile.Seek(0, 0)
+	if err != nil {
+		return fmt.Errorf("failed to seek file: %w", err)
 	}
 
 	// Check for existing file_data and delete old Large Object if it exists
@@ -515,7 +533,7 @@ func (p PostgreSQLFileHandler) UploadFileAttachment(submodelID string, idShortPa
 		Set(goqu.Record{
 			"value":        fmt.Sprintf("%d", newOID),
 			"file_name":    fileName,
-			"content_type": detectedContentType,
+			"content_type": resolvedContentType,
 		}).
 		Where(goqu.C("id").Eq(submodelElementID)).
 		ToSQL()

--- a/internal/submodelrepository/persistence/submodelElements/FileHandler.go
+++ b/internal/submodelrepository/persistence/submodelElements/FileHandler.go
@@ -421,12 +421,12 @@ func (p PostgreSQLFileHandler) UploadFileAttachment(submodelID string, idShortPa
 		detectedContentType = http.DetectContentType(contentTypeBuffer[:n])
 	}
 
-	fallbackFileName := fileName
-	if strings.TrimSpace(fallbackFileName) == "" && existingFileName.Valid {
-		fallbackFileName = existingFileName.String
+	resolvedFileName := strings.TrimSpace(fileName)
+	if resolvedFileName == "" && existingFileName.Valid {
+		resolvedFileName = existingFileName.String
 	}
 
-	resolvedContentType, mismatchDetectedVsDeclared := common.ResolveUploadedContentType(detectedContentType, existingContentType.String, fallbackFileName)
+	resolvedContentType, mismatchDetectedVsDeclared := common.ResolveUploadedContentType(detectedContentType, existingContentType.String, resolvedFileName)
 	if mismatchDetectedVsDeclared {
 		log.Printf("[WARN] SMREPO-UPLOADATTACHMENT-RESOLVEMIME detected content type differs from declared content type; using detected content type")
 	}
@@ -532,7 +532,7 @@ func (p PostgreSQLFileHandler) UploadFileAttachment(submodelID string, idShortPa
 	updateFileElementQuery, updateFileElementArgs, err := dialect.Update("file_element").
 		Set(goqu.Record{
 			"value":        fmt.Sprintf("%d", newOID),
-			"file_name":    fileName,
+			"file_name":    resolvedFileName,
 			"content_type": resolvedContentType,
 		}).
 		Where(goqu.C("id").Eq(submodelElementID)).


### PR DESCRIPTION
This pull request introduces a robust and consistent approach to resolving and storing MIME content types for uploaded files (thumbnails and attachments) in both the AAS Repository and Submodel Repository. It implements a new utility for content type resolution, updates the persistence logic to use this utility, and adds comprehensive integration and unit tests to verify correct behavior, especially for weak or ambiguous file uploads.

**Key changes:**

### Content Type Resolution Logic

* Added a new utility `ResolveUploadedContentType` in `internal/common/mime_resolver.go` that determines the most appropriate content type for uploaded files, prioritizing: detected type, declared type, file extension, and finally falling back to `application/octet-stream`. It also normalizes content types and detects mismatches.
* Added unit tests in `internal/common/mime_resolver_test.go` to ensure the resolver behaves as expected for various scenarios, including weak detection and mismatches.

### AAS Repository: Thumbnail Uploads

* Updated `PostgreSQLThumbnailFileHandler.uploadThumbnailByAASIDInTransaction` to use the new resolver, ensuring stored content types are stable and correct, and logging warnings when detected and declared types differ. The upsert/insert logic now uses the resolved content type. [[1]](diffhunk://#diff-1a487b01119b3ac3275f1288ccac7634ca15668a98912ac1cdeecdbeacf25172R193-R210) [[2]](diffhunk://#diff-1a487b01119b3ac3275f1288ccac7634ca15668a98912ac1cdeecdbeacf25172R225-L210) [[3]](diffhunk://#diff-1a487b01119b3ac3275f1288ccac7634ca15668a98912ac1cdeecdbeacf25172L280-R308) [[4]](diffhunk://#diff-1a487b01119b3ac3275f1288ccac7634ca15668a98912ac1cdeecdbeacf25172L307-R340)
* Added integration test `TestThumbnailUploadUsesDeclaredContentTypeFallback` to verify that weak MIME detection falls back to the declared content type and that the correct type is exposed in the API.
* Added helpers for test file creation and AAS creation with declared thumbnail content types in test code.

### Submodel Repository: File Attachments

* Updated file attachment upload logic to support weak file uploads and ensure declared content types are used when detection is ambiguous, with new helper for temporary file creation in tests.
* Enhanced integration tests to verify content type resolution for weak and reuploaded files, and to validate that the correct types are returned by the API. [[1]](diffhunk://#diff-49f0f31785aa031fcb93875dcd2bb7cc7500537a2053bff1d6dd4351242d4d29R545) [[2]](diffhunk://#diff-49f0f31785aa031fcb93875dcd2bb7cc7500537a2053bff1d6dd4351242d4d29L555-R566) [[3]](diffhunk://#diff-49f0f31785aa031fcb93875dcd2bb7cc7500537a2053bff1d6dd4351242d4d29L594-R640) [[4]](diffhunk://#diff-49f0f31785aa031fcb93875dcd2bb7cc7500537a2053bff1d6dd4351242d4d29L625-R653)

### Codebase Maintenance

* Added necessary imports (`log`, `strings`) to support new logging and string operations in persistence layers. [[1]](diffhunk://#diff-1a487b01119b3ac3275f1288ccac7634ca15668a98912ac1cdeecdbeacf25172R31) [[2]](diffhunk://#diff-78c311c52b3542adc13dca60624a37e28f48a1cddf8afbeed5f2bb7688ab490dR34-R38)
* Removed old content type detection code in `PostgreSQLFileHandler.UploadFileAttachment` to prepare for using the new resolver utility.

These changes collectively improve the reliability and correctness of file content type handling in the system, especially for edge cases where MIME type detection is inconclusive.

Closes #256 