### PR TITLE
moved globalAssetId assetlink creation from DTR to discovery integration

### DIFF
--- a/cmd/digitaltwinregistryservice/openapi.yaml
+++ b/cmd/digitaltwinregistryservice/openapi.yaml
@@ -9,11 +9,12 @@ info:
     and filtering. If the end user can change this header, the access control is
     not secure because it is not derived from the token.
 
+    Discovery integration:
+    Creating or updating shell descriptors also creates/updates discovery entries, including the
+    descriptor globalAssetId as specific asset id name "globalAssetId" when present.
+
     Digital Twin Registry custom additions (beyond IDTA base profile):
 
-    - POST /shell-descriptors and PUT /shell-descriptors/{aasIdentifier} also append a
-      discovery link from globalAssetId (stored as specific asset id name "globalAssetId")
-      when globalAssetId is present in the descriptor.
     - PUT /shell-descriptors/{aasIdentifier} and PUT
       /shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier} use
       path identifiers as source of truth (path id wins over request body id).
@@ -123,9 +124,8 @@ paths:
         - Asset Administration Shell Registry API
       summary: Creates a new Asset Administration Shell Descriptor, i.e. registers an AAS
       description: >-
-        DTR extension: if globalAssetId is present in the descriptor, the service also
-        appends a discovery entry as specific asset id (name "globalAssetId") for the
-        same shell identifier.
+        Creating a shell descriptor also creates discovery entries, including
+        globalAssetId as specific asset id name "globalAssetId" when present.
       operationId: PostAssetAdministrationShellDescriptor
       x-semanticIds:
         - https://admin-shell.io/aas/API/PostAssetAdministrationShellDescriptor/3/1
@@ -192,11 +192,11 @@ paths:
         - Asset Administration Shell Registry API
       summary: Creates or updates an existing Asset Administration Shell Descriptor
       description: |-
-        DTR extension:
+        Path identifier is authoritative and overwrites descriptor.id from request body.
 
-        - Path identifier is authoritative and overwrites descriptor.id from request body.
-        - If globalAssetId is present, the service additionally appends a discovery entry
-          as specific asset id (name "globalAssetId") for the shell.
+        Creating or updating a shell descriptor also creates/updates discovery
+        entries, including globalAssetId as specific asset id name
+        "globalAssetId" when present.
       operationId: PutAssetAdministrationShellDescriptorById
       x-semanticIds:
         - https://admin-shell.io/aas/API/PutAssetAdministrationShellDescriptorById/3/1

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -185,7 +185,13 @@ func InsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd
 		aasRef = sql.NullInt64{Int64: ref, Valid: true}
 	}
 
-	if err = common.CreateSpecificAssetIDDescriptor(tx, descriptorID, aasRef, aasd.SpecificAssetIds); err != nil {
+	specificAssetIds := aasd.SpecificAssetIds
+	// add globalAssetId as specific asset id if it exists if DiscoveryIntegration is enabled.
+	if cfg, ok := common.ConfigFromContext(ctx); ok && cfg.General.DiscoveryIntegration && aasd.GlobalAssetId != "" {
+		specificAssetIds = append(specificAssetIds, types.NewSpecificAssetID("globalAssetId", aasd.GlobalAssetId))
+	}
+
+	if err = common.CreateSpecificAssetIDDescriptor(tx, descriptorID, aasRef, specificAssetIds); err != nil {
 		return err
 	}
 

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -186,9 +186,9 @@ func InsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd
 	}
 
 	specificAssetIds := aasd.SpecificAssetIds
-	// add globalAssetId as specific asset id if it exists if DiscoveryIntegration is enabled.
+	// Add globalAssetId as a specific asset ID when DiscoveryIntegration is enabled and GlobalAssetId is set.
 	if cfg, ok := common.ConfigFromContext(ctx); ok && cfg.General.DiscoveryIntegration && aasd.GlobalAssetId != "" {
-		specificAssetIds = append(specificAssetIds, types.NewSpecificAssetID("globalAssetId", aasd.GlobalAssetId))
+		specificAssetIds = append(specificAssetIds, types.NewSpecificAssetID(globalAssetIDSpecificAssetIDName, aasd.GlobalAssetId))
 	}
 
 	if err = common.CreateSpecificAssetIDDescriptor(tx, descriptorID, aasRef, specificAssetIds); err != nil {

--- a/internal/common/descriptors/ReadSpecificAssetId.go
+++ b/internal/common/descriptors/ReadSpecificAssetId.go
@@ -40,6 +40,8 @@ import (
 	"github.com/lib/pq"
 )
 
+const globalAssetIDSpecificAssetIDName = "globalAssetId"
+
 type rowData struct {
 	descID               int64
 	specificID           int64
@@ -150,7 +152,10 @@ func ReadSpecificAssetIDsByDescriptorIDs(
 		goqu.I(common.AliasExternalSubjectReference + "." + common.ColID).As("c5"),
 		common.TSpecificAssetID.Col(common.ColPosition).As("sort_specific_asset_position"),
 	}, maskRuntime.Projections()...)...).
-		Where(goqu.L(fmt.Sprintf("%s.%s = ANY(?::bigint[])", common.AliasSpecificAssetID, common.ColDescriptorID), arr))
+		Where(
+			goqu.L(fmt.Sprintf("%s.%s = ANY(?::bigint[])", common.AliasSpecificAssetID, common.ColDescriptorID), arr),
+			common.TSpecificAssetID.Col(common.ColName).Neq(globalAssetIDSpecificAssetIDName),
+		)
 
 	inner = inner.
 		Order(

--- a/internal/digitaltwinregistry/custom_registry_service.go
+++ b/internal/digitaltwinregistry/custom_registry_service.go
@@ -55,8 +55,7 @@ func NewCustomRegistryService(
 	}
 }
 
-// PostAssetAdministrationShellDescriptor executes default POST behavior and
-// appends a discovery asset link from globalAssetId when present.
+// PostAssetAdministrationShellDescriptor executes default POST behavior.
 func (s *CustomRegistryService) PostAssetAdministrationShellDescriptor(
 	ctx context.Context,
 	assetAdministrationShellDescriptor model.AssetAdministrationShellDescriptor,
@@ -72,8 +71,7 @@ func (s *CustomRegistryService) PostAssetAdministrationShellDescriptor(
 	return baseResp, nil
 }
 
-// PutAssetAdministrationShellDescriptorById executes default PUT behavior and
-// appends a discovery asset link from globalAssetId when present.
+// PutAssetAdministrationShellDescriptorById executes default PUT behavior.
 func (s *CustomRegistryService) PutAssetAdministrationShellDescriptorById(
 	ctx context.Context,
 	aasIdentifier string,

--- a/internal/digitaltwinregistry/custom_registry_service.go
+++ b/internal/digitaltwinregistry/custom_registry_service.go
@@ -29,12 +29,9 @@ package digitaltwinregistry
 import (
 	"context"
 	"net/http"
-	"strings"
 
-	"github.com/aas-core-works/aas-core3.1-golang/types"
 	registryapiinternal "github.com/eclipse-basyx/basyx-go-components/internal/aasregistry/api"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
-	"github.com/eclipse-basyx/basyx-go-components/internal/common/descriptors"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	discoveryapiinternal "github.com/eclipse-basyx/basyx-go-components/internal/discoveryservice/api"
 )
@@ -72,15 +69,6 @@ func (s *CustomRegistryService) PostAssetAdministrationShellDescriptor(
 		return baseResp, baseErr
 	}
 
-	if errResp, err := s.appendGlobalAssetLink(
-		ctx,
-		assetAdministrationShellDescriptor.Id,
-		assetAdministrationShellDescriptor.GlobalAssetId,
-		"PostAssetAdministrationShellDescriptor",
-	); errResp != nil || err != nil {
-		return mapAppendGlobalAssetLinkResult(errResp, err, "PostAssetAdministrationShellDescriptor")
-	}
-
 	return baseResp, nil
 }
 
@@ -112,15 +100,6 @@ func (s *CustomRegistryService) PutAssetAdministrationShellDescriptorById(
 	)
 	if baseErr != nil || !is2xx(baseResp.Code) {
 		return baseResp, baseErr
-	}
-
-	if errResp, err := s.appendGlobalAssetLink(
-		ctx,
-		decodedAASID,
-		assetAdministrationShellDescriptor.GlobalAssetId,
-		"PutAssetAdministrationShellDescriptorById",
-	); errResp != nil || err != nil {
-		return mapAppendGlobalAssetLinkResult(errResp, err, "PutAssetAdministrationShellDescriptorById")
 	}
 
 	return baseResp, nil
@@ -163,68 +142,6 @@ func (s *CustomRegistryService) PutSubmodelDescriptorByIdThroughSuperpath(
 	)
 }
 
-func (s *CustomRegistryService) appendGlobalAssetLink(
-	ctx context.Context,
-	aasID string,
-	globalAssetID string,
-	method string,
-) (*model.ImplResponse, error) {
-	if s.discovery == nil {
-		return nil, nil
-	}
-	if strings.TrimSpace(globalAssetID) == "" || strings.TrimSpace(aasID) == "" {
-		return nil, nil
-	}
-
-	aasIdentifier := common.EncodeString(aasID)
-	links := []types.ISpecificAssetID{
-		types.NewSpecificAssetID("globalAssetId", globalAssetID),
-	}
-
-	discoveryOnlyCtx := descriptors.WithDiscoveryOnlySpecificAssetIDs(ctx)
-	addResp, addErr := s.discovery.AddAllAssetLinksByID(discoveryOnlyCtx, aasIdentifier, links)
-	if addErr != nil {
-		resp := common.NewErrorResponse(
-			addErr,
-			http.StatusInternalServerError,
-			customRegistryComponentName,
-			method,
-			"AddGlobalAssetLink",
-		)
-		return &resp, addErr
-	}
-	if !is2xx(addResp.Code) {
-		resp := common.NewErrorResponse(
-			common.NewInternalServerError("failed to add globalAssetId discovery link"),
-			http.StatusInternalServerError,
-			customRegistryComponentName,
-			method,
-			"AddGlobalAssetLink-Non2xx",
-		)
-		return &resp, nil
-	}
-	return nil, nil
-}
-
 func is2xx(code int) bool {
 	return code >= http.StatusOK && code < http.StatusMultipleChoices
-}
-
-func mapAppendGlobalAssetLinkResult(
-	errResp *model.ImplResponse,
-	err error,
-	method string,
-) (model.ImplResponse, error) {
-	if errResp != nil {
-		return *errResp, err
-	}
-
-	resp := common.NewErrorResponse(
-		common.NewInternalServerError("failed to append globalAssetId discovery link"),
-		http.StatusInternalServerError,
-		customRegistryComponentName,
-		method,
-		"AddGlobalAssetLink-NilResponse",
-	)
-	return resp, err
 }


### PR DESCRIPTION
globalAssetId assetlink will be created if Discovery Integration is enabled.
- you can use /lookup/shells to find the Descriptor based on the globalAssetId now.