### PR TITLE
Update of Regex Patterns in Test Cases of CompanyLookup

### DIFF
--- a/examples/BaSyxCompanyLookup/startup.sh
+++ b/examples/BaSyxCompanyLookup/startup.sh
@@ -109,7 +109,7 @@ curl --location --request POST 'http://localhost:5080/companies' \
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/expected/company_descriptors_1-4.json
+++ b/internal/companylookupservice/integration_tests/expected/company_descriptors_1-4.json
@@ -153,7 +153,7 @@
                 "version": "1"
             },
             "assetIdRegexPatterns": [
-                "^https://i\\.iese.fraunhofer\\.de/assetId/",
+                "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
                 "^https://i\\.fraun-iese\\.de/assetId/"
             ],
             "description": [

--- a/internal/companylookupservice/integration_tests/expected/company_descriptors_filter_asset_id.json
+++ b/internal/companylookupservice/integration_tests/expected/company_descriptors_filter_asset_id.json
@@ -16,7 +16,7 @@
                 "version": "1"
             },
             "assetIdRegexPatterns": [
-                "^https://i\\.iese.fraunhofer\\.de/assetId/",
+                "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
                 "^https://i\\.fraun-iese\\.de/assetId/"
             ],
             "description": [

--- a/internal/companylookupservice/integration_tests/expected/company_descriptors_filter_endpoint_interface.json
+++ b/internal/companylookupservice/integration_tests/expected/company_descriptors_filter_endpoint_interface.json
@@ -61,7 +61,7 @@
                 "version": "1"
             },
             "assetIdRegexPatterns": [
-                "^https://i\\.iese.fraunhofer\\.de/assetId/",
+                "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
                 "^https://i\\.fraun-iese\\.de/assetId/"
             ],
             "description": [

--- a/internal/companylookupservice/integration_tests/expected/company_descriptors_filter_name.json
+++ b/internal/companylookupservice/integration_tests/expected/company_descriptors_filter_name.json
@@ -16,7 +16,7 @@
                 "version": "1"
             },
             "assetIdRegexPatterns": [
-                "^https://i\\.iese.fraunhofer\\.de/assetId/",
+                "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
                 "^https://i\\.fraun-iese\\.de/assetId/"
             ],
             "description": [

--- a/internal/companylookupservice/integration_tests/expected/company_descriptors_filter_name_and_endpoint_interface.json
+++ b/internal/companylookupservice/integration_tests/expected/company_descriptors_filter_name_and_endpoint_interface.json
@@ -16,7 +16,7 @@
                 "version": "1"
             },
             "assetIdRegexPatterns": [
-                "^https://i\\.iese.fraunhofer\\.de/assetId/",
+                "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
                 "^https://i\\.fraun-iese\\.de/assetId/"
             ],
             "description": [

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_1.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_1.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_5.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_5.json
@@ -51,7 +51,7 @@
         ],
         "assetIdRegexPatterns": [
             "^https://i\\.excom1\\.de/assetId/",
-            "^https://i\\.updated.excom1\\.de/assetId/"
+            "^https://i\\.updated\\.excom1\\.de/assetId/"
         ]
     }
 }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_disallowed_aas_interfaces_in_endpoint.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_disallowed_aas_interfaces_in_endpoint.json
@@ -57,7 +57,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_creator_in_administrative_information.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_creator_in_administrative_information.json
@@ -70,7 +70,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_domain.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_domain.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_href_in_protocol_information.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_href_in_protocol_information.json
@@ -43,7 +43,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_interface_in_endpoint.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_interface_in_endpoint.json
@@ -43,7 +43,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_keys_in_reference.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_keys_in_reference.json
@@ -73,7 +73,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_language_in_description.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_language_in_description.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_language_in_displayname.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_language_in_displayname.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_name.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_name.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_protocol_information_in_endpoint.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_protocol_information_in_endpoint.json
@@ -40,7 +40,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_text_in_description.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_text_in_description.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_text_in_displayname.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_text_in_displayname.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_type_in_key.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_type_in_key.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_value_in_key.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_empty_value_in_key.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_invalid_domain_syntax.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_invalid_domain_syntax.json
@@ -78,7 +78,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_missing_domain.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_missing_domain.json
@@ -77,7 +77,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_missing_keys_in_reference.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_missing_keys_in_reference.json
@@ -72,7 +72,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_only_non_aas_interfaces_in_endpoint.json
+++ b/internal/companylookupservice/integration_tests/postBody/company_descriptor_malformed_only_non_aas_interfaces_in_endpoint.json
@@ -43,7 +43,7 @@
             "IESE Fraunhofer"
         ],
         "assetIdRegexPatterns": [
-            "^https://i\\.iese.fraunhofer\\.de/assetId/",
+            "^https://i\\.iese\\.fraunhofer\\.de/assetId/",
             "^https://i\\.fraun-iese\\.de/assetId/"
         ]
     }

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
@@ -214,7 +214,8 @@ func GetSubmodelElementPathsPageBySubmodelID(ctx context.Context, db *sql.DB, su
 
 	query = query.
 		Order(goqu.I("sme.idshort_path").Asc(), goqu.I("sme.id").Asc()).
-		Limit(uint(pageLimit + 1))
+		//nolint:gosec // pageLimit is validated to be >= 0
+		Limit(uint(pageLimit) + 1)
 
 	sqlQuery, args, toSQLErr := query.ToSQL()
 	if toSQLErr != nil {


### PR DESCRIPTION
This pull request standardizes the formatting of regular expressions used for `assetIdRegexPatterns` in various test and example files. The main change is the addition of missing escape characters in domain names within these regex patterns, ensuring consistency and correctness in matching asset IDs.

**Regex Pattern Standardization:**

* Updated all occurrences of `"^https://i\.iese.fraunhofer\.de/assetId/"` to `"^https://i\.iese\.fraunhofer\.de/assetId/"` across test post bodies and expected output JSON files to properly escape the dot in the domain and accurately reflect the intended domain matching. [[1]](diffhunk://#diff-5d81ce590bf3bb71880dc9750ae4d8016f0464eff903a923768c4e106a313077L81-R81) [[2]](diffhunk://#diff-4bbac1fcdb38e6fcbc09432e6f060fb8e917553699cf01093a5c9559ea489d4eL60-R60) [[3]](diffhunk://#diff-e1805ad37c9be92e42123b7bf32a7464848d765908979529dfe999388a4cbe61L73-R73) [[4]](diffhunk://#diff-6040e1e390a3166108be779d7d5acb257e32698f647bc3bf35cd25e829abaf4fL81-R81) [[5]](diffhunk://#diff-79c9f2b24d491aab04af13b23f2668e56d7c18da7d3f08f5365737d5173681f2L46-R46) [[6]](diffhunk://#diff-f1b61d446e81e46770d57e735d7ec3c31c2d54825beba4c63355cfcfd7ce5c30L46-R46) [[7]](diffhunk://#diff-b6987912a13c06742f9e0d4c0763862d1bb0e49494ad77f93a2471b849e22f8eL76-R76) [[8]](diffhunk://#diff-3f130b05927a065a42da50d1bb0ab20b53165c54379b328df4d6669fbd7c2080L81-R81) [[9]](diffhunk://#diff-12c3806c7b496926fec4566c86447f00303093c16ae2e47b8fbbdad550ce7500L81-R81) [[10]](diffhunk://#diff-e081f0db75da41aa987eaa7766ce9e307c862cdd7a54d6f03e8238b789fd3cb5L81-R81) [[11]](diffhunk://#diff-f884963bfe8db573c1111edaca04e670eafbe45cf9aa99ed498ae0f82b813c64L43-R43) [[12]](diffhunk://#diff-061ed4dec3168004157c8d9e3d2ccc38f01e07f89d8c58ea995599f9ab3874f4L81-R81) [[13]](diffhunk://#diff-c4f2346b77d3c43a08e7687af8c82bfafad04f040fa88bdc09232f7100f36a6eL19-R19) [[14]](diffhunk://#diff-bff1a5636f5517caee598c6645a9767745df5a28b35844bcb49c28741a886f59L64-R64) [[15]](diffhunk://#diff-8a42e2bd530e0622c73cf452c39adecf1464ecafd253aaaa7b2521b58bf01072L156-R156) [[16]](diffhunk://#diff-63960c6c4ec033a157ee7203891e5b51eb929daaf1216ee3d7fb0982160d1c5aL112-R112)

* Updated `"^https://i\.updated.excom1\.de/assetId/"` to `"^https://i\.updated\.excom1\.de/assetId/"` in the relevant test post body to ensure proper domain matching.

These changes improve the reliability of asset ID pattern matching in tests and examples by ensuring the regex patterns are correctly formed and consistent throughout the codebase.

**Submodel Repo Linter Suppression**

Suppressed a linter comment since it is ensured that no overflow can occur.