### PR TITLE
Improves router behavior for trailing slashes

### DIFF
--- a/cmd/aasenvironmentservice/main.go
+++ b/cmd/aasenvironmentservice/main.go
@@ -161,7 +161,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 
 	base := common.NormalizeBasePath(cfg.Server.ContextPath)
 	apiRouter := chi.NewRouter()
-	common.AddDefaultRouterErrorHandlers(apiRouter, "AASEnvironmentService")
+	common.ConfigureAPIRouter(apiRouter, "AASEnvironmentService")
 
 	if err = auth.SetupSecurity(ctx, cfg, apiRouter); err != nil {
 		return err

--- a/cmd/aasregistryservice/main.go
+++ b/cmd/aasregistryservice/main.go
@@ -108,7 +108,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 
 	// === Protected API Subrouter ===
 	apiRouter := chi.NewRouter()
-	common.AddDefaultRouterErrorHandlers(apiRouter, "AASRegistryService")
+	common.ConfigureAPIRouter(apiRouter, "AASRegistryService")
 
 	// Apply OIDC + ABAC once for all registry endpoints
 	if err := auth.SetupSecurity(ctx, cfg, apiRouter); err != nil {

--- a/cmd/aasrepositoryservice/main.go
+++ b/cmd/aasrepositoryservice/main.go
@@ -75,7 +75,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 	base := common.NormalizeBasePath(cfg.Server.ContextPath)
 
 	apiRouter := chi.NewRouter()
-	common.AddDefaultRouterErrorHandlers(apiRouter, "AASRepositoryService")
+	common.ConfigureAPIRouter(apiRouter, "AASRepositoryService")
 
 	if err := auth.SetupSecurity(ctx, cfg, apiRouter); err != nil {
 		return err

--- a/cmd/companylookupservice/main.go
+++ b/cmd/companylookupservice/main.go
@@ -72,7 +72,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 
 	// === Protected API Subrouter ===
 	apiRouter := chi.NewRouter()
-	common.AddDefaultRouterErrorHandlers(apiRouter, "CompanyLookupService")
+	common.ConfigureAPIRouter(apiRouter, "CompanyLookupService")
 
 	// Register all company lookup routes
 	for _, rt := range companyLookupCtrl.Routes() {

--- a/cmd/conceptdescriptionrepositoryservice/main.go
+++ b/cmd/conceptdescriptionrepositoryservice/main.go
@@ -101,6 +101,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 
 	// === Protected API Subrouter ===
 	apiRouter := chi.NewRouter()
+	common.ConfigureAPIRouter(apiRouter, "ConceptDescriptionRepositoryService")
 
 	// Apply OIDC + ABAC once for all repository endpoints
 	if err := auth.SetupSecurity(ctx, config, apiRouter); err != nil {

--- a/cmd/digitaltwinregistryservice/main.go
+++ b/cmd/digitaltwinregistryservice/main.go
@@ -134,7 +134,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 	descriptionCtrl := openapi.NewDescriptionAPIAPIController(descriptionSvc)
 
 	apiRouter := chi.NewRouter()
-	common.AddDefaultRouterErrorHandlers(apiRouter, "DigitalTwinRegistryService")
+	common.ConfigureAPIRouter(apiRouter, "DigitalTwinRegistryService")
 	if err := auth.SetupSecurityWithClaimsMiddleware(ctx, cfg, apiRouter, auth.EdcBpnHeaderMiddleware); err != nil {
 		return err
 	}

--- a/cmd/discoveryservice/main.go
+++ b/cmd/discoveryservice/main.go
@@ -109,7 +109,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 
 	// === Protected API Subrouter ===
 	apiRouter := chi.NewRouter()
-	common.AddDefaultRouterErrorHandlers(apiRouter, "DiscoveryService")
+	common.ConfigureAPIRouter(apiRouter, "DiscoveryService")
 
 	// Apply OIDC + ABAC once for all discovery endpoints
 	if err := auth.SetupSecurity(ctx, cfg, apiRouter); err != nil {

--- a/cmd/submodelregistryservice/main.go
+++ b/cmd/submodelregistryservice/main.go
@@ -108,7 +108,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 	// luk
 	// === Protected API Subrouter ===
 	apiRouter := chi.NewRouter()
-	common.AddDefaultRouterErrorHandlers(apiRouter, "SubmodelRegistryService")
+	common.ConfigureAPIRouter(apiRouter, "SubmodelRegistryService")
 
 	// Apply OIDC + ABAC once for all registry endpoints
 	if err := auth.SetupSecurity(ctx, cfg, apiRouter); err != nil {

--- a/cmd/submodelrepositoryservice/main.go
+++ b/cmd/submodelrepositoryservice/main.go
@@ -82,7 +82,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 
 	// === Protected API Subrouter ===
 	apiRouter := chi.NewRouter()
-	common.AddDefaultRouterErrorHandlers(apiRouter, "SubmodelRepositoryService")
+	common.ConfigureAPIRouter(apiRouter, "SubmodelRepositoryService")
 
 	// Apply OIDC + ABAC once for all repository endpoints
 	if err := auth.SetupSecurity(ctx, config, apiRouter); err != nil {

--- a/internal/aasregistry/integration_tests/it_config.json
+++ b/internal/aasregistry/integration_tests/it_config.json
@@ -14,6 +14,32 @@
     "expectedStatus": 200
   },
   {
+    "context": "002.1 - List AAS Descriptors (Trailing Slash) - GET /shell-descriptors/",
+    "method": "GET",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "expectedStatus": 200
+  },
+  {
+    "context": "002.2 - Create AAS Descriptor (Trailing Slash, Malformed) - POST /shell-descriptors/",
+    "method": "POST",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "data": "postBody/simple_ass_descriptor_malformed.json",
+    "expectedStatus": 400
+  },
+  {
+    "context": "002.3 - Replace AAS Descriptor (Trailing Slash) - PUT /shell-descriptors/",
+    "method": "PUT",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "data": "postBody/simple_ass_descriptor_2.json",
+    "expectedStatus": 405
+  },
+  {
+    "context": "002.4 - Delete AAS Descriptor (Trailing Slash) - DELETE /shell-descriptors/",
+    "method": "DELETE",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "expectedStatus": 405
+  },
+  {
     "context": "003 - Get AAS Descriptor by ID (Not Found) - GET /shell-descriptors/{aasId}",
     "method": "GET",
     "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",

--- a/internal/aasregistry/integration_tests/it_config.json
+++ b/internal/aasregistry/integration_tests/it_config.json
@@ -52,6 +52,32 @@
     "expectedStatus": 404
   },
   {
+    "context": "004.1 - List Submodel Descriptors (AAS Not Found, Trailing Slash) - GET /shell-descriptors/{aasId}/submodel-descriptors/",
+    "method": "GET",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
+    "expectedStatus": 404
+  },
+  {
+    "context": "004.2 - Create Submodel Descriptor (AAS Not Found, Trailing Slash) - POST /shell-descriptors/{aasId}/submodel-descriptors/",
+    "method": "POST",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
+    "data": "postBody/simple_submodel_descriptor_1.json",
+    "expectedStatus": 404
+  },
+  {
+    "context": "004.3 - Replace Submodel Descriptor Collection (Trailing Slash) - PUT /shell-descriptors/{aasId}/submodel-descriptors/",
+    "method": "PUT",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
+    "data": "postBody/simple_submodel_descriptor_2.json",
+    "expectedStatus": 405
+  },
+  {
+    "context": "004.4 - Delete Submodel Descriptor Collection (Trailing Slash) - DELETE /shell-descriptors/{aasId}/submodel-descriptors/",
+    "method": "DELETE",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
+    "expectedStatus": 405
+  },
+  {
     "context": "005 - Replace Submodel Descriptor (AAS Not Found) - PUT /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "PUT",
     "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAy",

--- a/internal/aasrepository/integration_tests/it_config.json
+++ b/internal/aasrepository/integration_tests/it_config.json
@@ -14,6 +14,24 @@
 		"expectedStatus": 200
 	},
 	{
+		"context": "003.1 - GET /shells/ - trailing slash collection",
+		"method": "GET",
+		"endpoint": "http://127.0.0.1:6004/shells/",
+		"expectedStatus": 200
+	},
+	{
+		"context": "003.2 - PUT /shells/ - trailing slash method not allowed",
+		"method": "PUT",
+		"endpoint": "http://127.0.0.1:6004/shells/",
+		"expectedStatus": 405
+	},
+	{
+		"context": "003.3 - DELETE /shells/ - trailing slash method not allowed",
+		"method": "DELETE",
+		"endpoint": "http://127.0.0.1:6004/shells/",
+		"expectedStatus": 405
+	},
+	{
 		"context": "004.1 - GET /shells - empty",
 		"method": "GET",
 		"endpoint": "http://127.0.0.1:6004/shells",

--- a/internal/aasrepository/integration_tests/it_config.json
+++ b/internal/aasrepository/integration_tests/it_config.json
@@ -32,6 +32,13 @@
 		"expectedStatus": 405
 	},
 	{
+		"context": "003.4 - POST /shells/ - trailing slash malformed payload",
+		"method": "POST",
+		"endpoint": "http://127.0.0.1:6004/shells/",
+		"data": "bodies/invalid/malformedJson.txt",
+		"expectedStatus": 400
+	},
+	{
 		"context": "004.1 - GET /shells - empty",
 		"method": "GET",
 		"endpoint": "http://127.0.0.1:6004/shells",

--- a/internal/common/router_error_handlers.go
+++ b/internal/common/router_error_handlers.go
@@ -9,7 +9,15 @@ import (
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 )
+
+// ConfigureAPIRouter applies common API router behavior.
+// It normalizes trailing slashes without redirects and registers standardized 404/405 handlers.
+func ConfigureAPIRouter(r *chi.Mux, component string) {
+	r.Use(middleware.StripSlashes)
+	AddDefaultRouterErrorHandlers(r, component)
+}
 
 // AddDefaultRouterErrorHandlers attaches standardized 404/405 responses to the router.
 // The component name is used in correlation code generation.

--- a/internal/common/router_error_handlers_test.go
+++ b/internal/common/router_error_handlers_test.go
@@ -69,3 +69,64 @@ func TestAddDefaultRouterErrorHandlers_MethodNotAllowed(t *testing.T) {
 		t.Fatalf("expected correlation id to contain %q, got %q", "DISCOVERYSERVICE-ROUTER-METHODNOTALLOWED", body[0].CorrelationID)
 	}
 }
+
+func TestConfigureAPIRouter_StripsTrailingSlashToCollectionRoute(t *testing.T) {
+	router := chi.NewRouter()
+	ConfigureAPIRouter(router, "Discovery Service")
+	router.Get("/lookup/shells", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("collection"))
+	})
+	router.Get("/lookup/shells/{aasIdentifier}", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("item"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/lookup/shells/", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+	if rec.Body.String() != "collection" {
+		t.Fatalf("expected collection route response, got %q", rec.Body.String())
+	}
+	if location := rec.Header().Get("Location"); location != "" {
+		t.Fatalf("expected no redirect location header, got %q", location)
+	}
+}
+
+func TestConfigureAPIRouter_CollectionTrailingSlashMethodNotAllowed(t *testing.T) {
+	router := chi.NewRouter()
+	ConfigureAPIRouter(router, "Submodel Registry Service")
+	router.Get("/submodel-descriptors", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	router.Post("/submodel-descriptors", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	router.Put("/submodel-descriptors/{submodelIdentifier}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/submodel-descriptors/", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+	}
+
+	var body []ErrorHandler
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if len(body) != 1 {
+		t.Fatalf("expected 1 error entry, got %d", len(body))
+	}
+	if body[0].Text != "method not allowed" {
+		t.Fatalf("expected error text %q, got %q", "method not allowed", body[0].Text)
+	}
+	if !strings.Contains(body[0].CorrelationID, "SUBMODELREGISTRYSERVICE-ROUTER-METHODNOTALLOWED") {
+		t.Fatalf("expected correlation id to contain %q, got %q", "SUBMODELREGISTRYSERVICE-ROUTER-METHODNOTALLOWED", body[0].CorrelationID)
+	}
+}

--- a/internal/companylookupservice/integration_tests/it_config.json
+++ b/internal/companylookupservice/integration_tests/it_config.json
@@ -14,6 +14,31 @@
         "expectedStatus": 200
     },
     {
+        "context": "002.1 - List Company Descriptors (Trailing Slash) - GET /companies/",
+        "method": "GET",
+        "endpoint": "http://127.0.0.1:6004/companies/",
+        "expectedStatus": 200
+    },
+    {
+        "context": "002.2 - Create Company Descriptor (Trailing Slash, Malformed) - POST /companies/",
+        "method": "POST",
+        "endpoint": "http://127.0.0.1:6004/companies/",
+        "data": "postBody/company_descriptor_malformed_missing_domain.json",
+        "expectedStatus": 400
+    },
+    {
+        "context": "002.3 - Replace Company Collection (Trailing Slash) - PUT /companies/",
+        "method": "PUT",
+        "endpoint": "http://127.0.0.1:6004/companies/",
+        "expectedStatus": 405
+    },
+    {
+        "context": "002.4 - Delete Company Collection (Trailing Slash) - DELETE /companies/",
+        "method": "DELETE",
+        "endpoint": "http://127.0.0.1:6004/companies/",
+        "expectedStatus": 405
+    },
+    {
         "context": "003 - Create Company Descriptor #1 - POST /companies",
         "method": "POST",
         "endpoint": "http://127.0.0.1:6004/companies",

--- a/internal/conceptdescriptionrepository/integration_tests/it_config.json
+++ b/internal/conceptdescriptionrepository/integration_tests/it_config.json
@@ -13,6 +13,24 @@
         "shouldMatch": "expected/GetAllConceptDescriptionsEmpty.json"
     },
     {
+        "context": "001.1 - Get All Concept Descriptions (Trailing Slash)",
+        "method": "GET",
+        "endpoint": "http://localhost:6004/concept-descriptions/",
+        "expectedStatus": 200
+    },
+    {
+        "context": "001.2 - Update Concept Descriptions Collection (Trailing Slash)",
+        "method": "PUT",
+        "endpoint": "http://localhost:6004/concept-descriptions/",
+        "expectedStatus": 405
+    },
+    {
+        "context": "001.3 - Delete Concept Descriptions Collection (Trailing Slash)",
+        "method": "DELETE",
+        "endpoint": "http://localhost:6004/concept-descriptions/",
+        "expectedStatus": 405
+    },
+    {
         "context": "002 - Create Concept Description A",
         "method": "POST",
         "endpoint": "http://localhost:6004/concept-descriptions",

--- a/internal/conceptdescriptionrepository/integration_tests/it_config.json
+++ b/internal/conceptdescriptionrepository/integration_tests/it_config.json
@@ -31,9 +31,9 @@
         "expectedStatus": 405
     },
     {
-        "context": "002 - Create Concept Description A",
+        "context": "002 - Create Concept Description A (Trailing Slash)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "http://localhost:6004/concept-descriptions/",
         "expectedStatus": 201,
         "data": "bodies/ConceptDescriptionA.json",
         "shouldMatch": "bodies/ConceptDescriptionA.json"

--- a/internal/digitaltwinregistry/integration_tests/docker_compose/keycloak/realm/basyx-realm.json
+++ b/internal/digitaltwinregistry/integration_tests/docker_compose/keycloak/realm/basyx-realm.json
@@ -28,7 +28,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "none",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,

--- a/internal/digitaltwinregistry/integration_tests/docker_compose/keycloak/realm/basyx-realm.json
+++ b/internal/digitaltwinregistry/integration_tests/docker_compose/keycloak/realm/basyx-realm.json
@@ -28,7 +28,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "none",
+  "sslRequired" : "external",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,

--- a/internal/digitaltwinregistry/integration_tests/it_config.json
+++ b/internal/digitaltwinregistry/integration_tests/it_config.json
@@ -25,7 +25,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
     "data": "postBody/descriptor_public.json",
     "expectedStatus": 201,
     "headers": {

--- a/internal/digitaltwinregistry/integration_tests/it_config.json
+++ b/internal/digitaltwinregistry/integration_tests/it_config.json
@@ -1,5 +1,29 @@
 [
   {
+    "method": "GET",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "expectedStatus": 200,
+    "headers": {
+      "Edc-Bpn": "BPNL00000000015G"
+    }
+  },
+  {
+    "method": "PUT",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "expectedStatus": 405,
+    "headers": {
+      "Edc-Bpn": "BPNL00000000015G"
+    }
+  },
+  {
+    "method": "DELETE",
+    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "expectedStatus": 405,
+    "headers": {
+      "Edc-Bpn": "BPNL00000000015G"
+    }
+  },
+  {
     "method": "POST",
     "endpoint": "http://127.0.0.1:6004/shell-descriptors",
     "data": "postBody/descriptor_public.json",

--- a/internal/discoveryservice/integration_tests/it_config.json
+++ b/internal/discoveryservice/integration_tests/it_config.json
@@ -1,5 +1,23 @@
 [
   {
+    "context": "000 - Lookup Collection (Trailing Slash) - GET /lookup/shells/",
+    "method": "GET",
+    "endpoint": "http://127.0.0.1:6004/lookup/shells/",
+    "expectedStatus": 200
+  },
+  {
+    "context": "000.1 - Lookup Collection (Trailing Slash) - POST /lookup/shells/",
+    "method": "POST",
+    "endpoint": "http://127.0.0.1:6004/lookup/shells/",
+    "expectedStatus": 405
+  },
+  {
+    "context": "000.2 - Lookup Collection (Trailing Slash) - DELETE /lookup/shells/",
+    "method": "DELETE",
+    "endpoint": "http://127.0.0.1:6004/lookup/shells/",
+    "expectedStatus": 405
+  },
+  {
     "context": "001 - Search empty dataset",
     "method": "POST",
     "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=5",

--- a/internal/smregistry/integration_tests/it_config.json
+++ b/internal/smregistry/integration_tests/it_config.json
@@ -14,6 +14,32 @@
     "expectedStatus": 200
   },
   {
+    "context": "002.1 - List Submodel Descriptors (Trailing Slash) - GET /submodel-descriptors/",
+    "method": "GET",
+    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/",
+    "expectedStatus": 200
+  },
+  {
+    "context": "002.2 - Create Submodel Descriptor (Trailing Slash, Malformed) - POST /submodel-descriptors/",
+    "method": "POST",
+    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/",
+    "data": "postBody/simple_submodel_descriptor_malformed.json",
+    "expectedStatus": 400
+  },
+  {
+    "context": "002.3 - Replace Submodel Descriptor (Trailing Slash) - PUT /submodel-descriptors/",
+    "method": "PUT",
+    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/",
+    "data": "postBody/simple_submodel_descriptor_2.json",
+    "expectedStatus": 405
+  },
+  {
+    "context": "002.4 - Delete Submodel Descriptor (Trailing Slash) - DELETE /submodel-descriptors/",
+    "method": "DELETE",
+    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/",
+    "expectedStatus": 405
+  },
+  {
     "context": "003 - Get Submodel Descriptor by ID (Not Found) - GET /submodel-descriptors/{submodelId}",
     "method": "GET",
     "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",

--- a/internal/submodelrepository/integration_tests/it_config.json
+++ b/internal/submodelrepository/integration_tests/it_config.json
@@ -13,6 +13,24 @@
         "expectedStatus": 200
     },
     {
+        "context": "Get All Submodels (Trailing Slash)",
+        "method": "GET",
+        "endpoint": "http://localhost:6004/submodels/",
+        "expectedStatus": 200
+    },
+    {
+        "context": "Replace Submodel (Trailing Slash)",
+        "method": "PUT",
+        "endpoint": "http://localhost:6004/submodels/",
+        "expectedStatus": 405
+    },
+    {
+        "context": "Delete Submodel (Trailing Slash)",
+        "method": "DELETE",
+        "endpoint": "http://localhost:6004/submodels/",
+        "expectedStatus": 405
+    },
+    {
         "context": "Post Submodel",
         "method": "POST",
         "endpoint": "http://localhost:6004/submodels",

--- a/internal/submodelrepository/integration_tests/it_config.json
+++ b/internal/submodelrepository/integration_tests/it_config.json
@@ -31,9 +31,9 @@
         "expectedStatus": 405
     },
     {
-        "context": "Post Submodel",
+        "context": "Post Submodel (Trailing Slash)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "http://localhost:6004/submodels/",
         "data": "bodies/post/postSubmodel.json",
         "shouldMatch": "bodies/post/postSubmodel.json",
         "expectedStatus": 201


### PR DESCRIPTION
This pull request introduces a new common router configuration function to standardize API route handling across all services. The main improvement is the normalization of trailing slashes in collection routes, ensuring that requests to endpoints with or without a trailing slash are handled consistently without redirects. This change is accompanied by comprehensive integration tests across all services to verify correct behavior for trailing slash requests, including appropriate status codes for unsupported methods.

Key changes include:

**Router configuration and error handling:**

* Introduced a new `ConfigureAPIRouter` function in `internal/common/router_error_handlers.go` that applies the `StripSlashes` middleware and registers standardized 404/405 error handlers, replacing direct calls to `AddDefaultRouterErrorHandlers` in all service entrypoints. This ensures that requests to collection endpoints with a trailing slash are routed correctly and unsupported HTTP methods return proper error responses.
* Updated all service `main.go` files to use `ConfigureAPIRouter` instead of `AddDefaultRouterErrorHandlers`, applying the new standardized routing behavior throughout the codebase. [[1]](diffhunk://#diff-51f1bcc3811289797b18916ce371dcc6c81a4339f3e95b19a845700bde74951aL164-R164) [[2]](diffhunk://#diff-1844897dd4209995585aa37d15898659999ecf8a0308b478a7d921bac66d8394L111-R111) [[3]](diffhunk://#diff-2a8654a4d8aaf70e328f028635529ccc7c5398862bc648fc096170e6de1f2d31L78-R78) [[4]](diffhunk://#diff-0f89a8d9021c46593138cf0324543a3800b4f6ede40f55f4d6921eb2c5c1cf56L75-R75) [[5]](diffhunk://#diff-07aced2e065509d52ffe396c98823625aee1254dd1bb0077280900f546add837R104) [[6]](diffhunk://#diff-ee38c16347b18545d4fb956226c6b9501a83ca5636f4b25bf4d85ecba90535adL137-R137) [[7]](diffhunk://#diff-00272267017056a3c6fcb8023ebc489db7f3e74ab006a0056f33f110da757179L112-R112) [[8]](diffhunk://#diff-7331a6d6a09a0d4f4bcc214a46a4515d8faf90abed5c6a1359a2af5c7a3998d7L111-R111) [[9]](diffhunk://#diff-76adea4f21342a9c4ef52d3fb7dfe2260bdfe14cb167d86c398cfb121b42d6dbL85-R85)

**Testing and validation:**

* Added new unit tests in `internal/common/router_error_handlers_test.go` to verify that collection routes with trailing slashes are handled without redirects and that unsupported methods return 405 with the correct error structure.

**Integration tests for trailing slash handling:**

* Expanded integration test configurations for all major services (AAS Registry, AAS Repository, Company Lookup, Concept Description Repository, Digital Twin Registry, Discovery Service, Submodel Registry, Submodel Repository) to cover requests to collection endpoints with trailing slashes. These tests verify correct handling of GET, PUT, POST, and DELETE methods, including expected status codes (200, 400, or 405 as appropriate). [[1]](diffhunk://#diff-8e84ecc602b186c55407fd82b8c6aabadeda6d1dd50b34fcd923e66455949cafR16-R41) [[2]](diffhunk://#diff-80ce905929076e774e8a204cdbdecd2d1ff0976d9bb98d3b37b91ec63ab5b23fR16-R33) [[3]](diffhunk://#diff-9f530e38fb457817c7fd80901c0a10f703bdd059aa9ffa528ce751b1dff28dfeR16-R40) [[4]](diffhunk://#diff-b63cbf1c6790d20193d3fb96d54e954605d89385276870b615f85ed668c9814aR15-R32) [[5]](diffhunk://#diff-b25d5649a6781d55c9be73f70b6da7c043d2640117b603f2191a4926da930d00R2-R25) [[6]](diffhunk://#diff-3a3859c4d693a002d222f18fd406b3dcae07d4eadb213d69974f0e291b16e543R2-R19) [[7]](diffhunk://#diff-5109f99f504cd937ec8a6d081c6a3fc92da1ef19e90ab992446bc4946952ce49R16-R41) [[8]](diffhunk://#diff-693f7b63e17474befce86575798d58435cf9f765376649e2aebe9c40c056d82bR15-R32)

**Other configuration:**

* Disabled SSL requirement in the Keycloak test realm configuration to facilitate local integration testing.