### PR TITLE
Fixes incorrect status codes for concept description repository

### DIFF
--- a/internal/conceptdescriptionrepository/api/api_concept_description_repository_api_service.go
+++ b/internal/conceptdescriptionrepository/api/api_concept_description_repository_api_service.go
@@ -186,7 +186,7 @@ func (s *ConceptDescriptionRepositoryAPIAPIService) PutConceptDescriptionById(ct
 	if err != nil {
 		return common.NewErrorResponse(err, http.StatusBadRequest, componentName, "PutConceptDescriptionById", "URLDecode"), nil
 	}
-	created, err := s.d.PutConceptDescription(ctx, string(decodedIdentifier), conceptDescription)
+	isUpdate, err := s.d.PutConceptDescription(ctx, string(decodedIdentifier), conceptDescription)
 	if err != nil {
 		switch {
 		case common.IsErrBadRequest(err):
@@ -198,15 +198,16 @@ func (s *ConceptDescriptionRepositoryAPIAPIService) PutConceptDescriptionById(ct
 		}
 	}
 
-	if created {
-		jsonable, toJsonErr := jsonization.ToJsonable(conceptDescription)
-		if toJsonErr != nil {
-			return common.NewErrorResponse(toJsonErr, http.StatusInternalServerError, componentName, "PutConceptDescriptionById", "ToJsonable"), toJsonErr
-		}
-		return model.Response(http.StatusCreated, jsonable), nil
+	if isUpdate {
+		return model.Response(http.StatusNoContent, nil), nil
 	}
 
-	return model.Response(http.StatusNoContent, nil), nil
+	jsonable, toJsonErr := jsonization.ToJsonable(conceptDescription)
+	if toJsonErr != nil {
+		return common.NewErrorResponse(toJsonErr, http.StatusInternalServerError, componentName, "PutConceptDescriptionById", "ToJsonable"), toJsonErr
+	}
+
+	return model.Response(http.StatusCreated, jsonable), nil
 }
 
 // DeleteConceptDescriptionById - Deletes a Concept Description

--- a/internal/conceptdescriptionrepository/api/api_concept_description_repository_api_service.go
+++ b/internal/conceptdescriptionrepository/api/api_concept_description_repository_api_service.go
@@ -186,7 +186,7 @@ func (s *ConceptDescriptionRepositoryAPIAPIService) PutConceptDescriptionById(ct
 	if err != nil {
 		return common.NewErrorResponse(err, http.StatusBadRequest, componentName, "PutConceptDescriptionById", "URLDecode"), nil
 	}
-	err = s.d.PutConceptDescription(ctx, string(decodedIdentifier), conceptDescription)
+	created, err := s.d.PutConceptDescription(ctx, string(decodedIdentifier), conceptDescription)
 	if err != nil {
 		switch {
 		case common.IsErrBadRequest(err):
@@ -198,12 +198,15 @@ func (s *ConceptDescriptionRepositoryAPIAPIService) PutConceptDescriptionById(ct
 		}
 	}
 
-	jsonable, toJsonErr := jsonization.ToJsonable(conceptDescription)
-	if toJsonErr != nil {
-		return common.NewErrorResponse(toJsonErr, http.StatusInternalServerError, componentName, "PutConceptDescriptionById", "ToJsonable"), toJsonErr
+	if created {
+		jsonable, toJsonErr := jsonization.ToJsonable(conceptDescription)
+		if toJsonErr != nil {
+			return common.NewErrorResponse(toJsonErr, http.StatusInternalServerError, componentName, "PutConceptDescriptionById", "ToJsonable"), toJsonErr
+		}
+		return model.Response(http.StatusCreated, jsonable), nil
 	}
 
-	return model.Response(http.StatusOK, jsonable), nil
+	return model.Response(http.StatusNoContent, nil), nil
 }
 
 // DeleteConceptDescriptionById - Deletes a Concept Description
@@ -219,6 +222,8 @@ func (s *ConceptDescriptionRepositoryAPIAPIService) DeleteConceptDescriptionById
 			return common.NewErrorResponse(err, http.StatusBadRequest, componentName, "DeleteConceptDescriptionById", "BadRequest"), nil
 		case common.IsErrDenied(err):
 			return common.NewErrorResponse(err, http.StatusForbidden, componentName, "DeleteConceptDescriptionById", "Denied"), nil
+		case common.IsErrNotFound(err):
+			return common.NewErrorResponse(err, http.StatusNotFound, componentName, "DeleteConceptDescriptionById", "NotFound"), nil
 		default:
 			return common.NewErrorResponse(err, http.StatusInternalServerError, componentName, "DeleteConceptDescriptionById", "Unhandled"), err
 		}

--- a/internal/conceptdescriptionrepository/integration_tests/bodies/ConceptDescriptionC.json
+++ b/internal/conceptdescriptionrepository/integration_tests/bodies/ConceptDescriptionC.json
@@ -1,0 +1,5 @@
+{
+  "id": "urn:example:cd:c:3",
+  "idShort": "ConceptC",
+  "modelType": "ConceptDescription"
+}

--- a/internal/conceptdescriptionrepository/integration_tests/it_config.json
+++ b/internal/conceptdescriptionrepository/integration_tests/it_config.json
@@ -77,9 +77,8 @@
         "context": "007 - Update Concept Description B via PUT",
         "method": "PUT",
         "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yjoy",
-        "expectedStatus": 200,
-        "data": "bodies/ConceptDescriptionBUpdated.json",
-        "shouldMatch": "bodies/ConceptDescriptionBUpdated.json"
+        "expectedStatus": 204,
+        "data": "bodies/ConceptDescriptionBUpdated.json"
     },
     {
         "context": "008 - Get Updated Concept Description B by ID",
@@ -97,6 +96,12 @@
     {
         "context": "010 - Get Concept Description A by ID (Not Found)",
         "method": "GET",
+        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
+        "expectedStatus": 404
+    },
+    {
+        "context": "010.1 - Delete Concept Description A by ID (Not Found)",
+        "method": "DELETE",
         "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
         "expectedStatus": 404
     },
@@ -119,6 +124,26 @@
         "endpoint": "http://localhost:6004/concept-descriptions",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsEmpty.json"
+    },
+    {
+        "context": "013.1 - Create Concept Description C via PUT",
+        "method": "PUT",
+        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yzoz",
+        "expectedStatus": 201,
+        "data": "bodies/ConceptDescriptionC.json"
+    },
+    {
+        "context": "013.2 - Get Concept Description C by ID",
+        "method": "GET",
+        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yzoz",
+        "expectedStatus": 200,
+        "shouldMatch": "bodies/ConceptDescriptionC.json"
+    },
+    {
+        "context": "013.3 - Delete Concept Description C",
+        "method": "DELETE",
+        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yzoz",
+        "expectedStatus": 204
     },
     {
         "context": "014 - Create Concept Description Full",

--- a/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
+++ b/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
@@ -468,7 +468,7 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptionByID(ctx context.Contex
 	return cd, nil
 }
 
-// PutConceptDescription updates or replaces the concept description with the given identifier.
+// PutConceptDescription creates or replaces the concept description with the given identifier and reports whether an existing row was replaced.
 func (b *ConceptDescriptionBackend) PutConceptDescription(ctx context.Context, id string, cd types.IConceptDescription) (bool, error) {
 	tx, cleanup, err := common.StartTransaction(b.db)
 	if err != nil {
@@ -498,8 +498,9 @@ func (b *ConceptDescriptionBackend) PutConceptDescription(ctx context.Context, i
 		}
 	}
 
+	isUpdate := false
 	if existingExists {
-		if _, err = b.deleteConceptDescriptionInTx(ctx, tx, id); err != nil {
+		if isUpdate, err = b.deleteConceptDescriptionInTx(ctx, tx, id); err != nil {
 			return false, err
 		}
 	}
@@ -525,7 +526,7 @@ func (b *ConceptDescriptionBackend) PutConceptDescription(ctx context.Context, i
 		return false, common.NewInternalServerError("CDREPO-PUTCD-COMMIT " + err.Error())
 	}
 
-	return !existingExists, nil
+	return isUpdate, nil
 }
 
 // DeleteConceptDescription removes a concept description by its identifier.

--- a/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
+++ b/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
@@ -145,17 +145,23 @@ func (b *ConceptDescriptionBackend) createConceptDescriptionInTx(ctx context.Con
 	return nil
 }
 
-func (b *ConceptDescriptionBackend) deleteConceptDescriptionInTx(ctx context.Context, tx *sql.Tx, id string) error {
+func (b *ConceptDescriptionBackend) deleteConceptDescriptionInTx(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
 	delQuery, args, err := goqu.Delete("concept_description").Where(goqu.Ex{"id": id}).ToSQL()
 	if err != nil {
-		return common.NewInternalServerError("CDREPO-DELCD-BUILDSQL " + err.Error())
+		return false, common.NewInternalServerError("CDREPO-DELCD-BUILDSQL " + err.Error())
 	}
 
-	if _, err = tx.ExecContext(ctx, delQuery, args...); err != nil {
-		return common.NewInternalServerError("CDREPO-DELCD-EXECSQL " + err.Error())
+	result, execErr := tx.ExecContext(ctx, delQuery, args...)
+	if execErr != nil {
+		return false, common.NewInternalServerError("CDREPO-DELCD-EXECSQL " + execErr.Error())
 	}
 
-	return nil
+	rowsAffected, rowsErr := result.RowsAffected()
+	if rowsErr != nil {
+		return false, common.NewInternalServerError("CDREPO-DELCD-ROWCOUNT " + rowsErr.Error())
+	}
+
+	return rowsAffected > 0, nil
 }
 
 func conceptDescriptionExistsInTx(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
@@ -463,63 +469,63 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptionByID(ctx context.Contex
 }
 
 // PutConceptDescription updates or replaces the concept description with the given identifier.
-func (b *ConceptDescriptionBackend) PutConceptDescription(ctx context.Context, id string, cd types.IConceptDescription) (err error) {
+func (b *ConceptDescriptionBackend) PutConceptDescription(ctx context.Context, id string, cd types.IConceptDescription) (bool, error) {
 	tx, cleanup, err := common.StartTransaction(b.db)
 	if err != nil {
-		return common.NewInternalServerError("CDREPO-PUTCD-STARTTX " + err.Error())
+		return false, common.NewInternalServerError("CDREPO-PUTCD-STARTTX " + err.Error())
 	}
 	defer cleanup(&err)
 
 	existingExists, existsErr := conceptDescriptionExistsInTx(ctx, tx, id)
 	if existsErr != nil {
-		return existsErr
+		return false, existsErr
 	}
 
 	shouldEnforceFormula, enforceErr := auth.ShouldEnforceFormula(ctx)
 	if enforceErr != nil {
-		return common.NewInternalServerError("CDREPO-PUTCD-SHOULDENFORCE " + enforceErr.Error())
+		return false, common.NewInternalServerError("CDREPO-PUTCD-SHOULDENFORCE " + enforceErr.Error())
 	}
 	if shouldEnforceFormula {
 		ctx = auth.SelectPutFormulaByExistence(ctx, existingExists)
 		if existingExists {
 			_, visible, visErr := b.checkConceptDescriptionVisibilityInTx(ctx, tx, id)
 			if visErr != nil {
-				return visErr
+				return false, visErr
 			}
 			if !visible {
-				return common.NewErrDenied("CDREPO-PUTCD-ABACDENIED existing concept description is not accessible under ABAC constraints")
+				return false, common.NewErrDenied("CDREPO-PUTCD-ABACDENIED existing concept description is not accessible under ABAC constraints")
 			}
 		}
 	}
 
 	if existingExists {
-		if err = b.deleteConceptDescriptionInTx(ctx, tx, id); err != nil {
-			return err
+		if _, err = b.deleteConceptDescriptionInTx(ctx, tx, id); err != nil {
+			return false, err
 		}
 	}
 
 	if err = b.createConceptDescriptionInTx(ctx, tx, cd); err != nil {
-		return err
+		return false, err
 	}
 
 	if shouldEnforceFormula {
 		exists, visible, visErr := b.checkConceptDescriptionVisibilityInTx(ctx, tx, cd.ID())
 		if visErr != nil {
-			return visErr
+			return false, visErr
 		}
 		if !exists {
-			return common.NewInternalServerError("CDREPO-PUTCD-ABACCHECKMISSING written concept description not found before commit")
+			return false, common.NewInternalServerError("CDREPO-PUTCD-ABACCHECKMISSING written concept description not found before commit")
 		}
 		if !visible {
-			return common.NewErrDenied("CDREPO-PUTCD-ABACDENIED written concept description is not accessible under ABAC constraints")
+			return false, common.NewErrDenied("CDREPO-PUTCD-ABACDENIED written concept description is not accessible under ABAC constraints")
 		}
 	}
 
 	if err = tx.Commit(); err != nil {
-		return common.NewInternalServerError("CDREPO-PUTCD-COMMIT " + err.Error())
+		return false, common.NewInternalServerError("CDREPO-PUTCD-COMMIT " + err.Error())
 	}
 
-	return nil
+	return !existingExists, nil
 }
 
 // DeleteConceptDescription removes a concept description by its identifier.
@@ -544,8 +550,12 @@ func (b *ConceptDescriptionBackend) DeleteConceptDescription(ctx context.Context
 		}
 	}
 
-	if err = b.deleteConceptDescriptionInTx(ctx, tx, id); err != nil {
+	deleted, err := b.deleteConceptDescriptionInTx(ctx, tx, id)
+	if err != nil {
 		return err
+	}
+	if !deleted {
+		return common.NewErrNotFound("CDREPO-DELCD-NOTFOUND Concept description with the given ID does not exist")
 	}
 
 	if err = tx.Commit(); err != nil {


### PR DESCRIPTION
This pull request updates the API and persistence logic for handling Concept Descriptions, improving the accuracy of HTTP responses for create, update, and delete operations. It also enhances integration tests to cover new and edge-case behaviors, ensuring better compliance with RESTful standards.

### API and Persistence Logic Improvements

* The `PutConceptDescription` method now returns a boolean indicating whether the operation created a new resource or updated an existing one, and the API responds with `201 Created` for creation and `204 No Content` for updates. This aligns the API with RESTful conventions. [[1]](diffhunk://#diff-ec9f6080568b1fa012d923f5912b271caf9041cb9925e59e7a1686023937e422L189-R189) [[2]](diffhunk://#diff-ec9f6080568b1fa012d923f5912b271caf9041cb9925e59e7a1686023937e422R201-R209) [[3]](diffhunk://#diff-66382ae1b2b63516b2ce26e50379fbd0119e431a41da5a026bdfe005371fcf9fL466-R528)
* The `DeleteConceptDescription` logic now checks if a resource was actually deleted and returns a `404 Not Found` error if the resource does not exist, improving error handling for deletion. [[1]](diffhunk://#diff-66382ae1b2b63516b2ce26e50379fbd0119e431a41da5a026bdfe005371fcf9fL547-R559) [[2]](diffhunk://#diff-ec9f6080568b1fa012d923f5912b271caf9041cb9925e59e7a1686023937e422R225-R226) [[3]](diffhunk://#diff-66382ae1b2b63516b2ce26e50379fbd0119e431a41da5a026bdfe005371fcf9fL148-R164)

### Integration Test Enhancements

* Integration tests have been updated and expanded:
  - PUT update tests now expect `204 No Content` when updating an existing resource.
  - Added tests for deletion of non-existent resources, expecting `404 Not Found`.
  - Added tests for creating a new Concept Description via PUT (`201 Created`), retrieving it, and then deleting it (`204 No Content`). [[1]](diffhunk://#diff-b63cbf1c6790d20193d3fb96d54e954605d89385276870b615f85ed668c9814aR128-R147) [[2]](diffhunk://#diff-52723e68d192eb2f85f0ed1dbdf5f857a8717d770604dd4512bc00fb9392b64eR1-R5)