### PR TITLE
Adds PUT, GET and DELETE for Submodel superpathes

### DIFF
--- a/cmd/aasenvironmentservice/main.go
+++ b/cmd/aasenvironmentservice/main.go
@@ -135,7 +135,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 		persistence,
 	)
 	customAASRepository := aasenvironment.NewCustomAASRepositoryService(
-		aasrepositoryapi.NewAssetAdministrationShellRepositoryAPIAPIService(*aasRepositoryPersistence, submodelRepositoryPersistence),
+		aasrepositoryapi.NewAssetAdministrationShellRepositoryAPIAPIService(aasRepositoryPersistence, submodelRepositoryPersistence),
 		persistence,
 	)
 	customSMRepository := aasenvironment.NewCustomSubmodelRepositoryService(

--- a/cmd/aasenvironmentservice/main.go
+++ b/cmd/aasenvironmentservice/main.go
@@ -135,7 +135,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 		persistence,
 	)
 	customAASRepository := aasenvironment.NewCustomAASRepositoryService(
-		aasrepositoryapi.NewAssetAdministrationShellRepositoryAPIAPIService(*aasRepositoryPersistence),
+		aasrepositoryapi.NewAssetAdministrationShellRepositoryAPIAPIService(*aasRepositoryPersistence, submodelRepositoryPersistence),
 		persistence,
 	)
 	customSMRepository := aasenvironment.NewCustomSubmodelRepositoryService(

--- a/cmd/aasrepositoryservice/main.go
+++ b/cmd/aasrepositoryservice/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -53,28 +54,28 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 	log.Printf("🗄️  Connecting to Postgres with DSN: postgres://%s:****@%s:%d/%s?sslmode=disable",
 		cfg.Postgres.User, cfg.Postgres.Host, cfg.Postgres.Port, cfg.Postgres.DBName)
 
-	aasDatabase, err := persistencepostgresql.NewAssetAdministrationShellDatabase(
-		dsn,
-		cfg.Postgres.MaxOpenConnections,
-		cfg.Postgres.MaxIdleConnections,
-		cfg.Postgres.ConnMaxLifetimeMinutes,
-		databaseSchema,
-		cfg.Server.StrictVerification,
-	)
+	sharedDB, err := common.InitializeDatabase(dsn, databaseSchema)
 	if err != nil {
 		log.Printf("❌ DB connect failed: %v", err)
 		return err
 	}
+	if cfg.Postgres.MaxOpenConnections > 0 {
+		sharedDB.SetMaxOpenConns(cfg.Postgres.MaxOpenConnections)
+	}
+	if cfg.Postgres.MaxIdleConnections > 0 {
+		sharedDB.SetMaxIdleConns(cfg.Postgres.MaxIdleConnections)
+	}
+	if cfg.Postgres.ConnMaxLifetimeMinutes > 0 {
+		sharedDB.SetConnMaxLifetime(time.Duration(cfg.Postgres.ConnMaxLifetimeMinutes) * time.Minute)
+	}
 
-	submodelDatabase, err := submodelrepositorydb.NewSubmodelDatabase(
-		dsn,
-		cfg.Postgres.MaxOpenConnections,
-		cfg.Postgres.MaxIdleConnections,
-		cfg.Postgres.ConnMaxLifetimeMinutes,
-		databaseSchema,
-		nil,
-		cfg.Server.StrictVerification,
-	)
+	aasDatabase, err := persistencepostgresql.NewAssetAdministrationShellDatabaseFromDB(sharedDB, cfg.Server.StrictVerification)
+	if err != nil {
+		log.Printf("❌ AAS DB init failed: %v", err)
+		return err
+	}
+
+	submodelDatabase, err := submodelrepositorydb.NewSubmodelDatabaseFromDB(sharedDB, nil, cfg.Server.StrictVerification)
 	if err != nil {
 		log.Printf("❌ Submodel DB connect failed: %v", err)
 		return err

--- a/cmd/aasrepositoryservice/main.go
+++ b/cmd/aasrepositoryservice/main.go
@@ -81,7 +81,7 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 	}
 	log.Println("✅ Postgres connection established")
 
-	aasSvc := api.NewAssetAdministrationShellRepositoryAPIAPIService(*aasDatabase, submodelDatabase)
+	aasSvc := api.NewAssetAdministrationShellRepositoryAPIAPIService(aasDatabase, submodelDatabase)
 	aasCtrl := openapi.NewAssetAdministrationShellRepositoryAPIAPIController(aasSvc, "", cfg.Server.StrictVerification)
 
 	descSvc := openapi.NewDescriptionAPIAPIService()

--- a/cmd/aasrepositoryservice/main.go
+++ b/cmd/aasrepositoryservice/main.go
@@ -16,6 +16,7 @@ import (
 	persistencepostgresql "github.com/eclipse-basyx/basyx-go-components/internal/aasrepository/persistence"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+	submodelrepositorydb "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence"
 	openapi "github.com/eclipse-basyx/basyx-go-components/pkg/aasrepositoryapi/go"
 )
 
@@ -64,9 +65,23 @@ func runServer(ctx context.Context, configPath string, databaseSchema string) er
 		log.Printf("❌ DB connect failed: %v", err)
 		return err
 	}
+
+	submodelDatabase, err := submodelrepositorydb.NewSubmodelDatabase(
+		dsn,
+		cfg.Postgres.MaxOpenConnections,
+		cfg.Postgres.MaxIdleConnections,
+		cfg.Postgres.ConnMaxLifetimeMinutes,
+		databaseSchema,
+		nil,
+		cfg.Server.StrictVerification,
+	)
+	if err != nil {
+		log.Printf("❌ Submodel DB connect failed: %v", err)
+		return err
+	}
 	log.Println("✅ Postgres connection established")
 
-	aasSvc := api.NewAssetAdministrationShellRepositoryAPIAPIService(*aasDatabase)
+	aasSvc := api.NewAssetAdministrationShellRepositoryAPIAPIService(*aasDatabase, submodelDatabase)
 	aasCtrl := openapi.NewAssetAdministrationShellRepositoryAPIAPIController(aasSvc, "", cfg.Server.StrictVerification)
 
 	descSvc := openapi.NewDescriptionAPIAPIService()

--- a/internal/aasrepository/api/api_asset_administration_shell_repository_api_service.go
+++ b/internal/aasrepository/api/api_asset_administration_shell_repository_api_service.go
@@ -14,6 +14,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"net/http"
 	"os"
@@ -32,14 +33,25 @@ import (
 // Include any external packages or services that will be required by this service.
 type AssetAdministrationShellRepositoryAPIAPIService struct {
 	assetAdministrationShellBackend persistencepostgresql.AssetAdministrationShellDatabase
+	submodelBackend                 submodelBackend
 }
 
 const componentName = "AASREPO"
 
+type submodelBackend interface {
+	GetSubmodelByID(ctx context.Context, submodelIdentifier string, level string, metadataOnly bool) (types.ISubmodel, error)
+	PutSubmodel(ctx context.Context, submodelIdentifier string, submodel types.ISubmodel) (bool, error)
+	DeleteSubmodel(ctx context.Context, submodelID string) error
+}
+
 // NewAssetAdministrationShellRepositoryAPIAPIService creates a default api service
-func NewAssetAdministrationShellRepositoryAPIAPIService(databaseBackendAssetAdministrationShell persistencepostgresql.AssetAdministrationShellDatabase) *AssetAdministrationShellRepositoryAPIAPIService {
+func NewAssetAdministrationShellRepositoryAPIAPIService(
+	databaseBackendAssetAdministrationShell persistencepostgresql.AssetAdministrationShellDatabase,
+	submodelBackend submodelBackend,
+) *AssetAdministrationShellRepositoryAPIAPIService {
 	return &AssetAdministrationShellRepositoryAPIAPIService{
 		assetAdministrationShellBackend: databaseBackendAssetAdministrationShell,
+		submodelBackend:                 submodelBackend,
 	}
 }
 
@@ -495,17 +507,268 @@ func (s *AssetAdministrationShellRepositoryAPIAPIService) DeleteSubmodelReferenc
 
 // GetSubmodelByIdAasRepository - Returns the Submodel
 func (s *AssetAdministrationShellRepositoryAPIAPIService) GetSubmodelByIdAasRepository(ctx context.Context, aasIdentifier string, submodelIdentifier string, level string, extent string) (gen.ImplResponse, error) {
-	return gen.Response(http.StatusNotImplemented, nil), errors.New("GetSubmodelByIdAasRepository method not implemented")
+	_ = extent
+	const operation = "GetSubmodelByIdAasRepository"
+
+	if s.submodelBackend == nil {
+		err := common.NewInternalServerError("AASREPO-GETSMBYID-NOSMBACKEND submodel backend is not configured")
+		return newAPIErrorResponse(err, http.StatusInternalServerError, operation, "InternalServerError"), err
+	}
+
+	decodedAASIdentifier, decodeAASErr := common.DecodeString(aasIdentifier)
+	if decodeAASErr != nil {
+		return newAPIErrorResponse(decodeAASErr, http.StatusBadRequest, operation, "MalformedAssetAdministrationShellIdentifier"), nil
+	}
+
+	decodedSubmodelIdentifier, decodeSubmodelErr := common.DecodeString(submodelIdentifier)
+	if decodeSubmodelErr != nil {
+		return newAPIErrorResponse(decodeSubmodelErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
+	}
+
+	if !isLevelValid(level) {
+		return newAPIErrorResponse(errors.New("invalid level parameter"), http.StatusBadRequest, operation, "InvalidLevelParameter"), nil
+	}
+
+	_, aasLookupErr := s.assetAdministrationShellBackend.GetAssetAdministrationShellByID(ctx, decodedAASIdentifier)
+	if aasLookupErr != nil {
+		if common.IsErrDenied(aasLookupErr) {
+			return newAPIErrorResponse(aasLookupErr, http.StatusForbidden, operation, "Forbidden"), nil
+		}
+		if common.IsErrNotFound(aasLookupErr) {
+			return newAPIErrorResponse(aasLookupErr, http.StatusNotFound, operation, "AssetAdministrationShellNotFound"), nil
+		}
+		if common.IsErrBadRequest(aasLookupErr) {
+			return newAPIErrorResponse(aasLookupErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(aasLookupErr, http.StatusInternalServerError, operation, "GetAssetAdministrationShellByID"), aasLookupErr
+	}
+
+	referenceCheckErr := s.assetAdministrationShellBackend.CheckIfSubmodelReferenceExistsInAssetAdministrationShell(decodedAASIdentifier, decodedSubmodelIdentifier)
+	if referenceCheckErr != nil {
+		if common.IsErrNotFound(referenceCheckErr) {
+			return newAPIErrorResponse(referenceCheckErr, http.StatusNotFound, operation, "SubmodelNotFound"), nil
+		}
+		if common.IsErrBadRequest(referenceCheckErr) {
+			return newAPIErrorResponse(referenceCheckErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(referenceCheckErr, http.StatusInternalServerError, operation, "CheckIfSubmodelReferenceExistsInAssetAdministrationShell"), referenceCheckErr
+	}
+
+	sm, getErr := s.submodelBackend.GetSubmodelByID(ctx, decodedSubmodelIdentifier, level, false)
+	if getErr != nil {
+		if common.IsErrDenied(getErr) {
+			return newAPIErrorResponse(getErr, http.StatusForbidden, operation, "Forbidden"), nil
+		}
+		if common.IsErrNotFound(getErr) || errors.Is(getErr, sql.ErrNoRows) {
+			return newAPIErrorResponse(getErr, http.StatusNotFound, operation, "SubmodelNotFound"), nil
+		}
+		if common.IsErrBadRequest(getErr) {
+			return newAPIErrorResponse(getErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(getErr, http.StatusInternalServerError, operation, "GetSubmodelByID"), getErr
+	}
+
+	jsonSubmodel, jsonErr := jsonization.ToJsonable(sm)
+	if jsonErr != nil {
+		return newAPIErrorResponse(jsonErr, http.StatusInternalServerError, operation, "ToJsonable"), jsonErr
+	}
+	deleteSubmodelElementsIfEmpty(jsonSubmodel)
+
+	return gen.Response(http.StatusOK, jsonSubmodel), nil
 }
 
 // PutSubmodelByIdAasRepository - Creates or updates the Submodel
 func (s *AssetAdministrationShellRepositoryAPIAPIService) PutSubmodelByIdAasRepository(ctx context.Context, aasIdentifier string, submodelIdentifier string, submodel types.ISubmodel) (gen.ImplResponse, error) {
-	return gen.Response(http.StatusNotImplemented, nil), errors.New("PutSubmodelByIdAasRepository method not implemented")
+	const operation = "PutSubmodelByIdAasRepository"
+
+	if s.submodelBackend == nil {
+		err := common.NewInternalServerError("AASREPO-PUTSMBYID-NOSMBACKEND submodel backend is not configured")
+		return newAPIErrorResponse(err, http.StatusInternalServerError, operation, "InternalServerError"), err
+	}
+
+	decodedAASIdentifier, decodeAASErr := common.DecodeString(aasIdentifier)
+	if decodeAASErr != nil {
+		return newAPIErrorResponse(decodeAASErr, http.StatusBadRequest, operation, "MalformedAssetAdministrationShellIdentifier"), nil
+	}
+
+	decodedSubmodelIdentifier, decodeSubmodelErr := common.DecodeString(submodelIdentifier)
+	if decodeSubmodelErr != nil {
+		return newAPIErrorResponse(decodeSubmodelErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
+	}
+
+	if decodedSubmodelIdentifier != submodel.ID() {
+		return newAPIErrorResponse(errors.New("submodel ID in path and body do not match"), http.StatusBadRequest, operation, "IdMismatch"), nil
+	}
+
+	_, aasLookupErr := s.assetAdministrationShellBackend.GetAssetAdministrationShellByID(ctx, decodedAASIdentifier)
+	if aasLookupErr != nil {
+		if common.IsErrDenied(aasLookupErr) {
+			return newAPIErrorResponse(aasLookupErr, http.StatusForbidden, operation, "Forbidden"), nil
+		}
+		if common.IsErrNotFound(aasLookupErr) {
+			return newAPIErrorResponse(aasLookupErr, http.StatusNotFound, operation, "AssetAdministrationShellNotFound"), nil
+		}
+		if common.IsErrBadRequest(aasLookupErr) {
+			return newAPIErrorResponse(aasLookupErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(aasLookupErr, http.StatusInternalServerError, operation, "GetAssetAdministrationShellByID"), aasLookupErr
+	}
+
+	isUpdate, putErr := s.submodelBackend.PutSubmodel(ctx, decodedSubmodelIdentifier, submodel)
+	if putErr != nil {
+		if common.IsErrDenied(putErr) {
+			return newAPIErrorResponse(putErr, http.StatusForbidden, operation, "Forbidden"), nil
+		}
+		if common.IsErrBadRequest(putErr) {
+			return newAPIErrorResponse(putErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		if common.IsErrConflict(putErr) {
+			return newAPIErrorResponse(putErr, http.StatusConflict, operation, "Conflict"), nil
+		}
+		if common.IsErrNotFound(putErr) {
+			return newAPIErrorResponse(putErr, http.StatusNotFound, operation, "SubmodelNotFound"), nil
+		}
+		return newAPIErrorResponse(putErr, http.StatusInternalServerError, operation, "PutSubmodel"), putErr
+	}
+
+	submodelReference := types.NewReference(
+		types.ReferenceTypesModelReference,
+		[]types.IKey{types.NewKey(types.KeyTypesSubmodel, decodedSubmodelIdentifier)},
+	)
+
+	createReferenceErr := s.assetAdministrationShellBackend.CreateSubmodelReferenceInAssetAdministrationShell(ctx, decodedAASIdentifier, submodelReference)
+	if createReferenceErr != nil && !common.IsErrConflict(createReferenceErr) {
+		if common.IsErrDenied(createReferenceErr) {
+			return newAPIErrorResponse(createReferenceErr, http.StatusForbidden, operation, "Forbidden"), nil
+		}
+		if common.IsErrNotFound(createReferenceErr) {
+			return newAPIErrorResponse(createReferenceErr, http.StatusNotFound, operation, "AssetAdministrationShellNotFound"), nil
+		}
+		if common.IsErrBadRequest(createReferenceErr) {
+			return newAPIErrorResponse(createReferenceErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(createReferenceErr, http.StatusInternalServerError, operation, "CreateSubmodelReferenceInAssetAdministrationShell"), createReferenceErr
+	}
+
+	if isUpdate {
+		return gen.Response(http.StatusNoContent, nil), nil
+	}
+
+	submodelJSON, jsonErr := jsonization.ToJsonable(submodel)
+	if jsonErr != nil {
+		return newAPIErrorResponse(jsonErr, http.StatusBadRequest, operation, "InvalidSubmodelData"), nil
+	}
+
+	return gen.Response(http.StatusCreated, submodelJSON), nil
 }
 
 // DeleteSubmodelByIdAasRepository - Deletes the submodel from the Asset Administration Shell and the Repository.
 func (s *AssetAdministrationShellRepositoryAPIAPIService) DeleteSubmodelByIdAasRepository(ctx context.Context, aasIdentifier string, submodelIdentifier string) (gen.ImplResponse, error) {
-	return gen.Response(http.StatusNotImplemented, nil), errors.New("DeleteSubmodelByIdAasRepository method not implemented")
+	const operation = "DeleteSubmodelByIdAasRepository"
+
+	if s.submodelBackend == nil {
+		err := common.NewInternalServerError("AASREPO-DELSMBYID-NOSMBACKEND submodel backend is not configured")
+		return newAPIErrorResponse(err, http.StatusInternalServerError, operation, "InternalServerError"), err
+	}
+
+	decodedAASIdentifier, decodeAASErr := common.DecodeString(aasIdentifier)
+	if decodeAASErr != nil {
+		return newAPIErrorResponse(decodeAASErr, http.StatusBadRequest, operation, "MalformedAssetAdministrationShellIdentifier"), nil
+	}
+
+	decodedSubmodelIdentifier, decodeSubmodelErr := common.DecodeString(submodelIdentifier)
+	if decodeSubmodelErr != nil {
+		return newAPIErrorResponse(decodeSubmodelErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
+	}
+
+	_, aasLookupErr := s.assetAdministrationShellBackend.GetAssetAdministrationShellByID(ctx, decodedAASIdentifier)
+	if aasLookupErr != nil {
+		if common.IsErrDenied(aasLookupErr) {
+			return newAPIErrorResponse(aasLookupErr, http.StatusForbidden, operation, "Forbidden"), nil
+		}
+		if common.IsErrNotFound(aasLookupErr) {
+			return newAPIErrorResponse(aasLookupErr, http.StatusNotFound, operation, "AssetAdministrationShellNotFound"), nil
+		}
+		if common.IsErrBadRequest(aasLookupErr) {
+			return newAPIErrorResponse(aasLookupErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(aasLookupErr, http.StatusInternalServerError, operation, "GetAssetAdministrationShellByID"), aasLookupErr
+	}
+
+	referenceCheckErr := s.assetAdministrationShellBackend.CheckIfSubmodelReferenceExistsInAssetAdministrationShell(decodedAASIdentifier, decodedSubmodelIdentifier)
+	if referenceCheckErr != nil {
+		if common.IsErrNotFound(referenceCheckErr) {
+			return newAPIErrorResponse(referenceCheckErr, http.StatusNotFound, operation, "SubmodelNotFound"), nil
+		}
+		if common.IsErrBadRequest(referenceCheckErr) {
+			return newAPIErrorResponse(referenceCheckErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(referenceCheckErr, http.StatusInternalServerError, operation, "CheckIfSubmodelReferenceExistsInAssetAdministrationShell"), referenceCheckErr
+	}
+
+	_, getErr := s.submodelBackend.GetSubmodelByID(ctx, decodedSubmodelIdentifier, "core", false)
+	if getErr != nil {
+		if common.IsErrDenied(getErr) {
+			return newAPIErrorResponse(getErr, http.StatusForbidden, operation, "Forbidden"), nil
+		}
+		if common.IsErrNotFound(getErr) || errors.Is(getErr, sql.ErrNoRows) {
+			return newAPIErrorResponse(getErr, http.StatusNotFound, operation, "SubmodelNotFound"), nil
+		}
+		if common.IsErrBadRequest(getErr) {
+			return newAPIErrorResponse(getErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(getErr, http.StatusInternalServerError, operation, "GetSubmodelByID"), getErr
+	}
+
+	deleteReferenceErr := s.assetAdministrationShellBackend.DeleteSubmodelReferenceInAssetAdministrationShell(ctx, decodedAASIdentifier, decodedSubmodelIdentifier)
+	if deleteReferenceErr != nil {
+		if common.IsErrDenied(deleteReferenceErr) {
+			return newAPIErrorResponse(deleteReferenceErr, http.StatusForbidden, operation, "Forbidden"), nil
+		}
+		if common.IsErrNotFound(deleteReferenceErr) {
+			return newAPIErrorResponse(deleteReferenceErr, http.StatusNotFound, operation, "SubmodelNotFound"), nil
+		}
+		if common.IsErrBadRequest(deleteReferenceErr) {
+			return newAPIErrorResponse(deleteReferenceErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(deleteReferenceErr, http.StatusInternalServerError, operation, "DeleteSubmodelReferenceInAssetAdministrationShell"), deleteReferenceErr
+	}
+
+	deleteSubmodelErr := s.submodelBackend.DeleteSubmodel(ctx, decodedSubmodelIdentifier)
+	if deleteSubmodelErr != nil {
+		if common.IsErrDenied(deleteSubmodelErr) {
+			return newAPIErrorResponse(deleteSubmodelErr, http.StatusForbidden, operation, "Forbidden"), nil
+		}
+		if common.IsErrNotFound(deleteSubmodelErr) || errors.Is(deleteSubmodelErr, sql.ErrNoRows) {
+			return newAPIErrorResponse(deleteSubmodelErr, http.StatusNotFound, operation, "SubmodelNotFound"), nil
+		}
+		if common.IsErrBadRequest(deleteSubmodelErr) {
+			return newAPIErrorResponse(deleteSubmodelErr, http.StatusBadRequest, operation, "BadRequest"), nil
+		}
+		return newAPIErrorResponse(deleteSubmodelErr, http.StatusInternalServerError, operation, "DeleteSubmodel"), nil
+	}
+
+	return gen.Response(http.StatusNoContent, nil), nil
+}
+
+func isLevelValid(level string) bool {
+	return level == "" || level == "core" || level == "deep"
+}
+
+func deleteSubmodelElementsIfEmpty(jsonSubmodel map[string]any) {
+	if jsonSubmodel == nil {
+		return
+	}
+
+	elements, exists := jsonSubmodel["submodelElements"]
+	if !exists {
+		return
+	}
+
+	elementArray, ok := elements.([]any)
+	if ok && len(elementArray) == 0 {
+		delete(jsonSubmodel, "submodelElements")
+	}
 }
 
 // PatchSubmodelAasRepository - Updates the Submodel

--- a/internal/aasrepository/api/api_asset_administration_shell_repository_api_service.go
+++ b/internal/aasrepository/api/api_asset_administration_shell_repository_api_service.go
@@ -633,6 +633,13 @@ func (s *AssetAdministrationShellRepositoryAPIAPIService) PutSubmodelByIdAasRepo
 
 	createReferenceErr := s.assetAdministrationShellBackend.CreateSubmodelReferenceInAssetAdministrationShell(ctx, decodedAASIdentifier, submodelReference)
 	if createReferenceErr != nil && !common.IsErrConflict(createReferenceErr) {
+		if !isUpdate {
+			rollbackErr := s.submodelBackend.DeleteSubmodel(ctx, decodedSubmodelIdentifier)
+			if rollbackErr != nil {
+				createReferenceErr = common.NewInternalServerError("AASREPO-PUTSMBYID-ROLLBACKFAILED reference creation failed and rollback failed: refErr=" + createReferenceErr.Error() + " rollbackErr=" + rollbackErr.Error())
+			}
+		}
+
 		if common.IsErrDenied(createReferenceErr) {
 			return newAPIErrorResponse(createReferenceErr, http.StatusForbidden, operation, "Forbidden"), nil
 		}
@@ -731,6 +738,14 @@ func (s *AssetAdministrationShellRepositoryAPIAPIService) DeleteSubmodelByIdAasR
 
 	deleteSubmodelErr := s.submodelBackend.DeleteSubmodel(ctx, decodedSubmodelIdentifier)
 	if deleteSubmodelErr != nil {
+		restoreReferenceErr := s.assetAdministrationShellBackend.CreateSubmodelReferenceInAssetAdministrationShell(ctx, decodedAASIdentifier, types.NewReference(
+			types.ReferenceTypesModelReference,
+			[]types.IKey{types.NewKey(types.KeyTypesSubmodel, decodedSubmodelIdentifier)},
+		))
+		if restoreReferenceErr != nil && !common.IsErrConflict(restoreReferenceErr) {
+			deleteSubmodelErr = common.NewInternalServerError("AASREPO-DELSMBYID-RESTOREREF failed to delete submodel and failed to restore submodel reference: " + restoreReferenceErr.Error())
+		}
+
 		if common.IsErrDenied(deleteSubmodelErr) {
 			return newAPIErrorResponse(deleteSubmodelErr, http.StatusForbidden, operation, "Forbidden"), nil
 		}
@@ -740,7 +755,7 @@ func (s *AssetAdministrationShellRepositoryAPIAPIService) DeleteSubmodelByIdAasR
 		if common.IsErrBadRequest(deleteSubmodelErr) {
 			return newAPIErrorResponse(deleteSubmodelErr, http.StatusBadRequest, operation, "BadRequest"), nil
 		}
-		return newAPIErrorResponse(deleteSubmodelErr, http.StatusInternalServerError, operation, "DeleteSubmodel"), nil
+		return newAPIErrorResponse(deleteSubmodelErr, http.StatusInternalServerError, operation, "DeleteSubmodel"), deleteSubmodelErr
 	}
 
 	return gen.Response(http.StatusNoContent, nil), nil

--- a/internal/aasrepository/api/api_asset_administration_shell_repository_api_service.go
+++ b/internal/aasrepository/api/api_asset_administration_shell_repository_api_service.go
@@ -25,6 +25,7 @@ import (
 	persistencepostgresql "github.com/eclipse-basyx/basyx-go-components/internal/aasrepository/persistence"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	gen "github.com/eclipse-basyx/basyx-go-components/internal/common/model"
+	submodelpersistence "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence"
 	openapi "github.com/eclipse-basyx/basyx-go-components/pkg/aasrepositoryapi/go"
 )
 
@@ -32,22 +33,16 @@ import (
 // This service should implement the business logic for every endpoint for the AssetAdministrationShellRepositoryAPIAPI API.
 // Include any external packages or services that will be required by this service.
 type AssetAdministrationShellRepositoryAPIAPIService struct {
-	assetAdministrationShellBackend persistencepostgresql.AssetAdministrationShellDatabase
-	submodelBackend                 submodelBackend
+	assetAdministrationShellBackend *persistencepostgresql.AssetAdministrationShellDatabase
+	submodelBackend                 *submodelpersistence.SubmodelDatabase
 }
 
 const componentName = "AASREPO"
 
-type submodelBackend interface {
-	GetSubmodelByID(ctx context.Context, submodelIdentifier string, level string, metadataOnly bool) (types.ISubmodel, error)
-	PutSubmodel(ctx context.Context, submodelIdentifier string, submodel types.ISubmodel) (bool, error)
-	DeleteSubmodel(ctx context.Context, submodelID string) error
-}
-
 // NewAssetAdministrationShellRepositoryAPIAPIService creates a default api service
 func NewAssetAdministrationShellRepositoryAPIAPIService(
-	databaseBackendAssetAdministrationShell persistencepostgresql.AssetAdministrationShellDatabase,
-	submodelBackend submodelBackend,
+	databaseBackendAssetAdministrationShell *persistencepostgresql.AssetAdministrationShellDatabase,
+	submodelBackend *submodelpersistence.SubmodelDatabase,
 ) *AssetAdministrationShellRepositoryAPIAPIService {
 	return &AssetAdministrationShellRepositoryAPIAPIService{
 		assetAdministrationShellBackend: databaseBackendAssetAdministrationShell,

--- a/internal/aasrepository/integration_tests/aasrepository_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_integration_test.go
@@ -433,6 +433,52 @@ func TestPutSubmodelByIdAasRepositoryReturnsCreatedSubmodelAnd201(t *testing.T) 
 	assert.Equal(t, endpoint, headers.Get("Location"), "Expected Location header to point to created submodel resource")
 }
 
+func TestPutSubmodelByIdAasRepositoryReturnsNoContentOnUpdate(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	aasID := fmt.Sprintf("https://example.com/ids/aas/put-submodel-update-%d", time.Now().UnixNano())
+	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+
+	statusCode, err := createAASForThumbnailTest(baseURL, aasID)
+	require.NoError(t, err, "AAS creation failed")
+	require.Equal(t, http.StatusCreated, statusCode, "Expected 201 Created for AAS creation")
+
+	submodelID := fmt.Sprintf("https://example.com/ids/sm/put-submodel-update-%d", time.Now().UnixNano())
+	submodelIdentifier := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
+	endpoint := fmt.Sprintf("%s/shells/%s/submodels/%s", baseURL, aasIdentifier, submodelIdentifier)
+
+	initialBody := fmt.Sprintf(
+		`{"id":"%s","idShort":"PutUpdateSubmodel","modelType":"Submodel","kind":"Instance","submodelElements":[{"idShort":"prop1","modelType":"Property","valueType":"xs:string","value":"before"}]}`,
+		submodelID,
+	)
+
+	_, initialStatusCode, _, initialErr := putJSONResponse(endpoint, initialBody)
+	require.NoError(t, initialErr, "Initial PUT submodel request failed")
+	require.Equal(t, http.StatusCreated, initialStatusCode, "Expected 201 Created for initial PUT")
+
+	updatedBody := fmt.Sprintf(
+		`{"id":"%s","idShort":"PutUpdateSubmodel","modelType":"Submodel","kind":"Instance","submodelElements":[{"idShort":"prop1","modelType":"Property","valueType":"xs:string","value":"after"}]}`,
+		submodelID,
+	)
+
+	updatePayload, updateStatusCode, updateHeaders, updateErr := putJSONResponse(endpoint, updatedBody)
+	require.NoError(t, updateErr, "Update PUT submodel request failed")
+	require.Equal(t, http.StatusNoContent, updateStatusCode, "Expected 204 No Content for update PUT")
+	assert.Nil(t, updatePayload, "Expected empty response body for update PUT")
+	assert.Empty(t, updateHeaders.Get("Location"), "Expected no Location header for update PUT")
+
+	getPayload, getStatusCode, getErr := getJSONResponse(endpoint)
+	require.NoError(t, getErr, "GET submodel after update failed")
+	require.Equal(t, http.StatusOK, getStatusCode, "Expected 200 OK for GET after update PUT")
+
+	submodelElements, ok := getPayload["submodelElements"].([]any)
+	require.True(t, ok, "Expected submodelElements in GET response")
+	require.NotEmpty(t, submodelElements, "Expected submodelElements to contain updated property")
+
+	firstElement, ok := submodelElements[0].(map[string]any)
+	require.True(t, ok, "Expected first submodel element as object")
+	assert.Equal(t, "after", firstElement["value"], "Expected updated property value to be persisted")
+}
+
 func TestGetSubmodelByIdAasRepositoryReturnsSubmodel(t *testing.T) {
 	baseURL := "http://localhost:6004"
 	aasID := fmt.Sprintf("https://example.com/ids/aas/get-submodel-%d", time.Now().UnixNano())

--- a/internal/aasrepository/integration_tests/aasrepository_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_integration_test.go
@@ -237,6 +237,69 @@ func getJSONResponse(endpoint string) (map[string]any, int, error) {
 	return payload, resp.StatusCode, nil
 }
 
+func putJSONResponse(endpoint string, body string) (map[string]any, int, http.Header, error) {
+	req, err := http.NewRequest(http.MethodPut, endpoint, strings.NewReader(body))
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	responseBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, resp.StatusCode, resp.Header.Clone(), fmt.Errorf("failed to read response body: %v", readErr)
+	}
+
+	if strings.TrimSpace(string(responseBody)) == "" {
+		return nil, resp.StatusCode, resp.Header.Clone(), nil
+	}
+
+	var payload map[string]any
+	if unmarshalErr := json.Unmarshal(responseBody, &payload); unmarshalErr != nil {
+		return nil, resp.StatusCode, resp.Header.Clone(), fmt.Errorf("failed to unmarshal response body: %v", unmarshalErr)
+	}
+
+	return payload, resp.StatusCode, resp.Header.Clone(), nil
+}
+
+func deleteResponseStatus(endpoint string) (int, error) {
+	req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode, nil
+}
+
+func getResponseStatus(endpoint string) (int, error) {
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode, nil
+}
+
 func getThumbnailWithoutFollowingRedirect(endpoint string) (int, string, error) {
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -340,6 +403,100 @@ func TestIntegration(t *testing.T) {
 			return fmt.Sprintf("Step_(%s)_%d_%s_%s", context, stepNumber, step.Method, step.Endpoint)
 		},
 	})
+}
+
+func TestPutSubmodelByIdAasRepositoryReturnsCreatedSubmodelAnd201(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	aasID := fmt.Sprintf("https://example.com/ids/aas/put-submodel-create-%d", time.Now().UnixNano())
+	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+
+	statusCode, err := createAASForThumbnailTest(baseURL, aasID)
+	require.NoError(t, err, "AAS creation failed")
+	require.Equal(t, http.StatusCreated, statusCode, "Expected 201 Created for AAS creation")
+
+	submodelID := fmt.Sprintf("https://example.com/ids/sm/put-submodel-create-%d", time.Now().UnixNano())
+	submodelIdentifier := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
+	endpoint := fmt.Sprintf("%s/shells/%s/submodels/%s", baseURL, aasIdentifier, submodelIdentifier)
+
+	body := fmt.Sprintf(
+		`{"id":"%s","idShort":"PutCreateSubmodel","modelType":"Submodel","kind":"Instance","submodelElements":[{"idShort":"prop1","modelType":"Property","valueType":"xs:string","value":"hello"}]}`,
+		submodelID,
+	)
+
+	payload, putStatusCode, headers, putErr := putJSONResponse(endpoint, body)
+	require.NoError(t, putErr, "PUT submodel request failed")
+	require.Equal(t, http.StatusCreated, putStatusCode, "Expected 201 Created when creating new submodel via AAS endpoint")
+	require.NotNil(t, payload, "Expected response payload for created submodel")
+	assert.Equal(t, submodelID, payload["id"], "Expected response body to contain created submodel id")
+	assert.Equal(t, "PutCreateSubmodel", payload["idShort"], "Expected response body to contain created submodel idShort")
+	assert.Equal(t, "Submodel", payload["modelType"], "Expected response body to contain created submodel modelType")
+	assert.Equal(t, endpoint, headers.Get("Location"), "Expected Location header to point to created submodel resource")
+}
+
+func TestGetSubmodelByIdAasRepositoryReturnsSubmodel(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	aasID := fmt.Sprintf("https://example.com/ids/aas/get-submodel-%d", time.Now().UnixNano())
+	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+
+	statusCode, err := createAASForThumbnailTest(baseURL, aasID)
+	require.NoError(t, err, "AAS creation failed")
+	require.Equal(t, http.StatusCreated, statusCode, "Expected 201 Created for AAS creation")
+
+	submodelID := fmt.Sprintf("https://example.com/ids/sm/get-submodel-%d", time.Now().UnixNano())
+	submodelIdentifier := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
+	endpoint := fmt.Sprintf("%s/shells/%s/submodels/%s", baseURL, aasIdentifier, submodelIdentifier)
+
+	body := fmt.Sprintf(
+		`{"id":"%s","idShort":"GetSubmodelViaAAS","modelType":"Submodel","kind":"Instance","submodelElements":[{"idShort":"prop1","modelType":"Property","valueType":"xs:string","value":"hello"}]}`,
+		submodelID,
+	)
+	_, putStatusCode, _, putErr := putJSONResponse(endpoint, body)
+	require.NoError(t, putErr, "PUT submodel request failed")
+	require.Equal(t, http.StatusCreated, putStatusCode, "Expected 201 Created when creating submodel via AAS endpoint")
+
+	payload, getStatusCode, getErr := getJSONResponse(endpoint + "?level=core")
+	require.NoError(t, getErr, "GET submodel request failed")
+	require.Equal(t, http.StatusOK, getStatusCode, "Expected 200 OK for GET submodel via AAS endpoint")
+	assert.Equal(t, submodelID, payload["id"], "Expected submodel id in GET response")
+	assert.Equal(t, "GetSubmodelViaAAS", payload["idShort"], "Expected submodel idShort in GET response")
+	assert.Equal(t, "Submodel", payload["modelType"], "Expected submodel modelType in GET response")
+}
+
+func TestDeleteSubmodelByIdAasRepositoryDeletesSubmodelAndReference(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	aasID := fmt.Sprintf("https://example.com/ids/aas/delete-submodel-%d", time.Now().UnixNano())
+	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+
+	statusCode, err := createAASForThumbnailTest(baseURL, aasID)
+	require.NoError(t, err, "AAS creation failed")
+	require.Equal(t, http.StatusCreated, statusCode, "Expected 201 Created for AAS creation")
+
+	submodelID := fmt.Sprintf("https://example.com/ids/sm/delete-submodel-%d", time.Now().UnixNano())
+	submodelIdentifier := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
+	endpoint := fmt.Sprintf("%s/shells/%s/submodels/%s", baseURL, aasIdentifier, submodelIdentifier)
+
+	body := fmt.Sprintf(
+		`{"id":"%s","idShort":"DeleteSubmodelViaAAS","modelType":"Submodel","kind":"Instance","submodelElements":[{"idShort":"prop1","modelType":"Property","valueType":"xs:string","value":"hello"}]}`,
+		submodelID,
+	)
+	_, putStatusCode, _, putErr := putJSONResponse(endpoint, body)
+	require.NoError(t, putErr, "PUT submodel request failed")
+	require.Equal(t, http.StatusCreated, putStatusCode, "Expected 201 Created when creating submodel via AAS endpoint")
+
+	deleteStatusCode, deleteErr := deleteResponseStatus(endpoint)
+	require.NoError(t, deleteErr, "DELETE submodel request failed")
+	require.Equal(t, http.StatusNoContent, deleteStatusCode, "Expected 204 No Content for DELETE submodel via AAS endpoint")
+
+	referencesPayload, referencesStatusCode, referencesErr := getJSONResponse(fmt.Sprintf("%s/shells/%s/submodel-refs", baseURL, aasIdentifier))
+	require.NoError(t, referencesErr, "GET submodel references failed")
+	require.Equal(t, http.StatusOK, referencesStatusCode, "Expected 200 OK for GET submodel references")
+	result, ok := referencesPayload["result"].([]any)
+	require.True(t, ok, "Expected result array in submodel references response")
+	assert.Len(t, result, 0, "Expected no submodel references after deletion")
+
+	getDeletedStatusCode, getDeletedErr := getResponseStatus(endpoint)
+	require.NoError(t, getDeletedErr, "GET deleted submodel request failed")
+	require.Equal(t, http.StatusNotFound, getDeletedStatusCode, "Expected 404 Not Found for deleted submodel")
 }
 
 func TestThumbnailAttachmentOperations(t *testing.T) {

--- a/pkg/aasrepositoryapi/go/api_asset_administration_shell_repository_api.go
+++ b/pkg/aasrepositoryapi/go/api_asset_administration_shell_repository_api.go
@@ -748,16 +748,111 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) DeleteSubmodelRefer
 // GetSubmodelByIdAasRepository - Returns the Submodel
 // nolint:revive
 func (c *AssetAdministrationShellRepositoryAPIAPIController) GetSubmodelByIdAasRepository(w http.ResponseWriter, r *http.Request) {
+	aasIdentifierParam := chi.URLParam(r, "aasIdentifier")
+	if aasIdentifierParam == "" {
+		c.errorHandler(w, r, &RequiredError{"aasIdentifier"}, nil)
+		return
+	}
+
+	submodelIdentifierParam := chi.URLParam(r, "submodelIdentifier")
+	if submodelIdentifierParam == "" {
+		c.errorHandler(w, r, &RequiredError{"submodelIdentifier"}, nil)
+		return
+	}
+
+	query := r.URL.Query()
+	levelParam := query.Get("level")
+	extentParam := query.Get("extent")
+
+	result, err := c.service.GetSubmodelByIdAasRepository(
+		r.Context(),
+		aasIdentifierParam,
+		submodelIdentifierParam,
+		levelParam,
+		extentParam,
+	)
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+
+	_ = EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // PutSubmodelByIdAasRepository - Creates or updates the Submodel
 // nolint:revive
 func (c *AssetAdministrationShellRepositoryAPIAPIController) PutSubmodelByIdAasRepository(w http.ResponseWriter, r *http.Request) {
+	aasIdentifierParam := chi.URLParam(r, "aasIdentifier")
+	if aasIdentifierParam == "" {
+		c.errorHandler(w, r, &RequiredError{"aasIdentifier"}, nil)
+		return
+	}
+
+	submodelIdentifierParam := chi.URLParam(r, "submodelIdentifier")
+	if submodelIdentifierParam == "" {
+		c.errorHandler(w, r, &RequiredError{"submodelIdentifier"}, nil)
+		return
+	}
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	var jsonable interface{}
+	if err := json.Unmarshal(bodyBytes, &jsonable); err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		return
+	}
+
+	result, err := c.service.PutSubmodelByIdAasRepository(
+		r.Context(),
+		aasIdentifierParam,
+		submodelIdentifierParam,
+		submodelParam,
+	)
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+
+	if result.Code == http.StatusCreated {
+		location := c.buildSubmodelLocation(r, aasIdentifierParam, submodelIdentifierParam)
+		if location != "" {
+			w.Header().Set("Location", location)
+		}
+	}
+
+	_ = EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // DeleteSubmodelByIdAasRepository - Deletes the submodel from the Asset Administration Shell and the Repository.
 // nolint:revive
 func (c *AssetAdministrationShellRepositoryAPIAPIController) DeleteSubmodelByIdAasRepository(w http.ResponseWriter, r *http.Request) {
+	aasIdentifierParam := chi.URLParam(r, "aasIdentifier")
+	if aasIdentifierParam == "" {
+		c.errorHandler(w, r, &RequiredError{"aasIdentifier"}, nil)
+		return
+	}
+
+	submodelIdentifierParam := chi.URLParam(r, "submodelIdentifier")
+	if submodelIdentifierParam == "" {
+		c.errorHandler(w, r, &RequiredError{"submodelIdentifier"}, nil)
+		return
+	}
+
+	result, err := c.service.DeleteSubmodelByIdAasRepository(r.Context(), aasIdentifierParam, submodelIdentifierParam)
+	if err != nil {
+		c.errorHandler(w, r, err, &result)
+		return
+	}
+
+	_ = EncodeJSONResponse(result.Body, &result.Code, w)
 }
 
 // PatchSubmodelAasRepository - Updates the Submodel


### PR DESCRIPTION
This pull request introduces integration of Submodel management into the Asset Administration Shell (AAS) Repository service, enabling the AAS repository to directly handle Submodel CRUD operations via its API. The changes also include improved error handling, validation, and new integration test helpers for these endpoints.

Key changes are grouped as follows:

**AAS Repository and Submodel Integration:**

* The `AssetAdministrationShellRepositoryAPIAPIService` now accepts a `submodelBackend` dependency, allowing it to interact with a Submodel database for Submodel-related operations. The constructor and service wiring in both `cmd/aasrepositoryservice/main.go` and `cmd/aasenvironmentservice/main.go` are updated accordingly. [[1]](diffhunk://#diff-2a8654a4d8aaf70e328f028635529ccc7c5398862bc648fc096170e6de1f2d31R19) [[2]](diffhunk://#diff-2a8654a4d8aaf70e328f028635529ccc7c5398862bc648fc096170e6de1f2d31R68-R84) [[3]](diffhunk://#diff-51f1bcc3811289797b18916ce371dcc6c81a4339f3e95b19a845700bde74951aL138-R138) [[4]](diffhunk://#diff-184da0f1aacb26b53893bce34b9f205286a5e154b57bf5ed422e0dfdda125cd0R36-R54)
* A new `submodelBackend` interface is defined in `api_asset_administration_shell_repository_api_service.go` to abstract Submodel operations.

**API Endpoint Implementations:**

* Full implementations for the following endpoints are added: `GetSubmodelByIdAasRepository`, `PutSubmodelByIdAasRepository`, and `DeleteSubmodelByIdAasRepository`. These methods include validation, decoding, permission checks, and error handling, ensuring robust interaction between the AAS and Submodel repositories.

**Validation and Utility Improvements:**

* New helper functions are introduced for validating the `level` parameter and for cleaning up empty `submodelElements` from JSON responses, improving API correctness and output cleanliness.

**Integration Test Utilities:**

* New HTTP helper functions (`putJSONResponse`, `deleteResponseStatus`, `getResponseStatus`) are added to the integration test suite to support testing of the new Submodel endpoints.

These changes collectively enable the AAS repository service to manage Submodels directly, improving cohesion and simplifying client interactions.