### PR TITLE
Fixes conflict handling for POST submodel reference enpoint

### DIFF
--- a/internal/aasrepository/integration_tests/aasrepository_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_integration_test.go
@@ -294,6 +294,23 @@ func putJSONResponse(endpoint string, body string) (map[string]any, int, http.He
 	return payload, resp.StatusCode, resp.Header.Clone(), nil
 }
 
+func postResponseStatus(endpoint string, body string) (int, error) {
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode, nil
+}
+
 func deleteResponseStatus(endpoint string) (int, error) {
 	req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
 	if err != nil {
@@ -614,6 +631,28 @@ func TestGetSubmodelByIdAasRepositoryReturnsSubmodel(t *testing.T) {
 	assert.Equal(t, submodelID, payload["id"], "Expected submodel id in GET response")
 	assert.Equal(t, "GetSubmodelViaAAS", payload["idShort"], "Expected submodel idShort in GET response")
 	assert.Equal(t, "Submodel", payload["modelType"], "Expected submodel modelType in GET response")
+}
+
+func TestPostSubmodelReferenceAasRepositoryReturnsConflictOnDuplicate(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	aasID := fmt.Sprintf("https://example.com/ids/aas/submodel-ref-duplicate-%d", time.Now().UnixNano())
+	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+
+	statusCode, err := createAASForThumbnailTest(baseURL, aasID)
+	require.NoError(t, err, "AAS creation failed")
+	require.Equal(t, http.StatusCreated, statusCode, "Expected 201 Created for AAS creation")
+
+	submodelID := fmt.Sprintf("https://example.com/ids/sm/submodel-ref-duplicate-%d", time.Now().UnixNano())
+	endpoint := fmt.Sprintf("%s/shells/%s/submodel-refs", baseURL, aasIdentifier)
+	requestBody := fmt.Sprintf(`{"type":"ModelReference","keys":[{"type":"Submodel","value":"%s"}]}`, submodelID)
+
+	firstStatusCode, firstErr := postResponseStatus(endpoint, requestBody)
+	require.NoError(t, firstErr, "First POST submodel reference request failed")
+	require.Equal(t, http.StatusCreated, firstStatusCode, "Expected 201 Created for first POST submodel reference")
+
+	secondStatusCode, secondErr := postResponseStatus(endpoint, requestBody)
+	require.NoError(t, secondErr, "Second POST submodel reference request failed")
+	require.Equal(t, http.StatusConflict, secondStatusCode, "Expected 409 Conflict when posting duplicate submodel reference")
 }
 
 func TestSubmodelSuperPathEndpointsAasRepository(t *testing.T) {

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -479,6 +479,20 @@ func (s *AssetAdministrationShellDatabase) createSubmodelReferenceInAssetAdminis
 		return common.NewInternalServerError("AASREPO-CHECKSMREFINAAS-GETAASDBID " + err.Error())
 	}
 
+	keys := submodelRef.Keys()
+	if len(keys) > 0 {
+		submodelIdentifier := keys[0].Value()
+		if submodelIdentifier != "" {
+			checkErr := s.checkIfSubmodelReferenceExistsInAssetAdministrationShellInTransaction(tx, aasIdentifier, submodelIdentifier)
+			if checkErr == nil {
+				return common.NewErrConflict("AASREPO-NEWSMREFINAAS-CONFLICT Submodel reference to Submodel with ID '" + submodelIdentifier + "' already exists in Asset Administration Shell with ID '" + aasIdentifier + "'")
+			}
+			if !common.IsErrNotFound(checkErr) {
+				return checkErr
+			}
+		}
+	}
+
 	dialect := goqu.Dialect("postgres")
 
 	nextPosition, nextPositionErr := s.getNextSubmodelReferencePositionInTransaction(tx, aasDBID)


### PR DESCRIPTION
This pull request adds a new integration test to verify that posting a duplicate submodel reference returns a conflict, and updates the database logic to enforce this constraint. It also introduces a helper function to simplify POST request handling in tests.

**Testing improvements:**

* Added a new test `TestPostSubmodelReferenceAasRepositoryReturnsConflictOnDuplicate` to ensure that attempting to add the same submodel reference twice returns a 409 Conflict status, verifying correct API behavior for duplicate submodel references.
* Introduced the `postResponseStatus` helper function to streamline sending POST requests and checking status codes in integration tests.

**Database logic enhancement:**

* Updated `createSubmodelReferenceInAssetAdministrationShellInTransaction` to check for existing submodel references before insertion, returning a conflict error if a duplicate is found. This enforces uniqueness at the database operation level.