### PR TITLE
improves logging for preconfiguration and AAS uploads

### DIFF
--- a/internal/aasenvironment/preconfiguration.go
+++ b/internal/aasenvironment/preconfiguration.go
@@ -95,6 +95,13 @@ func RunAASPreconfiguration(ctx context.Context, uploadService UploadService, co
 			}
 		}
 
+		log.Printf(
+			"%s-%s-IMPORTSTART importing preconfiguration file '%s'",
+			preconfigurationComponent,
+			preconfigurationOperation,
+			sanitizeLogValue(filePath),
+		)
+
 		if err := importPreconfigurationFile(ctx, uploadService, filePath, &summary); err != nil {
 			log.Printf("%s-%s-IMPORTFILE failed to import '%s': %v", preconfigurationComponent, preconfigurationOperation, sanitizeLogValue(filePath), err)
 		}

--- a/internal/aasenvironment/upload_api_service.go
+++ b/internal/aasenvironment/upload_api_service.go
@@ -210,8 +210,8 @@ func (s *uploadAPIService) handleXMLUpload(ctx context.Context, fileName string,
 	}), nil
 }
 
-func (s *uploadAPIService) processAASXPackage(ctx context.Context, _ string, _ string, packageReader *aasx.PackageRead) error {
-	specPart, environment, err := readEnvironmentFromAASXSpec(packageReader)
+func (s *uploadAPIService) processAASXPackage(ctx context.Context, fileName string, _ string, packageReader *aasx.PackageRead) error {
+	specPart, environment, err := readEnvironmentFromAASXSpec(packageReader, fileName)
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func (s *uploadAPIService) processEnvironment(ctx context.Context, _ string, _ s
 	return nil
 }
 
-func readEnvironmentFromAASXSpec(packageReader *aasx.PackageRead) (*aasx.Part, aastypes.IEnvironment, error) {
+func readEnvironmentFromAASXSpec(packageReader *aasx.PackageRead, uploadSource string) (*aasx.Part, aastypes.IEnvironment, error) {
 	if packageReader == nil {
 		return nil, nil, common.NewErrBadRequest("AASENV-PARSEAASX-NILREADER package reader is required")
 	}
@@ -329,7 +329,7 @@ func readEnvironmentFromAASXSpec(packageReader *aasx.PackageRead) (*aasx.Part, a
 		return specPart, environment, nil
 	}
 
-	instance, err := parseAASXMLInstance(specContent)
+	instance, err := parseAASXMLInstance(specContent, buildAASXSpecSourceLabel(uploadSource, specPart))
 	if err != nil {
 		return nil, nil, common.NewErrBadRequest(
 			fmt.Sprintf("AASENV-PARSEAASX-UNMARSHALXML failed to parse XML spec: %v", err),
@@ -374,7 +374,7 @@ func parseAASJSONEnvironment(specContent []byte) (aastypes.IEnvironment, error) 
 	return environment, nil
 }
 
-func parseAASXMLInstance(specContent []byte) (aastypes.IClass, error) {
+func parseAASXMLInstance(specContent []byte, sourceLabel string) (aastypes.IClass, error) {
 	instance, err := aasxmlization.Unmarshal(xml.NewDecoder(bytes.NewReader(specContent)))
 	if err == nil {
 		return instance, nil
@@ -397,8 +397,14 @@ func parseAASXMLInstance(specContent []byte) (aastypes.IClass, error) {
 	if adaptationErr != nil {
 		retryFailures = append(retryFailures, fmt.Sprintf("namespace adaptation failed: %v", adaptationErr))
 	} else if namespaceAdapted {
+		sanitizedSourceLabel := sanitizeLogValue(strings.TrimSpace(sourceLabel))
+		if sanitizedSourceLabel == "" {
+			sanitizedSourceLabel = "unknown"
+		}
+		// #nosec G706 -- source label is sanitized to strip CR/LF before logging.
 		log.Printf(
-			"[WARN] AASENV-PARSEAASX-NAMESPACEADAPTED adapted legacy AAS namespace to '%s' for backward compatibility",
+			"[WARN] AASENV-PARSEAASX-NAMESPACEADAPTED source='%s' adapted legacy AAS namespace to '%s' for backward compatibility",
+			sanitizedSourceLabel,
 			sanitizeLogValue(currentAASNamespace),
 		)
 		adaptedRetried, adaptedRetryErr := aasxmlization.Unmarshal(xml.NewDecoder(bytes.NewReader(adaptedContent)))
@@ -425,6 +431,26 @@ func parseAASXMLInstance(specContent []byte) (aastypes.IClass, error) {
 	}
 
 	return nil, fmt.Errorf("%w (%s)", err, strings.Join(retryFailures, "; "))
+}
+
+func buildAASXSpecSourceLabel(uploadSource string, specPart *aasx.Part) string {
+	trimmedUploadSource := strings.TrimSpace(uploadSource)
+	specURI := ""
+	if specPart != nil {
+		specURI = normalizePartURI(specPart.URI)
+	}
+
+	if trimmedUploadSource == "" && specURI == "" {
+		return ""
+	}
+	if trimmedUploadSource == "" {
+		return specURI
+	}
+	if specURI == "" {
+		return trimmedUploadSource
+	}
+
+	return trimmedUploadSource + ":" + specURI
 }
 
 func adaptLegacyAASNamespace(content []byte) ([]byte, string, bool, error) {

--- a/internal/aasenvironment/upload_api_service_test.go
+++ b/internal/aasenvironment/upload_api_service_test.go
@@ -88,7 +88,7 @@ func TestReadEnvironmentFromAASXSpec_AdaptsLegacyNamespace(t *testing.T) {
 		_ = packageReader.Close()
 	}()
 
-	_, environment, parseErr := readEnvironmentFromAASXSpec(packageReader)
+	_, environment, parseErr := readEnvironmentFromAASXSpec(packageReader, filepath.Base(hartingPath))
 	if parseErr != nil {
 		t.Fatalf("expected legacy namespace to be adapted successfully, got error: %v", parseErr)
 	}


### PR DESCRIPTION
This pull request introduces improvements to the preconfiguration and upload handling logic, with a focus on better logging and traceability for XML/AASX file processing. The main changes include passing source information through the parsing pipeline, improved logging with source labels, and refactoring to support these enhancements.

**Logging and traceability improvements:**

* Added a log entry at the start of each preconfiguration file import to improve traceability in `RunAASPreconfiguration` (`preconfiguration.go`).
* Enhanced warnings for legacy namespace adaptation to include the sanitized source label, making it easier to identify the origin of processed files (`parseAASXMLInstance`).

**Function signature and parameter changes:**

* Updated `processAASXPackage`, `readEnvironmentFromAASXSpec`, and `parseAASXMLInstance` to accept and propagate the upload source (file name), enabling more informative logging and error messages. [[1]](diffhunk://#diff-bfe6f960b7c47996a9be2ed4488c28f9a913fe2bfe104fbe44d5827d5f8ca79aL213-R214) [[2]](diffhunk://#diff-bfe6f960b7c47996a9be2ed4488c28f9a913fe2bfe104fbe44d5827d5f8ca79aL283-R283) [[3]](diffhunk://#diff-bfe6f960b7c47996a9be2ed4488c28f9a913fe2bfe104fbe44d5827d5f8ca79aL377-R377) [[4]](diffhunk://#diff-bfe6f960b7c47996a9be2ed4488c28f9a913fe2bfe104fbe44d5827d5f8ca79aL332-R332)

**Utility and refactoring:**

* Introduced `buildAASXSpecSourceLabel` to construct a source label from the upload source and part URI, improving context for downstream logging and error reporting.

**Test updates:**

* Updated tests to pass the required upload source parameter, ensuring compatibility with the new function signatures (`upload_api_service_test.go`).