### PR TITLE
Fixes Property empty Value omitted

### DIFF
--- a/internal/aasenvironment/integration_tests/expected/productionplan_submodels.json
+++ b/internal/aasenvironment/integration_tests/expected/productionplan_submodels.json
@@ -7431,6 +7431,7 @@
                 ],
                 "type": "ExternalReference"
               },
+              "value": "",
               "valueType": "xs:string"
             },
             {
@@ -7554,6 +7555,7 @@
                         ],
                         "type": "ExternalReference"
                       },
+                      "value": "",
                       "valueType": "xs:string"
                     },
                     {
@@ -7776,6 +7778,7 @@
                         ],
                         "type": "ExternalReference"
                       },
+                      "value": "",
                       "valueType": "xs:string"
                     }
                   ]
@@ -7932,6 +7935,7 @@
                     ],
                     "type": "ExternalReference"
                   },
+                  "value": "",
                   "valueType": "xs:string"
                 },
                 {
@@ -7963,6 +7967,7 @@
                     ],
                     "type": "ExternalReference"
                   },
+                  "value": "",
                   "valueType": "xs:string"
                 },
                 {
@@ -7994,6 +7999,7 @@
                     ],
                     "type": "ExternalReference"
                   },
+                  "value": "",
                   "valueType": "xs:string"
                 },
                 {
@@ -8025,6 +8031,7 @@
                     ],
                     "type": "ExternalReference"
                   },
+                  "value": "",
                   "valueType": "xs:string"
                 }
               ]

--- a/internal/common/builder/submodel_element_builder.go
+++ b/internal/common/builder/submodel_element_builder.go
@@ -397,14 +397,6 @@ func buildProperty(smeRow model.SubmodelElementRow, refBuilderMap map[int64]*Ref
 		return nil, err
 	}
 
-	var valuePresence struct {
-		Value *string `json:"value"`
-	}
-	err = json.Unmarshal(*smeRow.Value, &valuePresence)
-	if err != nil {
-		return nil, err
-	}
-
 	valueID, err := getSingleReference(&valueRow.ValueID, &valueRow.ValueIDReferred, refBuilderMap, refMutex)
 	if err != nil {
 		return nil, err
@@ -414,8 +406,8 @@ func buildProperty(smeRow model.SubmodelElementRow, refBuilderMap map[int64]*Ref
 	valueType := types.DataTypeDefXSD(valueRow.ValueType)
 
 	prop := types.NewProperty(valueType)
-	if valuePresence.Value != nil {
-		prop.SetValue(&valueRow.Value)
+	if valueRow.Value != nil {
+		prop.SetValue(valueRow.Value)
 	}
 	if valueID != nil {
 		prop.SetValueID(valueID)

--- a/internal/common/builder/submodel_element_builder.go
+++ b/internal/common/builder/submodel_element_builder.go
@@ -396,6 +396,15 @@ func buildProperty(smeRow model.SubmodelElementRow, refBuilderMap map[int64]*Ref
 	if err != nil {
 		return nil, err
 	}
+
+	var valuePresence struct {
+		Value *string `json:"value"`
+	}
+	err = json.Unmarshal(*smeRow.Value, &valuePresence)
+	if err != nil {
+		return nil, err
+	}
+
 	valueID, err := getSingleReference(&valueRow.ValueID, &valueRow.ValueIDReferred, refBuilderMap, refMutex)
 	if err != nil {
 		return nil, err
@@ -405,7 +414,7 @@ func buildProperty(smeRow model.SubmodelElementRow, refBuilderMap map[int64]*Ref
 	valueType := types.DataTypeDefXSD(valueRow.ValueType)
 
 	prop := types.NewProperty(valueType)
-	if valueRow.Value != "" {
+	if valuePresence.Value != nil {
 		prop.SetValue(&valueRow.Value)
 	}
 	if valueID != nil {

--- a/internal/common/model/transactionObjects.go
+++ b/internal/common/model/transactionObjects.go
@@ -347,7 +347,7 @@ type SubmodelElementRow struct {
 type PropertyValueRow struct {
 	// Value is the actual value of the property stored as a string.
 	// The string representation must be interpreted according to the ValueType field.
-	Value string `json:"value"`
+	Value *string `json:"value"`
 
 	// ValueType specifies the XSD data type of the value.
 	// This determines how the Value string should be parsed and interpreted

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -485,6 +485,60 @@ func TestTemporalXSDRoundTripFormatting(t *testing.T) {
 	})
 }
 
+func TestPropertyEmptyStringRoundTrip(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	submodelID := fmt.Sprintf("urn:basyx:integration:property-empty-string-%d", time.Now().UnixNano())
+	submodelIDEncoded := common.EncodeString(submodelID)
+
+	t.Cleanup(func() {
+		statusCode, body, err := requestJSON(http.MethodDelete, fmt.Sprintf("%s/submodels/%s", baseURL, submodelIDEncoded), nil)
+		if err != nil {
+			t.Logf("cleanup delete failed for empty-string test submodel: %v", err)
+			return
+		}
+		if statusCode != http.StatusNoContent && statusCode != http.StatusNotFound {
+			t.Logf("cleanup delete returned unexpected status=%d body=%s", statusCode, string(body))
+		}
+	})
+
+	postPayload := map[string]any{
+		"id":        submodelID,
+		"idShort":   "RoundtripEmptyString",
+		"kind":      "Instance",
+		"modelType": "Submodel",
+		"submodelElements": []map[string]any{
+			{
+				"idShort":   "TheProperty",
+				"modelType": "Property",
+				"valueType": "xs:string",
+				"value":     "",
+			},
+		},
+	}
+
+	statusCode, body, err := requestJSON(http.MethodPost, fmt.Sprintf("%s/submodels", baseURL), postPayload)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
+
+	statusCode, body, err = requestJSON(http.MethodGet, fmt.Sprintf("%s/submodels/%s", baseURL, submodelIDEncoded), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
+
+	var submodel map[string]any
+	require.NoError(t, json.Unmarshal(body, &submodel))
+
+	rawElements, ok := submodel["submodelElements"].([]any)
+	require.True(t, ok, "submodelElements must be an array")
+	require.Len(t, rawElements, 1, "expected exactly one submodel element")
+
+	property, ok := rawElements[0].(map[string]any)
+	require.True(t, ok, "submodel element must be an object")
+
+	value, hasValue := property["value"]
+	require.True(t, hasValue, "property value key must be present when empty string was posted")
+	assert.Equal(t, "", value)
+}
+
 func TestContractSubmodelRepository(t *testing.T) {
 	baseURL := "http://localhost:6004"
 

--- a/internal/submodelrepository/persistence/submodelElements/value_type_mapper.go
+++ b/internal/submodelrepository/persistence/submodelElements/value_type_mapper.go
@@ -56,9 +56,9 @@ type TypedValue struct {
 //   - TypedValue: A struct with the value placed in the appropriate field based on type
 func MapValueByType(valueType types.DataTypeDefXSD, value *string) TypedValue {
 	tv := TypedValue{}
-	valid := value != nil && *value != ""
+	valid := value != nil && (*value != "" || IsTextType(valueType))
 	actualValue := ""
-	if valid {
+	if value != nil {
 		actualValue = *value
 	}
 	switch {


### PR DESCRIPTION
## Description of Changes

This PR fixes a round-trip fidelity bug where `Property` elements posted with `"value": ""` were returned without a `value` field on GET.

### Root cause
- Empty strings for text-based property values were treated as “not set” during persistence (`NULL` in DB), making them indistinguishable from missing values.
- During rebuild, property value assignment also depended on non-empty content.

### What changed
- **Preserve explicit empty string for text types at persistence layer**
  - Updated [value_type_mapper.go](/Users/fried/Documents/Projekte/BaSyx_Kern/basyx-go-components/internal/submodelrepository/persistence/submodelElements/value_type_mapper.go) so `MapValueByType(...)` stores `""` as a valid value for text datatypes (`xs:string`, `xs:anyURI`, `xs:base64Binary`, `xs:hexBinary`) instead of mapping to `NULL`.
- **Preserve value-field presence when rebuilding Property elements**
  - Updated [submodel_element_builder.go](/Users/fried/Documents/Projekte/BaSyx_Kern/basyx-go-components/internal/common/builder/submodel_element_builder.go) to set property value when the `value` key is present in stored payload (including empty string), not only when non-empty.
- **Added regression coverage**
  - Added `TestPropertyEmptyStringRoundTrip` in [submodelrepository_integration_test.go](/Users/fried/Documents/Projekte/BaSyx_Kern/basyx-go-components/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go) to verify POST→GET preserves `"value": ""`.

### Behavior after fix
- `POST` with `"value": ""` now round-trips as `GET` with `"value": ""`.
- Existing behavior for non-empty values and omitted `value` remains unchanged.

## Related Issue

closes #280 
