### PR TITLE
Add provenance predicate type detection to Docker workflows

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -183,6 +183,25 @@ jobs:
           jq -e 'type == "object" and length > 0' predicates/provenance.buildkit.json >/dev/null
           jq -e 'type == "object" and length > 0' predicates/sbom.buildkit.spdx.json >/dev/null
 
+      - name: Detect provenance predicate type
+        run: |
+          set -euo pipefail
+          PROVENANCE_PREDICATE_TYPE=$(jq -r '
+            if has("buildDefinition") and has("runDetails") then "https://slsa.dev/provenance/v1"
+            elif has("builder") and has("buildType") then "https://slsa.dev/provenance/v0.2"
+            else ""
+            end
+          ' predicates/provenance.buildkit.json)
+
+          if [ -z "${PROVENANCE_PREDICATE_TYPE}" ]; then
+            echo "Unsupported BuildKit provenance predicate shape:" >&2
+            jq -r 'keys_unsorted | @json' predicates/provenance.buildkit.json >&2
+            exit 1
+          fi
+
+          echo "Detected provenance predicate type: ${PROVENANCE_PREDICATE_TYPE}"
+          echo "PROVENANCE_PREDICATE_TYPE=${PROVENANCE_PREDICATE_TYPE}" >> "$GITHUB_ENV"
+
       - name: Verify BuildKit OCI attestation manifests exist
         env:
           IMAGE_DIGEST_REF: ${{ matrix.service.image }}@${{ steps.build.outputs.digest }}
@@ -197,7 +216,7 @@ jobs:
         run: |
           set -euo pipefail
           cosign attest --yes \
-            --type slsaprovenance \
+            --type "${PROVENANCE_PREDICATE_TYPE}" \
             --predicate predicates/provenance.buildkit.json \
             "${IMAGE_DIGEST_REF}"
           cosign attest --yes \
@@ -216,7 +235,7 @@ jobs:
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "${IMAGE_DIGEST_REF}"
           cosign verify-attestation \
-            --type slsaprovenance \
+            --type "${PROVENANCE_PREDICATE_TYPE}" \
             --certificate-identity "${COSIGN_CERT_IDENTITY}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "${IMAGE_DIGEST_REF}" > /tmp/provenance.jsonl

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -168,6 +168,25 @@ jobs:
           jq -e 'type == "object" and length > 0' predicates/provenance.buildkit.json >/dev/null
           jq -e 'type == "object" and length > 0' predicates/sbom.buildkit.spdx.json >/dev/null
 
+      - name: Detect provenance predicate type
+        run: |
+          set -euo pipefail
+          PROVENANCE_PREDICATE_TYPE=$(jq -r '
+            if has("buildDefinition") and has("runDetails") then "https://slsa.dev/provenance/v1"
+            elif has("builder") and has("buildType") then "https://slsa.dev/provenance/v0.2"
+            else ""
+            end
+          ' predicates/provenance.buildkit.json)
+
+          if [ -z "${PROVENANCE_PREDICATE_TYPE}" ]; then
+            echo "Unsupported BuildKit provenance predicate shape:" >&2
+            jq -r 'keys_unsorted | @json' predicates/provenance.buildkit.json >&2
+            exit 1
+          fi
+
+          echo "Detected provenance predicate type: ${PROVENANCE_PREDICATE_TYPE}"
+          echo "PROVENANCE_PREDICATE_TYPE=${PROVENANCE_PREDICATE_TYPE}" >> "$GITHUB_ENV"
+
       - name: Verify BuildKit OCI attestation manifests exist
         env:
           IMAGE_DIGEST_REF: ${{ matrix.service.image }}@${{ steps.build.outputs.digest }}
@@ -182,7 +201,7 @@ jobs:
         run: |
           set -euo pipefail
           cosign attest --yes \
-            --type slsaprovenance \
+            --type "${PROVENANCE_PREDICATE_TYPE}" \
             --predicate predicates/provenance.buildkit.json \
             "${IMAGE_DIGEST_REF}"
           cosign attest --yes \
@@ -201,7 +220,7 @@ jobs:
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "${IMAGE_DIGEST_REF}"
           cosign verify-attestation \
-            --type slsaprovenance \
+            --type "${PROVENANCE_PREDICATE_TYPE}" \
             --certificate-identity "${COSIGN_CERT_IDENTITY}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "${IMAGE_DIGEST_REF}" > /tmp/provenance.jsonl

--- a/docu/security/SUPPLY_CHAIN_SECURITY.md
+++ b/docu/security/SUPPLY_CHAIN_SECURITY.md
@@ -59,12 +59,15 @@ For snapshots, use the snapshot workflow identity.
 
 The workflow creates explicit Cosign provenance attestations from BuildKit provenance data, then verifies those attestations with identity constraints.
 
+Use the provenance predicate type that was detected from BuildKit output (commonly `https://slsa.dev/provenance/v1` or `https://slsa.dev/provenance/v0.2`).
+
 ```bash
 IMAGE="eclipsebasyx/aasregistry-go@sha256:<digest>"
 IDENTITY="https://github.com/eclipse-basyx/basyx-go-components/.github/workflows/docker-release.yml@refs/tags/v1.2.3"
+PROVENANCE_TYPE="https://slsa.dev/provenance/v1"
 
 cosign verify-attestation \
-  --type slsaprovenance \
+  --type "$PROVENANCE_TYPE" \
   --certificate-identity "$IDENTITY" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   "$IMAGE"


### PR DESCRIPTION
This pull request improves the handling of BuildKit provenance predicate types in both the Docker release and snapshot GitHub workflows, making the attestation and verification steps more robust and flexible. The workflows now automatically detect the correct provenance predicate type and use it throughout the attestation and verification process, and the documentation has been updated to reflect this change.

**Workflow improvements:**

* Added a step to both `.github/workflows/docker-release.yml` and `.github/workflows/docker-snapshot.yml` to detect the provenance predicate type from `provenance.buildkit.json` and set it as the `PROVENANCE_PREDICATE_TYPE` environment variable. [[1]](diffhunk://#diff-155353073f96bc01f2db838a9b2a2112568bac7ea32a4b4797c5dbc21c6fca42R186-R204) [[2]](diffhunk://#diff-b6e93f9d1e90235b0df433f9714564b8e9743d290d9debe8901395c3fb131140R171-R189)
* Updated the `cosign attest` and `cosign verify-attestation` steps in both workflows to use the detected `PROVENANCE_PREDICATE_TYPE` instead of the hardcoded `slsaprovenance` type. [[1]](diffhunk://#diff-155353073f96bc01f2db838a9b2a2112568bac7ea32a4b4797c5dbc21c6fca42L200-R219) [[2]](diffhunk://#diff-155353073f96bc01f2db838a9b2a2112568bac7ea32a4b4797c5dbc21c6fca42L219-R238) [[3]](diffhunk://#diff-b6e93f9d1e90235b0df433f9714564b8e9743d290d9debe8901395c3fb131140L185-R204) [[4]](diffhunk://#diff-b6e93f9d1e90235b0df433f9714564b8e9743d290d9debe8901395c3fb131140L204-R223)

**Documentation update:**

* Updated `docu/security/SUPPLY_CHAIN_SECURITY.md` to instruct users to use the detected provenance predicate type in the `cosign verify-attestation` command, and provided examples for common predicate types.