### PR TITLE
Fixes optional field handling

### DIFF
--- a/internal/aasrepository/integration_tests/aasrepository_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_integration_test.go
@@ -551,6 +551,40 @@ func TestIntegration(t *testing.T) {
 	})
 }
 
+func TestPostAssetAdministrationShellAcceptsNullSubmodels(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	aasID := fmt.Sprintf("https://example.com/ids/aas/null-submodels-%d", time.Now().UnixNano())
+
+	requestBody := fmt.Sprintf(`{
+		"id":"%s",
+		"idShort":"NullSubmodelsShell",
+		"modelType":"AssetAdministrationShell",
+		"assetInformation":{"assetKind":"Instance"},
+		"submodels":null
+	}`, aasID)
+
+	statusCode, err := postResponseStatus(baseURL+"/shells", requestBody)
+	require.NoError(t, err, "POST AAS request failed")
+	require.Equal(t, http.StatusCreated, statusCode, "Expected 201 Created for AAS payload with submodels=null")
+
+	encodedAASIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+	t.Cleanup(func() {
+		deleteStatusCode, deleteErr := deleteResponseStatus(fmt.Sprintf("%s/shells/%s", baseURL, encodedAASIdentifier))
+		if deleteErr != nil {
+			t.Logf("cleanup delete failed for AAS %s: %v", aasID, deleteErr)
+			return
+		}
+		if deleteStatusCode != http.StatusNoContent && deleteStatusCode != http.StatusNotFound {
+			t.Logf("cleanup delete returned unexpected status=%d for AAS %s", deleteStatusCode, aasID)
+		}
+	})
+
+	payload, getStatusCode, getErr := getJSONResponse(fmt.Sprintf("%s/shells/%s", baseURL, encodedAASIdentifier))
+	require.NoError(t, getErr, "GET AAS request failed")
+	require.Equal(t, http.StatusOK, getStatusCode, "Expected 200 OK after creating AAS with submodels=null")
+	assert.Equal(t, aasID, payload["id"], "Expected created AAS id in GET response")
+}
+
 func TestPutSubmodelByIdAasRepositoryReturnsCreatedSubmodelAnd201(t *testing.T) {
 	baseURL := "http://localhost:6004"
 	aasID := fmt.Sprintf("https://example.com/ids/aas/put-submodel-create-%d", time.Now().UnixNano())

--- a/internal/common/optional_array_payload_normalizer.go
+++ b/internal/common/optional_array_payload_normalizer.go
@@ -26,28 +26,30 @@
 package common
 
 // NormalizePayloadNullFields removes null-valued fields recursively from JSON-like payloads.
-func NormalizePayloadNullFields(payload any) {
+// It returns the normalized payload so callers can reassign non-map roots such as []any.
+// For map[string]any roots, the input map is also updated in place for backward compatibility.
+func NormalizePayloadNullFields(payload any) any {
 	normalizedPayload := normalizePayloadNullFieldsIterative(payload)
 	rootMap, rootIsMap := payload.(map[string]any)
 	normalizedMap, normalizedIsMap := normalizedPayload.(map[string]any)
-	if !rootIsMap || !normalizedIsMap {
-		return
+	if rootIsMap && normalizedIsMap {
+		clear(rootMap)
+		for key, value := range normalizedMap {
+			rootMap[key] = value
+		}
 	}
 
-	clear(rootMap)
-	for key, value := range normalizedMap {
-		rootMap[key] = value
-	}
+	return normalizedPayload
 }
 
 // NormalizeAASPayloadOptionalArrays normalizes AAS payloads by removing null-valued fields.
-func NormalizeAASPayloadOptionalArrays(payload any) {
-	NormalizePayloadNullFields(payload)
+func NormalizeAASPayloadOptionalArrays(payload any) any {
+	return NormalizePayloadNullFields(payload)
 }
 
 // NormalizeSubmodelPayloadOptionalArrays normalizes submodel payloads by removing null-valued fields.
-func NormalizeSubmodelPayloadOptionalArrays(payload any) {
-	NormalizePayloadNullFields(payload)
+func NormalizeSubmodelPayloadOptionalArrays(payload any) any {
+	return NormalizePayloadNullFields(payload)
 }
 
 type normalizerFrameKind uint8

--- a/internal/common/optional_array_payload_normalizer.go
+++ b/internal/common/optional_array_payload_normalizer.go
@@ -1,0 +1,45 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+func NormalizeAASPayloadOptionalArrays(payload any) {
+	normalizeTopLevelOptionalArrayNull(payload, "submodels")
+}
+
+func NormalizeSubmodelPayloadOptionalArrays(payload any) {
+	normalizeTopLevelOptionalArrayNull(payload, "submodelElements")
+}
+
+func normalizeTopLevelOptionalArrayNull(payload any, field string) {
+	jsonObject, ok := payload.(map[string]any)
+	if !ok {
+		return
+	}
+
+	if rawFieldValue, exists := jsonObject[field]; exists && rawFieldValue == nil {
+		delete(jsonObject, field)
+	}
+}

--- a/internal/common/optional_array_payload_normalizer.go
+++ b/internal/common/optional_array_payload_normalizer.go
@@ -27,7 +27,17 @@ package common
 
 // NormalizePayloadNullFields removes null-valued fields recursively from JSON-like payloads.
 func NormalizePayloadNullFields(payload any) {
-	_ = normalizePayloadNullFields(payload)
+	normalizedPayload := normalizePayloadNullFieldsIterative(payload)
+	rootMap, rootIsMap := payload.(map[string]any)
+	normalizedMap, normalizedIsMap := normalizedPayload.(map[string]any)
+	if !rootIsMap || !normalizedIsMap {
+		return
+	}
+
+	clear(rootMap)
+	for key, value := range normalizedMap {
+		rootMap[key] = value
+	}
 }
 
 // NormalizeAASPayloadOptionalArrays normalizes AAS payloads by removing null-valued fields.
@@ -40,27 +50,112 @@ func NormalizeSubmodelPayloadOptionalArrays(payload any) {
 	NormalizePayloadNullFields(payload)
 }
 
-func normalizePayloadNullFields(payload any) any {
-	switch typed := payload.(type) {
-	case map[string]any:
-		for key, value := range typed {
-			if value == nil {
-				delete(typed, key)
-				continue
+type normalizerFrameKind uint8
+
+const (
+	normalizerFrameKindRoot normalizerFrameKind = iota
+	normalizerFrameKindMap
+	normalizerFrameKindSlice
+)
+
+type normalizerFrame struct {
+	stage             uint8
+	value             any
+	result            any
+	kind              normalizerFrameKind
+	parent            *normalizerFrame
+	parentMapKey      string
+	parentSliceIndex  int
+	mapKeys           []string
+	mapChildResults   map[string]any
+	sliceChildResults []any
+}
+
+func normalizePayloadNullFieldsIterative(payload any) any {
+	rootFrame := &normalizerFrame{
+		value: payload,
+		kind:  normalizerFrameKindRoot,
+	}
+	stack := []*normalizerFrame{rootFrame}
+
+	for len(stack) > 0 {
+		activeFrame := stack[len(stack)-1]
+		switch activeFrame.stage {
+		case 0:
+			switch typedValue := activeFrame.value.(type) {
+			case map[string]any:
+				activeFrame.stage = 1
+				activeFrame.mapChildResults = make(map[string]any, len(typedValue))
+				activeFrame.mapKeys = make([]string, 0, len(typedValue))
+
+				for key, value := range typedValue {
+					activeFrame.mapKeys = append(activeFrame.mapKeys, key)
+					childFrame := &normalizerFrame{
+						value:        value,
+						kind:         normalizerFrameKindMap,
+						parent:       activeFrame,
+						parentMapKey: key,
+					}
+					stack = append(stack, childFrame)
+				}
+			case []any:
+				activeFrame.stage = 1
+				activeFrame.sliceChildResults = make([]any, len(typedValue))
+
+				for index, value := range typedValue {
+					childFrame := &normalizerFrame{
+						value:            value,
+						kind:             normalizerFrameKindSlice,
+						parent:           activeFrame,
+						parentSliceIndex: index,
+					}
+					stack = append(stack, childFrame)
+				}
+			default:
+				activeFrame.result = typedValue
+				stack = stack[:len(stack)-1]
+				propagateNormalizationResultToParent(activeFrame)
 			}
-			typed[key] = normalizePayloadNullFields(value)
-		}
-		return typed
-	case []any:
-		normalized := make([]any, 0, len(typed))
-		for _, item := range typed {
-			if item == nil {
-				continue
+		default:
+			switch activeFrame.value.(type) {
+			case map[string]any:
+				normalizedMap := make(map[string]any, len(activeFrame.mapChildResults))
+				for _, key := range activeFrame.mapKeys {
+					normalizedChildValue := activeFrame.mapChildResults[key]
+					if normalizedChildValue == nil {
+						continue
+					}
+					normalizedMap[key] = normalizedChildValue
+				}
+				activeFrame.result = normalizedMap
+			case []any:
+				normalizedSlice := make([]any, 0, len(activeFrame.sliceChildResults))
+				for _, normalizedChildValue := range activeFrame.sliceChildResults {
+					if normalizedChildValue == nil {
+						continue
+					}
+					normalizedSlice = append(normalizedSlice, normalizedChildValue)
+				}
+				activeFrame.result = normalizedSlice
 			}
-			normalized = append(normalized, normalizePayloadNullFields(item))
+
+			stack = stack[:len(stack)-1]
+			propagateNormalizationResultToParent(activeFrame)
 		}
-		return normalized
-	default:
-		return payload
+	}
+
+	return rootFrame.result
+}
+
+func propagateNormalizationResultToParent(frame *normalizerFrame) {
+	if frame == nil || frame.parent == nil {
+		return
+	}
+
+	switch frame.kind {
+	case normalizerFrameKindMap:
+		frame.parent.mapChildResults[frame.parentMapKey] = frame.result
+	case normalizerFrameKindSlice:
+		frame.parent.sliceChildResults[frame.parentSliceIndex] = frame.result
 	}
 }

--- a/internal/common/optional_array_payload_normalizer.go
+++ b/internal/common/optional_array_payload_normalizer.go
@@ -25,14 +25,17 @@
 
 package common
 
+// NormalizePayloadNullFields removes null-valued fields recursively from JSON-like payloads.
 func NormalizePayloadNullFields(payload any) {
 	_ = normalizePayloadNullFields(payload)
 }
 
+// NormalizeAASPayloadOptionalArrays normalizes AAS payloads by removing null-valued fields.
 func NormalizeAASPayloadOptionalArrays(payload any) {
 	NormalizePayloadNullFields(payload)
 }
 
+// NormalizeSubmodelPayloadOptionalArrays normalizes submodel payloads by removing null-valued fields.
 func NormalizeSubmodelPayloadOptionalArrays(payload any) {
 	NormalizePayloadNullFields(payload)
 }

--- a/internal/common/optional_array_payload_normalizer.go
+++ b/internal/common/optional_array_payload_normalizer.go
@@ -25,21 +25,39 @@
 
 package common
 
+func NormalizePayloadNullFields(payload any) {
+	_ = normalizePayloadNullFields(payload)
+}
+
 func NormalizeAASPayloadOptionalArrays(payload any) {
-	normalizeTopLevelOptionalArrayNull(payload, "submodels")
+	NormalizePayloadNullFields(payload)
 }
 
 func NormalizeSubmodelPayloadOptionalArrays(payload any) {
-	normalizeTopLevelOptionalArrayNull(payload, "submodelElements")
+	NormalizePayloadNullFields(payload)
 }
 
-func normalizeTopLevelOptionalArrayNull(payload any, field string) {
-	jsonObject, ok := payload.(map[string]any)
-	if !ok {
-		return
-	}
-
-	if rawFieldValue, exists := jsonObject[field]; exists && rawFieldValue == nil {
-		delete(jsonObject, field)
+func normalizePayloadNullFields(payload any) any {
+	switch typed := payload.(type) {
+	case map[string]any:
+		for key, value := range typed {
+			if value == nil {
+				delete(typed, key)
+				continue
+			}
+			typed[key] = normalizePayloadNullFields(value)
+		}
+		return typed
+	case []any:
+		normalized := make([]any, 0, len(typed))
+		for _, item := range typed {
+			if item == nil {
+				continue
+			}
+			normalized = append(normalized, normalizePayloadNullFields(item))
+		}
+		return normalized
+	default:
+		return payload
 	}
 }

--- a/internal/common/optional_array_payload_normalizer_test.go
+++ b/internal/common/optional_array_payload_normalizer_test.go
@@ -1,0 +1,76 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeAASPayloadOptionalArraysRemovesNullSubmodels(t *testing.T) {
+	payload := map[string]any{
+		"id":        "https://example.com/aas/1",
+		"submodels": nil,
+	}
+
+	NormalizeAASPayloadOptionalArrays(payload)
+
+	_, hasSubmodels := payload["submodels"]
+	assert.False(t, hasSubmodels)
+}
+
+func TestNormalizeAASPayloadOptionalArraysKeepsNonNullSubmodels(t *testing.T) {
+	payload := map[string]any{
+		"id":        "https://example.com/aas/2",
+		"submodels": []any{},
+	}
+
+	NormalizeAASPayloadOptionalArrays(payload)
+
+	_, hasSubmodels := payload["submodels"]
+	assert.True(t, hasSubmodels)
+}
+
+func TestNormalizeSubmodelPayloadOptionalArraysRemovesNullElements(t *testing.T) {
+	payload := map[string]any{
+		"id":               "https://example.com/sm/1",
+		"submodelElements": nil,
+	}
+
+	NormalizeSubmodelPayloadOptionalArrays(payload)
+
+	_, hasSubmodelElements := payload["submodelElements"]
+	assert.False(t, hasSubmodelElements)
+}
+
+func TestNormalizeSubmodelPayloadOptionalArraysIgnoresNonObjectPayload(t *testing.T) {
+	payload := []any{map[string]any{"submodelElements": nil}}
+
+	NormalizeSubmodelPayloadOptionalArrays(payload)
+
+	assert.Len(t, payload, 1)
+}

--- a/internal/common/optional_array_payload_normalizer_test.go
+++ b/internal/common/optional_array_payload_normalizer_test.go
@@ -74,3 +74,47 @@ func TestNormalizeSubmodelPayloadOptionalArraysIgnoresNonObjectPayload(t *testin
 
 	assert.Len(t, payload, 1)
 }
+
+func TestNormalizeSubmodelPayloadOptionalArraysRemovesNestedNullFields(t *testing.T) {
+	payload := map[string]any{
+		"id": "https://example.com/sm/2",
+		"submodelElements": []any{
+			map[string]any{
+				"idShort": "collection",
+				"value": []any{
+					map[string]any{
+						"idShort": "nested",
+						"value":   nil,
+					},
+					nil,
+				},
+				"semanticId": nil,
+			},
+		},
+	}
+
+	NormalizeSubmodelPayloadOptionalArrays(payload)
+
+	rawElements, hasElements := payload["submodelElements"]
+	assert.True(t, hasElements)
+
+	elements, ok := rawElements.([]any)
+	assert.True(t, ok)
+	assert.Len(t, elements, 1)
+
+	firstElement, ok := elements[0].(map[string]any)
+	assert.True(t, ok)
+	_, hasSemanticID := firstElement["semanticId"]
+	assert.False(t, hasSemanticID)
+
+	nestedRaw, hasNested := firstElement["value"]
+	assert.True(t, hasNested)
+	nested, ok := nestedRaw.([]any)
+	assert.True(t, ok)
+	assert.Len(t, nested, 1)
+
+	nestedElement, ok := nested[0].(map[string]any)
+	assert.True(t, ok)
+	_, hasValue := nestedElement["value"]
+	assert.False(t, hasValue)
+}

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -597,6 +597,41 @@ func TestContractSubmodelRepository(t *testing.T) {
 		assert.NotEmpty(t, metadata, "metadata response should not be empty")
 	})
 
+	t.Run("PostSubmodelAcceptsNullSubmodelElements", func(t *testing.T) {
+		submodelID := fmt.Sprintf("https://example.com/ids/sm/contract-null-elements-%d", time.Now().UnixNano())
+		submodelIDShort := fmt.Sprintf("contractNullElements%d", time.Now().UnixNano())
+
+		statusCode, body, err := requestJSON(http.MethodPost, fmt.Sprintf("%s/submodels", baseURL), map[string]any{
+			"id":               submodelID,
+			"idShort":          submodelIDShort,
+			"kind":             "Instance",
+			"modelType":        "Submodel",
+			"submodelElements": nil,
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
+
+		encodedSubmodelID := common.EncodeString(submodelID)
+		t.Cleanup(func() {
+			_, _, _ = requestJSON(http.MethodDelete, fmt.Sprintf("%s/submodels/%s", baseURL, encodedSubmodelID), nil)
+		})
+
+		statusCode, body, err = requestJSON(http.MethodGet, fmt.Sprintf("%s/submodels/%s", baseURL, encodedSubmodelID), nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
+
+		var submodel map[string]any
+		require.NoError(t, json.Unmarshal(body, &submodel), "response=%s", string(body))
+
+		rawElements, hasElements := submodel["submodelElements"]
+		if !hasElements {
+			return
+		}
+
+		_, ok := rawElements.([]any)
+		require.True(t, ok, "submodelElements should be a JSON array when present")
+	})
+
 	t.Run("PatchSubmodelByIDMetadataAcceptsStringModelTypeAndUpdatesDescription", func(t *testing.T) {
 		submodelID := fmt.Sprintf("https://example.com/ids/sm/contract-patch-metadata-%d", time.Now().UnixNano())
 		submodelIDShort := fmt.Sprintf("contractPatchMetadata%d", time.Now().UnixNano())

--- a/pkg/aasrepositoryapi/go/api_asset_administration_shell_repository_api.go
+++ b/pkg/aasrepositoryapi/go/api_asset_administration_shell_repository_api.go
@@ -369,6 +369,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PostAssetAdministra
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizeAASPayloadOptionalArrays(jsonable)
 	aasParam, err := aasjsonization.AssetAdministrationShellFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -458,6 +459,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PutAssetAdministrat
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizeAASPayloadOptionalArrays(jsonable)
 	aasParam, err := aasjsonization.AssetAdministrationShellFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -809,6 +811,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PutSubmodelByIdAasR
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -889,6 +892,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PatchSubmodelAasRep
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)

--- a/pkg/aasrepositoryapi/go/api_asset_administration_shell_repository_api.go
+++ b/pkg/aasrepositoryapi/go/api_asset_administration_shell_repository_api.go
@@ -369,7 +369,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PostAssetAdministra
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	common.NormalizeAASPayloadOptionalArrays(jsonable)
+	common.NormalizePayloadNullFields(jsonable)
 	aasParam, err := aasjsonization.AssetAdministrationShellFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -459,7 +459,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PutAssetAdministrat
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	common.NormalizeAASPayloadOptionalArrays(jsonable)
+	common.NormalizePayloadNullFields(jsonable)
 	aasParam, err := aasjsonization.AssetAdministrationShellFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -551,6 +551,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PutAssetInformation
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizePayloadNullFields(jsonable)
 	assetInformationParam, err := aasjsonization.AssetInformationFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -706,6 +707,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PostSubmodelReferen
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizePayloadNullFields(jsonable)
 	refParam, err := aasjsonization.ReferenceFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -811,7 +813,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PutSubmodelByIdAasR
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
+	common.NormalizePayloadNullFields(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -892,7 +894,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PatchSubmodelAasRep
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
+	common.NormalizePayloadNullFields(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -1218,6 +1220,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PostSubmodelElement
 		return
 	}
 
+	common.NormalizePayloadNullFields(jsonable)
 	submodelElementParam, err := aasjsonization.SubmodelElementFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -1552,6 +1555,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PutSubmodelElementB
 		return
 	}
 
+	common.NormalizePayloadNullFields(jsonable)
 	submodelElementParam, err := aasjsonization.SubmodelElementFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -1605,6 +1609,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PostSubmodelElement
 		return
 	}
 
+	common.NormalizePayloadNullFields(jsonable)
 	submodelElementParam, err := aasjsonization.SubmodelElementFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -1694,6 +1699,7 @@ func (c *AssetAdministrationShellRepositoryAPIAPIController) PatchSubmodelElemen
 		return
 	}
 
+	common.NormalizePayloadNullFields(jsonable)
 	submodelElementParam, err := aasjsonization.SubmodelElementFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)

--- a/pkg/conceptdescriptionrepositoryapi/go/api_concept_description_repository_api.go
+++ b/pkg/conceptdescriptionrepositoryapi/go/api_concept_description_repository_api.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/aas-core-works/aas-core3.1-golang/jsonization"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/go-chi/chi/v5"
 )
@@ -149,6 +150,7 @@ func (c *ConceptDescriptionRepositoryAPIAPIController) PostConceptDescription(w 
 		c.errorHandler(w, r, &model.ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizePayloadNullFields(jsonable)
 	conceptDescriptionParam, err := jsonization.ConceptDescriptionFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &model.ParsingError{Err: err}, nil)
@@ -200,6 +202,7 @@ func (c *ConceptDescriptionRepositoryAPIAPIController) PutConceptDescriptionById
 		c.errorHandler(w, r, &model.ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizePayloadNullFields(jsonable)
 	conceptDescriptionParam, err := jsonization.ConceptDescriptionFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &model.ParsingError{Err: err}, nil)

--- a/pkg/discoveryapi/api_asset_administration_shell_basic_discovery_api.go
+++ b/pkg/discoveryapi/api_asset_administration_shell_basic_discovery_api.go
@@ -293,10 +293,10 @@ func (c *AssetAdministrationShellBasicDiscoveryAPIAPIController) PostAllAssetLin
 		return
 	}
 
-	var specificAssetIdParamAbs []map[string]interface{}
+	var specificAssetIDPayload any
 	d := json.NewDecoder(r.Body)
-	if err := d.Decode(&specificAssetIdParamAbs); err != nil {
-		log.Printf("%+v", specificAssetIdParamAbs)
+	if err := d.Decode(&specificAssetIDPayload); err != nil {
+		log.Printf("%+v", specificAssetIDPayload)
 		log.Printf("🧭 [%s] Error in PostAllAssetLinksById: decode request body failed: %v", componentName, err)
 		result := common.NewErrorResponse(
 			common.NewErrBadRequest("Incorrect RequestBody - 02"),
@@ -309,8 +309,38 @@ func (c *AssetAdministrationShellBasicDiscoveryAPIAPIController) PostAllAssetLin
 		return
 	}
 
+	common.NormalizePayloadNullFields(specificAssetIDPayload)
+
+	specificAssetIDItems, ok := specificAssetIDPayload.([]any)
+	if !ok {
+		log.Printf("🧭 [%s] Error in PostAllAssetLinksById: payload is not an array", componentName)
+		result := common.NewErrorResponse(
+			common.NewErrBadRequest("Incorrect RequestBody - 02"),
+			http.StatusBadRequest,
+			componentName,
+			"PostAllAssetLinksById",
+			"RequestBody",
+		)
+		EncodeJSONResponse(result.Body, &result.Code, w)
+		return
+	}
+
 	var interfaceSpecificAssetIds []types.ISpecificAssetID
-	for _, item := range specificAssetIdParamAbs {
+	for _, rawItem := range specificAssetIDItems {
+		item, ok := rawItem.(map[string]any)
+		if !ok {
+			log.Printf("🧭 [%s] Error in PostAllAssetLinksById: specific asset id entry is not an object", componentName)
+			result := common.NewErrorResponse(
+				common.NewErrBadRequest("Invalid specific asset id element"),
+				http.StatusBadRequest,
+				componentName,
+				"PostAllAssetLinksById",
+				"specificAssetId",
+			)
+			EncodeJSONResponse(result.Body, &result.Code, w)
+			return
+		}
+
 		saID, err := jsonization.SpecificAssetIDFromJsonable(item)
 		if err != nil {
 			log.Printf("🧭 [%s] Error in PostAllAssetLinksById: failed to parse specific asset id: %v", componentName, err)

--- a/pkg/submodelrepositoryapi/api_submodel_repository_api.go
+++ b/pkg/submodelrepositoryapi/api_submodel_repository_api.go
@@ -389,6 +389,7 @@ func (c *SubmodelRepositoryAPIAPIController) PostSubmodel(w http.ResponseWriter,
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -790,6 +791,7 @@ func (c *SubmodelRepositoryAPIAPIController) PutSubmodelByID(w http.ResponseWrit
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -845,6 +847,7 @@ func (c *SubmodelRepositoryAPIAPIController) PatchSubmodelByID(w http.ResponseWr
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
+	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)

--- a/pkg/submodelrepositoryapi/api_submodel_repository_api.go
+++ b/pkg/submodelrepositoryapi/api_submodel_repository_api.go
@@ -389,7 +389,7 @@ func (c *SubmodelRepositoryAPIAPIController) PostSubmodel(w http.ResponseWriter,
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
+	common.NormalizePayloadNullFields(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -791,7 +791,6 @@ func (c *SubmodelRepositoryAPIAPIController) PutSubmodelByID(w http.ResponseWrit
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -847,7 +846,7 @@ func (c *SubmodelRepositoryAPIAPIController) PatchSubmodelByID(w http.ResponseWr
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	common.NormalizeSubmodelPayloadOptionalArrays(jsonable)
+	common.NormalizePayloadNullFields(jsonable)
 	submodelParam, err := aasjsonization.SubmodelFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -1145,6 +1144,7 @@ func (c *SubmodelRepositoryAPIAPIController) PostSubmodelElementSubmodelRepo(w h
 	}
 
 	// Use SDK's jsonization to deserialize into proper SDK type
+	common.NormalizePayloadNullFields(jsonable)
 	submodelElementParam, err := aasjsonization.SubmodelElementFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -1464,6 +1464,7 @@ func (c *SubmodelRepositoryAPIAPIController) PutSubmodelElementByPathSubmodelRep
 	}
 
 	// Use SDK's jsonization to deserialize into proper SDK type
+	common.NormalizePayloadNullFields(jsonable)
 	submodelElementParam, err := aasjsonization.SubmodelElementFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -1530,6 +1531,7 @@ func (c *SubmodelRepositoryAPIAPIController) PostSubmodelElementByPathSubmodelRe
 	}
 
 	// Use SDK's jsonization to deserialize into proper SDK type
+	common.NormalizePayloadNullFields(jsonable)
 	submodelElementParam, err := aasjsonization.SubmodelElementFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -1614,6 +1616,7 @@ func (c *SubmodelRepositoryAPIAPIController) PatchSubmodelElementByPathSubmodelR
 	}
 
 	// Use SDK's jsonization to deserialize into proper SDK type
+	common.NormalizePayloadNullFields(jsonable)
 	submodelElementParam, err := aasjsonization.SubmodelElementFromJsonable(jsonable)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)


### PR DESCRIPTION
## Description of Changes

Added iterative payload normalization to remove null fields before SDK json parsing:
`internal/common/optional_array_payload_normalizer.go`

Applied normalization in AAS/Submodel repository controller parse paths before jsonization.*FromJsonable(...), so null inputs are treated like omitted fields for model payloads:
`pkg/aasrepositoryapi/go/api_asset_administration_shell_repository_api.go`
`pkg/submodelrepositoryapi/api_submodel_repository_api.go`

Added/extended tests for normalization behavior:
top-level null removal
nested null removal inside objects/arrays
non-object payload handling
`internal/common/optional_array_payload_normalizer_test.go`

Added integration coverage for the originally reported interoperability cases:
AAS repo accepts submodels: null
Submodel repo accepts submodelElements: null
`internal/aasrepository/integration_tests/aasrepository_integration_test.go`
`internal/submodelrepository/integration_tests/submodelrepository_integration_test.go`

## Related Issue

closes #276 
