### PR TITLE
Fixes bug in ARE and SML

### DIFF
--- a/internal/common/builder/submodel_element_builder.go
+++ b/internal/common/builder/submodel_element_builder.go
@@ -659,36 +659,22 @@ func buildAnnotatedRelationshipElement(smeRow model.SubmodelElementRow) (types.I
 		return nil, err
 	}
 
-	var firstJsonable, secondJsonable map[string]any
-	if valueRow.First == nil {
-		return nil, fmt.Errorf("first reference in RelationshipElement is nil")
-	}
-	firstJsonable, err = parseReferenceJsonable(valueRow.First)
+	firstSDK, err := buildOptionalReference(valueRow.First, "first")
 	if err != nil {
 		return nil, err
 	}
-	if valueRow.Second == nil {
-		return nil, fmt.Errorf("second reference in RelationshipElement is nil")
-	}
-	secondJsonable, err = parseReferenceJsonable(valueRow.Second)
+	secondSDK, err := buildOptionalReference(valueRow.Second, "second")
 	if err != nil {
 		return nil, err
-	}
-
-	firstSDK, err := jsonization.ReferenceFromJsonable(firstJsonable)
-	if err != nil {
-		_, _ = fmt.Printf("[DEBUG] buildAnnotatedRelationshipElement First: JSON: %v, Error: %v\n", firstJsonable, err)
-		return nil, fmt.Errorf("error converting first jsonable to Reference: %w", err)
-	}
-	secondSDK, err := jsonization.ReferenceFromJsonable(secondJsonable)
-	if err != nil {
-		_, _ = fmt.Printf("[DEBUG] buildAnnotatedRelationshipElement Second: JSON: %v, Error: %v\n", secondJsonable, err)
-		return nil, fmt.Errorf("error converting second jsonable to Reference: %w", err)
 	}
 
 	relElem := types.NewAnnotatedRelationshipElement()
-	relElem.SetFirst(firstSDK)
-	relElem.SetSecond(secondSDK)
+	if firstSDK != nil {
+		relElem.SetFirst(firstSDK)
+	}
+	if secondSDK != nil {
+		relElem.SetSecond(secondSDK)
+	}
 	return relElem, nil
 }
 
@@ -880,36 +866,22 @@ func buildRelationshipElement(smeRow model.SubmodelElementRow) (types.ISubmodelE
 		return nil, err
 	}
 
-	var firstJsonable, secondJsonable map[string]any
-	if valueRow.First == nil {
-		return nil, fmt.Errorf("first reference in RelationshipElement is nil")
-	}
-	firstJsonable, err = parseReferenceJsonable(valueRow.First)
+	firstSDK, err := buildOptionalReference(valueRow.First, "first")
 	if err != nil {
 		return nil, err
 	}
-	if valueRow.Second == nil {
-		return nil, fmt.Errorf("second reference in RelationshipElement is nil")
-	}
-	secondJsonable, err = parseReferenceJsonable(valueRow.Second)
+	secondSDK, err := buildOptionalReference(valueRow.Second, "second")
 	if err != nil {
 		return nil, err
-	}
-
-	firstSDK, err := jsonization.ReferenceFromJsonable(firstJsonable)
-	if err != nil {
-		_, _ = fmt.Printf("[DEBUG] buildRelationshipElement First: JSON: %v, Error: %v\n", firstJsonable, err)
-		return nil, fmt.Errorf("error converting first jsonable to Reference: %w", err)
-	}
-	secondSDK, err := jsonization.ReferenceFromJsonable(secondJsonable)
-	if err != nil {
-		_, _ = fmt.Printf("[DEBUG] buildRelationshipElement Second: JSON: %v, Error: %v\n", secondJsonable, err)
-		return nil, fmt.Errorf("error converting second jsonable to Reference: %w", err)
 	}
 
 	relElem := types.NewRelationshipElement()
-	relElem.SetFirst(firstSDK)
-	relElem.SetSecond(secondSDK)
+	if firstSDK != nil {
+		relElem.SetFirst(firstSDK)
+	}
+	if secondSDK != nil {
+		relElem.SetSecond(secondSDK)
+	}
 	return relElem, nil
 }
 
@@ -979,6 +951,23 @@ func parseReferenceJsonable(raw []byte) (map[string]any, error) {
 	}
 
 	return normalizeReferenceJsonable(arrayPayload[0]), nil
+}
+
+func buildOptionalReference(raw []byte, fieldName string) (types.IReference, error) {
+	jsonable, err := parseReferenceJsonable(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(jsonable) == 0 {
+		return nil, nil
+	}
+
+	ref, err := jsonization.ReferenceFromJsonable(jsonable)
+	if err != nil {
+		_, _ = fmt.Printf("[DEBUG] buildOptionalReference %s: JSON: %v, Error: %v\n", fieldName, jsonable, err)
+		return nil, fmt.Errorf("error converting %s jsonable to Reference: %w", fieldName, err)
+	}
+	return ref, nil
 }
 
 func normalizeReferenceJsonable(payload map[string]any) map[string]any {

--- a/internal/common/builder/submodel_element_builder_test.go
+++ b/internal/common/builder/submodel_element_builder_test.go
@@ -1,0 +1,72 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package builder
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildRelationshipElementAllowsNullOptionalReferences(t *testing.T) {
+	t.Parallel()
+
+	value := json.RawMessage(`{"first":null,"second":null}`)
+	element, err := buildRelationshipElement(model.SubmodelElementRow{
+		IDShort:   sql.NullString{String: "SparseRelationship", Valid: true},
+		ModelType: int64(types.ModelTypeRelationshipElement),
+		Value:     &value,
+	})
+
+	require.NoError(t, err)
+
+	relationship, ok := element.(*types.RelationshipElement)
+	require.True(t, ok)
+	require.Nil(t, relationship.First())
+	require.Nil(t, relationship.Second())
+}
+
+func TestBuildAnnotatedRelationshipElementAllowsNullOptionalReferences(t *testing.T) {
+	t.Parallel()
+
+	value := json.RawMessage(`{"first":null,"second":null}`)
+	element, err := buildAnnotatedRelationshipElement(model.SubmodelElementRow{
+		IDShort:   sql.NullString{String: "SparseAnnotatedRelationship", Valid: true},
+		ModelType: int64(types.ModelTypeAnnotatedRelationshipElement),
+		Value:     &value,
+	})
+
+	require.NoError(t, err)
+
+	relationship, ok := element.(*types.AnnotatedRelationshipElement)
+	require.True(t, ok)
+	require.Nil(t, relationship.First())
+	require.Nil(t, relationship.Second())
+}

--- a/internal/common/model/grammar/logical_expression_to_sql.go
+++ b/internal/common/model/grammar/logical_expression_to_sql.go
@@ -1124,7 +1124,7 @@ func andBindingsForResolvedFieldPaths(resolved []ResolvedFieldPath, predicate ex
 			if b.Index.stringValue != nil {
 				if b.Alias == "submodel_element.idshort_path" && strings.HasSuffix(*b.Index.stringValue, "[]") {
 					prefix := strings.TrimSuffix(*b.Index.stringValue, "[]")
-					where = append(where, goqu.I(b.Alias).Like(goqu.L("? || '[%'", prefix)))
+					where = append(where, goqu.L("? LIKE ? ESCAPE '!'", goqu.I(b.Alias), escapeSQLLikePattern(prefix)+"[%"))
 					continue
 				}
 				where = append(where, goqu.I(b.Alias).Eq(*b.Index.stringValue))
@@ -1135,6 +1135,13 @@ func andBindingsForResolvedFieldPaths(resolved []ResolvedFieldPath, predicate ex
 		return goqu.L("1=1")
 	}
 	return goqu.And(where...)
+}
+
+func escapeSQLLikePattern(value string) string {
+	escaped := strings.ReplaceAll(value, "!", "!!")
+	escaped = strings.ReplaceAll(escaped, "%", "!%")
+	escaped = strings.ReplaceAll(escaped, "_", "!_")
+	return escaped
 }
 
 // wrapBindingsAsResolvedPath wraps bare array bindings into a minimal ResolvedFieldPath

--- a/internal/common/model/grammar/query_sme_sql_test.go
+++ b/internal/common/model/grammar/query_sme_sql_test.go
@@ -70,7 +70,7 @@ func TestQueryWrapper_SMECondition_ListWildcardValueType_ToSQL(t *testing.T) {
 		"Query": {
 			"$condition": {
 				"$eq": [
-					{"$field": "$sme.NewTestList[]#valueType"},
+					{"$field": "$sme.New_TestList[]#valueType"},
 					{"$strVal": "xs:string"}
 				]
 			}
@@ -105,7 +105,10 @@ func TestQueryWrapper_SMECondition_ListWildcardValueType_ToSQL(t *testing.T) {
 	if !strings.Contains(sql, `"submodel_element"."idshort_path" LIKE`) {
 		t.Fatalf("expected LIKE idshort_path constraint for [] wildcard, got: %s", sql)
 	}
-	if !argListContains(args, "NewTestList") {
-		t.Fatalf("expected args to contain %q prefix, got %#v", "NewTestList", args)
+	if !strings.Contains(sql, `ESCAPE`) {
+		t.Fatalf("expected ESCAPE clause for [] wildcard idshort_path constraint, got: %s", sql)
+	}
+	if !argListContains(args, "New!_TestList[%") {
+		t.Fatalf("expected args to contain escaped prefix, got %#v", args)
 	}
 }

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -835,6 +835,68 @@ func TestContractSubmodelRepository(t *testing.T) {
 		assert.Equal(t, "Property", createdElement["modelType"], "created payload should contain modelType")
 	})
 
+	t.Run("DeleteSubmodelElementListEntryWithoutIDShortCompactsRemainingEntries", func(t *testing.T) {
+		submodelID := fmt.Sprintf("https://example.com/ids/sm/contract-delete-list-entry-%d", time.Now().UnixNano())
+		submodelIDShort := fmt.Sprintf("contractDeleteListEntry%d", time.Now().UnixNano())
+		encodedSubmodelID := createSubmodel(t, submodelID, submodelIDShort)
+
+		listEntries := make([]map[string]any, 0, 50)
+		for i := range 50 {
+			listEntries = append(listEntries, map[string]any{
+				"modelType": "Property",
+				"valueType": "xs:string",
+				"value":     fmt.Sprintf("list-entry-%02d", i),
+			})
+		}
+
+		statusCode, body, err := requestJSON(http.MethodPost, fmt.Sprintf("%s/submodels/%s/submodel-elements", baseURL, encodedSubmodelID), map[string]any{
+			"idShort":              "LargeUnnamedList",
+			"modelType":            "SubmodelElementList",
+			"typeValueListElement": "Property",
+			"valueTypeListElement": "xs:string",
+			"value":                listEntries,
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
+
+		for _, deleteIndex := range []int{17, 3, 42} {
+			deletePath := fmt.Sprintf("LargeUnnamedList[%d]", deleteIndex)
+			statusCode, body, err = requestJSON(http.MethodDelete, fmt.Sprintf("%s/submodels/%s/submodel-elements/%s", baseURL, encodedSubmodelID, deletePath), nil)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusNoContent, statusCode, "deletePath=%s response=%s", deletePath, string(body))
+		}
+
+		statusCode, body, err = requestJSON(http.MethodGet, fmt.Sprintf("%s/submodels/%s/submodel-elements/LargeUnnamedList", baseURL, encodedSubmodelID), nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
+
+		var listElement map[string]any
+		require.NoError(t, json.Unmarshal(body, &listElement), "response=%s", string(body))
+		remainingEntries, ok := listElement["value"].([]any)
+		require.True(t, ok, "list value must be an array")
+		require.Len(t, remainingEntries, 47)
+	})
+
+	t.Run("PostAnnotatedRelationshipElementReturnsCreatedPayload", func(t *testing.T) {
+		submodelID := fmt.Sprintf("https://example.com/ids/sm/contract-post-annotated-relationship-%d", time.Now().UnixNano())
+		submodelIDShort := fmt.Sprintf("contractPostAnnotatedRelationship%d", time.Now().UnixNano())
+		encodedSubmodelID := createSubmodel(t, submodelID, submodelIDShort)
+
+		payload := map[string]any{
+			"idShort":   "CreatedAnnotatedRelationship",
+			"modelType": "AnnotatedRelationshipElement",
+		}
+
+		statusCode, body, err := requestJSON(http.MethodPost, fmt.Sprintf("%s/submodels/%s/submodel-elements", baseURL, encodedSubmodelID), payload)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
+
+		var createdElement map[string]any
+		require.NoError(t, json.Unmarshal(body, &createdElement), "response=%s", string(body))
+		assert.Equal(t, "CreatedAnnotatedRelationship", createdElement["idShort"])
+		assert.Equal(t, "AnnotatedRelationshipElement", createdElement["modelType"])
+	})
+
 	t.Run("GetSubmodelByIDDoesNotExposeEmptySubmodelElementsArray", func(t *testing.T) {
 		submodelID := fmt.Sprintf("https://example.com/ids/sm/contract-empty-elements-%d", time.Now().UnixNano())
 		submodelIDShort := fmt.Sprintf("contractEmptyElements%d", time.Now().UnixNano())

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -877,6 +877,89 @@ func TestContractSubmodelRepository(t *testing.T) {
 		require.Len(t, remainingEntries, 47)
 	})
 
+	t.Run("DeleteSubmodelElementListEntryEscapesLikeWildcardPathsWhenCompacting", func(t *testing.T) {
+		submodelID := fmt.Sprintf("https://example.com/ids/sm/contract-delete-list-like-escape-%d", time.Now().UnixNano())
+		submodelIDShort := fmt.Sprintf("contractDeleteListLikeEscape%d", time.Now().UnixNano())
+		encodedSubmodelID := createSubmodel(t, submodelID, submodelIDShort)
+
+		statusCode, body, err := requestJSON(http.MethodPost, fmt.Sprintf("%s/submodels/%s/submodel-elements", baseURL, encodedSubmodelID), map[string]any{
+			"idShort":              "A_B",
+			"modelType":            "SubmodelElementList",
+			"typeValueListElement": "Property",
+			"valueTypeListElement": "xs:string",
+			"value": []map[string]any{
+				{
+					"modelType": "Property",
+					"valueType": "xs:string",
+					"value":     "deleted",
+				},
+				{
+					"modelType": "Property",
+					"valueType": "xs:string",
+					"value":     "moved",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
+
+		statusCode, body, err = requestJSON(http.MethodPost, fmt.Sprintf("%s/submodels/%s/submodel-elements", baseURL, encodedSubmodelID), map[string]any{
+			"idShort":              "AxB",
+			"modelType":            "SubmodelElementList",
+			"typeValueListElement": "SubmodelElementCollection",
+			"value": []map[string]any{
+				{
+					"modelType": "SubmodelElementCollection",
+					"value": []map[string]any{
+						{
+							"idShort":   "Nested",
+							"modelType": "Property",
+							"valueType": "xs:string",
+							"value":     "other-0",
+						},
+					},
+				},
+				{
+					"modelType": "SubmodelElementCollection",
+					"value": []map[string]any{
+						{
+							"idShort":   "Nested",
+							"modelType": "Property",
+							"valueType": "xs:string",
+							"value":     "other-1",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
+
+		statusCode, body, err = requestJSON(http.MethodGet, fmt.Sprintf("%s/submodels/%s/submodel-elements/AxB[1].Nested", baseURL, encodedSubmodelID), nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
+
+		statusCode, body, err = requestJSON(http.MethodDelete, fmt.Sprintf("%s/submodels/%s/submodel-elements/A_B[0]", baseURL, encodedSubmodelID), nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, statusCode, "response=%s", string(body))
+
+		statusCode, body, err = requestJSON(http.MethodGet, fmt.Sprintf("%s/submodels/%s/submodel-elements/A_B[0]", baseURL, encodedSubmodelID), nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
+
+		var movedProperty map[string]any
+		require.NoError(t, json.Unmarshal(body, &movedProperty), "response=%s", string(body))
+		assert.Equal(t, "moved", movedProperty["value"])
+
+		statusCode, body, err = requestJSON(http.MethodGet, fmt.Sprintf("%s/submodels/%s/submodel-elements/AxB[1].Nested", baseURL, encodedSubmodelID), nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
+
+		var unrelatedProperty map[string]any
+		require.NoError(t, json.Unmarshal(body, &unrelatedProperty), "response=%s", string(body))
+		assert.Equal(t, "other-1", unrelatedProperty["value"])
+	})
+
 	t.Run("PostAnnotatedRelationshipElementReturnsCreatedPayload", func(t *testing.T) {
 		submodelID := fmt.Sprintf("https://example.com/ids/sm/contract-post-annotated-relationship-%d", time.Now().UnixNano())
 		submodelIDShort := fmt.Sprintf("contractPostAnnotatedRelationship%d", time.Now().UnixNano())

--- a/internal/submodelrepository/persistence/submodelElements/AnnotatedRelationshipElementHandler.go
+++ b/internal/submodelrepository/persistence/submodelElements/AnnotatedRelationshipElementHandler.go
@@ -324,18 +324,18 @@ func (p PostgreSQLAnnotatedRelationshipElementHandler) GetInsertQueryPart(_ *sql
 	}, nil
 }
 
-func serializeReference(ref types.IReference, json jsoniter.API) (string, error) {
-	var firstRef string
-	if !isEmptyReference(ref) {
-		jsonable, err := jsonization.ToJsonable(ref)
-		if err != nil {
-			return "", common.NewErrBadRequest("SMREPO-SERREF-JSONABLE Failed to convert reference to jsonable: " + err.Error())
-		}
-		refBytes, err := json.Marshal(jsonable)
-		if err != nil {
-			return "", err
-		}
-		firstRef = string(refBytes)
+func serializeReference(ref types.IReference, json jsoniter.API) (any, error) {
+	if isEmptyReference(ref) {
+		return nil, nil
 	}
-	return firstRef, nil
+
+	jsonable, err := jsonization.ToJsonable(ref)
+	if err != nil {
+		return nil, common.NewErrBadRequest("SMREPO-SERREF-JSONABLE Failed to convert reference to jsonable: " + err.Error())
+	}
+	refBytes, err := json.Marshal(jsonable)
+	if err != nil {
+		return nil, err
+	}
+	return string(refBytes), nil
 }

--- a/internal/submodelrepository/persistence/submodelElements/RelationshipElementHandler.go
+++ b/internal/submodelrepository/persistence/submodelElements/RelationshipElementHandler.go
@@ -34,7 +34,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/FriedJannik/aas-go-sdk/jsonization"
 	"github.com/FriedJannik/aas-go-sdk/types"
 	"github.com/doug-martin/goqu/v9"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
@@ -257,31 +256,16 @@ func (p PostgreSQLRelationshipElementHandler) GetInsertQueryPart(_ *sql.Tx, id i
 		return nil, common.NewErrBadRequest("submodelElement is not of type RelationshipElement")
 	}
 
-	var firstRef, secondRef string
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-	if !isEmptyReference(relElem.First()) {
-		jsonable, err := jsonization.ToJsonable(relElem.First())
-		if err != nil {
-			return nil, common.NewErrBadRequest("SMREPO-GIQP-RELEL-FIRSTJSON Failed to convert first reference to jsonable: " + err.Error())
-		}
-		ref, err := json.Marshal(jsonable)
-		if err != nil {
-			return nil, err
-		}
-		firstRef = string(ref)
+	firstRef, err := serializeReference(relElem.First(), json)
+	if err != nil {
+		return nil, err
 	}
 
-	if !isEmptyReference(relElem.Second()) {
-		jsonable, err := jsonization.ToJsonable(relElem.Second())
-		if err != nil {
-			return nil, common.NewErrBadRequest("SMREPO-GIQP-RELEL-SECONDJSON Failed to convert second reference to jsonable: " + err.Error())
-		}
-		ref, err := json.Marshal(jsonable)
-		if err != nil {
-			return nil, err
-		}
-		secondRef = string(ref)
+	secondRef, err := serializeReference(relElem.Second(), json)
+	if err != nil {
+		return nil, err
 	}
 
 	return &InsertQueryPart{
@@ -301,17 +285,9 @@ func buildUpdateRelationshipElementRecordObject(isPut bool, relElem types.IRelat
 	// For PUT: always update (even if nil, which clears the field)
 	// For PATCH: only update if provided (not nil)
 	if isPut || relElem.First() != nil {
-		var firstRef string
-		if relElem.First() != nil && !isEmptyReference(relElem.First()) {
-			jsonable, err := jsonization.ToJsonable(relElem.First())
-			if err != nil {
-				return nil, common.NewErrBadRequest("SMREPO-BURERO-FIRSTJSONABLE Failed to convert first reference to jsonable: " + err.Error())
-			}
-			ref, err := json.Marshal(jsonable)
-			if err != nil {
-				return nil, err
-			}
-			firstRef = string(ref)
+		firstRef, err := serializeReference(relElem.First(), json)
+		if err != nil {
+			return nil, err
 		}
 		updateRecord["first"] = firstRef
 	}
@@ -320,17 +296,9 @@ func buildUpdateRelationshipElementRecordObject(isPut bool, relElem types.IRelat
 	// For PUT: always update (even if nil, which clears the field)
 	// For PATCH: only update if provided (not nil)
 	if isPut || relElem.Second() != nil {
-		var secondRef string
-		if relElem.Second() != nil && !isEmptyReference(relElem.Second()) {
-			jsonable, err := jsonization.ToJsonable(relElem.Second())
-			if err != nil {
-				return nil, common.NewErrBadRequest("SMREPO-BURERO-SECONDJSONABLE Failed to convert second reference to jsonable: " + err.Error())
-			}
-			ref, err := json.Marshal(jsonable)
-			if err != nil {
-				return nil, err
-			}
-			secondRef = string(ref)
+		secondRef, err := serializeReference(relElem.Second(), json)
+		if err != nil {
+			return nil, err
 		}
 		updateRecord["second"] = secondRef
 	}

--- a/internal/submodelrepository/persistence/submodelElements/SMECrudHandler.go
+++ b/internal/submodelrepository/persistence/submodelElements/SMECrudHandler.go
@@ -689,7 +689,7 @@ func ResolveUpdatedPath(idShortOrPath string, submodelElement types.ISubmodelEle
 // It uses PostgreSQL's OVERLAY function to replace the old prefix portion with the new prefix,
 // ensuring only the exact prefix is replaced without affecting similar-prefix siblings.
 func updateChildPaths(tx *sql.Tx, dialect goqu.DialectWrapper, submodelDatabaseID int, oldPath string, newPath string, separator string) error {
-	likePattern := oldPath + separator + "%"
+	likePattern := escapeSQLLikePattern(oldPath) + separator + "%"
 	oldPrefixLen := len(oldPath)
 
 	// SET idshort_path = newPath || SUBSTRING(idshort_path FROM oldPrefixLen+1)
@@ -705,7 +705,7 @@ func updateChildPaths(tx *sql.Tx, dialect goqu.DialectWrapper, submodelDatabaseI
 		}).
 		Where(
 			goqu.C("submodel_id").Eq(submodelDatabaseID),
-			goqu.C("idshort_path").Like(likePattern),
+			idShortPathLikeEscaped(goqu.C("idshort_path"), likePattern),
 		).
 		ToSQL()
 	if err != nil {

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
@@ -319,13 +319,14 @@ func DeleteSubmodelElementByPath(tx *sql.Tx, submodelID string, idShortOrPath st
 }
 
 func deleteSubmodelElementTree(tx *sql.Tx, submodelDatabaseID int, idShortOrPath string) (int64, error) {
+	escapedPath := escapeSQLLikePattern(idShortOrPath)
 	del := goqu.Delete("submodel_element").Where(
 		goqu.And(
 			goqu.I("submodel_id").Eq(submodelDatabaseID),
 			goqu.Or(
 				goqu.I("idshort_path").Eq(idShortOrPath),
-				goqu.I("idshort_path").Like(idShortOrPath+".%"),
-				goqu.I("idshort_path").Like(idShortOrPath+"[%"),
+				idShortPathLikeEscaped(goqu.I("idshort_path"), escapedPath+".%"),
+				idShortPathLikeEscaped(goqu.I("idshort_path"), escapedPath+"[%"),
 			),
 		),
 	)
@@ -457,8 +458,20 @@ func moveListChildOneSlotLeft(tx *sql.Tx, submodelDatabaseID int, parentPath str
 	return updateListChildPosition(tx, submodelDatabaseID, child.id, newPosition)
 }
 
+func escapeSQLLikePattern(value string) string {
+	escaped := strings.ReplaceAll(value, "!", "!!")
+	escaped = strings.ReplaceAll(escaped, "%", "!%")
+	escaped = strings.ReplaceAll(escaped, "_", "!_")
+	return escaped
+}
+
+func idShortPathLikeEscaped(idShortPath goqu.Expression, pattern string) goqu.Expression {
+	return goqu.L("? LIKE ? ESCAPE '!'", idShortPath, pattern)
+}
+
 func updateListChildPath(tx *sql.Tx, submodelDatabaseID int, oldPath string, newPath string) error {
 	dialect := goqu.Dialect("postgres")
+	escapedOldPath := escapeSQLLikePattern(oldPath)
 	query, args, err := dialect.Update("submodel_element").
 		Set(goqu.Record{
 			"idshort_path": goqu.L("? || SUBSTRING(idshort_path FROM ?)", newPath, len(oldPath)+1),
@@ -467,8 +480,8 @@ func updateListChildPath(tx *sql.Tx, submodelDatabaseID int, oldPath string, new
 			goqu.C("submodel_id").Eq(submodelDatabaseID),
 			goqu.Or(
 				goqu.C("idshort_path").Eq(oldPath),
-				goqu.C("idshort_path").Like(oldPath+".%"),
-				goqu.C("idshort_path").Like(oldPath+"[%"),
+				idShortPathLikeEscaped(goqu.C("idshort_path"), escapedOldPath+".%"),
+				idShortPathLikeEscaped(goqu.C("idshort_path"), escapedOldPath+"[%"),
 			),
 		).
 		ToSQL()
@@ -529,14 +542,14 @@ func DeleteAllChildren(db *sql.DB, submodelId string, idShortPath string, tx *sq
 		return common.NewInternalServerError("SMREPO-DELALLCHILDREN-GETSMDATABASEID Failed to resolve Submodel database ID: " + err.Error())
 	}
 
-	// Delete All Elements that start with idShortPath + "." or with idShortPath + "["
+	escapedPath := escapeSQLLikePattern(idShortPath)
 
 	del := goqu.Delete("submodel_element").Where(
 		goqu.And(
 			goqu.I("submodel_id").Eq(submodelDatabaseID),
 			goqu.Or(
-				goqu.I("idshort_path").Like(idShortPath+".%"),
-				goqu.I("idshort_path").Like(idShortPath+"[%"),
+				idShortPathLikeEscaped(goqu.I("idshort_path"), escapedPath+".%"),
+				idShortPathLikeEscaped(goqu.I("idshort_path"), escapedPath+"[%"),
 			),
 		),
 	)

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
@@ -37,6 +37,7 @@ import (
 	"database/sql"
 	"errors"
 	"strconv"
+	"strings"
 
 	"github.com/FriedJannik/aas-go-sdk/types"
 	"github.com/doug-martin/goqu/v9"
@@ -298,6 +299,26 @@ func DeleteSubmodelElementByPath(tx *sql.Tx, submodelID string, idShortOrPath st
 		return common.NewInternalServerError("SMREPO-DELSMEBPATH-GETSMDATABASEID Failed to resolve Submodel database ID: " + err.Error())
 	}
 
+	affectedRows, err := deleteSubmodelElementTree(tx, submodelDatabaseID, idShortOrPath)
+	if err != nil {
+		return err
+	}
+	if affectedRows == 0 {
+		return common.NewErrNotFound("SMREPO-DELSMEBPATH-NOTFOUND Submodel-Element ID-Short: " + idShortOrPath)
+	}
+
+	if !isListElementPath(idShortOrPath) {
+		return nil
+	}
+
+	parentPath, deletedIndex, err := splitListElementPath(idShortOrPath)
+	if err != nil {
+		return err
+	}
+	return compactListAfterDelete(tx, submodelDatabaseID, parentPath, deletedIndex)
+}
+
+func deleteSubmodelElementTree(tx *sql.Tx, submodelDatabaseID int, idShortOrPath string) (int64, error) {
 	del := goqu.Delete("submodel_element").Where(
 		goqu.And(
 			goqu.I("submodel_id").Eq(submodelDatabaseID),
@@ -310,89 +331,172 @@ func DeleteSubmodelElementByPath(tx *sql.Tx, submodelID string, idShortOrPath st
 	)
 	sqlQuery, args, err := del.ToSQL()
 	if err != nil {
-		return common.NewInternalServerError("SMREPO-DELSMEBPATH-TOSQL Failed to build delete query: " + err.Error())
+		return 0, common.NewInternalServerError("SMREPO-DELSMEBPATH-TOSQL Failed to build delete query: " + err.Error())
 	}
 	result, err := tx.Exec(sqlQuery, args...)
 	if err != nil {
-		return common.NewInternalServerError("SMREPO-DELSMEBPATH-EXEC Failed to execute delete query: " + err.Error())
+		return 0, common.NewInternalServerError("SMREPO-DELSMEBPATH-EXEC Failed to execute delete query: " + err.Error())
 	}
 	affectedRows, err := result.RowsAffected()
 	if err != nil {
-		return common.NewInternalServerError("SMREPO-DELSMEBPATH-ROWSAFFECTED Failed to get affected rows: " + err.Error())
+		return 0, common.NewInternalServerError("SMREPO-DELSMEBPATH-ROWSAFFECTED Failed to get affected rows: " + err.Error())
 	}
-	// if idShortPath ends with ] it is part of a SubmodelElementList and we need to update the indices of the remaining elements
-	if idShortOrPath[len(idShortOrPath)-1] == ']' {
-		// extract the parent path and the index of the deleted element
-		var parentPath string
-		var deletedIndex int
-		for i := len(idShortOrPath) - 1; i >= 0; i-- {
-			if idShortOrPath[i] == '[' {
-				parentPath = idShortOrPath[:i]
-				indexStr := idShortOrPath[i+1 : len(idShortOrPath)-1]
-				var err error
-				deletedIndex, err = strconv.Atoi(indexStr)
-				if err != nil {
-					return common.NewInternalServerError("SMREPO-DELSMEBPATH-PARSEINDEX Failed to parse index: " + err.Error())
-				}
-				break
-			}
-		}
+	return affectedRows, nil
+}
 
-		// get the id of the parent SubmodelElementList
-		dialect := goqu.Dialect("postgres")
-		selectQuery, selectArgs, err := dialect.From("submodel_element").
-			Select("id").
-			Where(goqu.And(
-				goqu.C("submodel_id").Eq(submodelDatabaseID),
-				goqu.C("idshort_path").Eq(parentPath),
-			)).
-			ToSQL()
-		if err != nil {
-			return common.NewInternalServerError("SMREPO-DELSMEBPATH-SELECTPARENT-TOSQL Failed to build select query: " + err.Error())
-		}
+func isListElementPath(idShortPath string) bool {
+	return strings.HasSuffix(idShortPath, "]")
+}
 
-		var parentID int
-		err = tx.QueryRow(selectQuery, selectArgs...).Scan(&parentID)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return common.NewErrNotFound("SMREPO-DELSMEBPATH-SELECTPARENT-NOTFOUND Parent ID-Short: " + parentPath)
-			}
-			return common.NewInternalServerError("SMREPO-DELSMEBPATH-SELECTPARENT-EXEC Failed to execute select query: " + err.Error())
-		}
+func splitListElementPath(idShortPath string) (string, int, error) {
+	indexStart := strings.LastIndex(idShortPath, "[")
+	if indexStart < 0 {
+		return "", 0, common.NewInternalServerError("SMREPO-DELSMEBPATH-PARSEINDEX Missing list index in path: " + idShortPath)
+	}
 
-		// update the indices of the remaining elements in the SubmodelElementList
-		updateQuery, updateArgs, err := dialect.Update("submodel_element").
-			Set(goqu.Record{"position": goqu.L("position - 1")}).
-			Where(goqu.And(
-				goqu.C("parent_sme_id").Eq(parentID),
-				goqu.C("position").Gt(deletedIndex),
-			)).
-			ToSQL()
-		if err != nil {
-			return common.NewInternalServerError("SMREPO-DELSMEBPATH-UPDATEINDICES-TOSQL Failed to build update query: " + err.Error())
-		}
-		_, err = tx.Exec(updateQuery, updateArgs...)
-		if err != nil {
-			return common.NewInternalServerError("SMREPO-DELSMEBPATH-UPDATEINDICES-EXEC Failed to execute update query: " + err.Error())
-		}
-		// update their idshort_path as well
-		updatePathQuery, updatePathArgs, err := dialect.Update("submodel_element").
-			Set(goqu.Record{"idshort_path": goqu.L("regexp_replace(idshort_path, '\\[' || (position + 1) || '\\]', '[' || position || ']')")}).
-			Where(goqu.And(
-				goqu.C("parent_sme_id").Eq(parentID),
-				goqu.C("position").Gte(deletedIndex),
-			)).
-			ToSQL()
-		if err != nil {
-			return common.NewInternalServerError("SMREPO-DELSMEBPATH-UPDATEPATH-TOSQL Failed to build update path query: " + err.Error())
-		}
-		_, err = tx.Exec(updatePathQuery, updatePathArgs...)
-		if err != nil {
-			return common.NewInternalServerError("SMREPO-DELSMEBPATH-UPDATEPATH-EXEC Failed to execute update path query: " + err.Error())
+	deletedIndex, err := strconv.Atoi(idShortPath[indexStart+1 : len(idShortPath)-1])
+	if err != nil {
+		return "", 0, common.NewInternalServerError("SMREPO-DELSMEBPATH-PARSEINDEX Failed to parse index: " + err.Error())
+	}
+	return idShortPath[:indexStart], deletedIndex, nil
+}
+
+type listChildToCompact struct {
+	id          int
+	oldPath     string
+	oldPosition int
+}
+
+func compactListAfterDelete(tx *sql.Tx, submodelDatabaseID int, parentPath string, deletedIndex int) error {
+	parentID, err := getListParentID(tx, submodelDatabaseID, parentPath)
+	if err != nil {
+		return err
+	}
+
+	children, err := getListChildrenAfterDeletedIndex(tx, submodelDatabaseID, parentID, deletedIndex)
+	if err != nil {
+		return err
+	}
+
+	for _, child := range children {
+		if err = moveListChildOneSlotLeft(tx, submodelDatabaseID, parentPath, child); err != nil {
+			return err
 		}
 	}
-	if affectedRows == 0 {
-		return common.NewErrNotFound("SMREPO-DELSMEBPATH-NOTFOUND Submodel-Element ID-Short: " + idShortOrPath)
+	return nil
+}
+
+func getListParentID(tx *sql.Tx, submodelDatabaseID int, parentPath string) (int, error) {
+	dialect := goqu.Dialect("postgres")
+	selectQuery, selectArgs, err := dialect.From("submodel_element").
+		Select("id").
+		Where(
+			goqu.C("submodel_id").Eq(submodelDatabaseID),
+			goqu.C("idshort_path").Eq(parentPath),
+		).
+		ToSQL()
+	if err != nil {
+		return 0, common.NewInternalServerError("SMREPO-DELSMEBPATH-SELECTPARENT-TOSQL Failed to build select query: " + err.Error())
+	}
+
+	var parentID int
+	err = tx.QueryRow(selectQuery, selectArgs...).Scan(&parentID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, common.NewErrNotFound("SMREPO-DELSMEBPATH-SELECTPARENT-NOTFOUND Parent ID-Short: " + parentPath)
+		}
+		return 0, common.NewInternalServerError("SMREPO-DELSMEBPATH-SELECTPARENT-EXEC Failed to execute select query: " + err.Error())
+	}
+	return parentID, nil
+}
+
+func getListChildrenAfterDeletedIndex(tx *sql.Tx, submodelDatabaseID int, parentID int, deletedIndex int) ([]listChildToCompact, error) {
+	dialect := goqu.Dialect("postgres")
+	query, args, err := dialect.From("submodel_element").
+		Select("id", "idshort_path", "position").
+		Where(
+			goqu.C("submodel_id").Eq(submodelDatabaseID),
+			goqu.C("parent_sme_id").Eq(parentID),
+			goqu.C("position").Gt(deletedIndex),
+		).
+		Order(goqu.C("position").Asc()).
+		ToSQL()
+	if err != nil {
+		return nil, common.NewInternalServerError("SMREPO-DELSMEBPATH-SELECTSIBLINGS-TOSQL Failed to build sibling query: " + err.Error())
+	}
+
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, common.NewInternalServerError("SMREPO-DELSMEBPATH-SELECTSIBLINGS-EXEC Failed to execute sibling query: " + err.Error())
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	children := make([]listChildToCompact, 0)
+	for rows.Next() {
+		var child listChildToCompact
+		if err = rows.Scan(&child.id, &child.oldPath, &child.oldPosition); err != nil {
+			return nil, common.NewInternalServerError("SMREPO-DELSMEBPATH-SELECTSIBLINGS-SCAN Failed to scan sibling row: " + err.Error())
+		}
+		children = append(children, child)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, common.NewInternalServerError("SMREPO-DELSMEBPATH-SELECTSIBLINGS-ROWS Failed to read sibling rows: " + err.Error())
+	}
+	return children, nil
+}
+
+func moveListChildOneSlotLeft(tx *sql.Tx, submodelDatabaseID int, parentPath string, child listChildToCompact) error {
+	newPosition := child.oldPosition - 1
+	newPath := parentPath + "[" + strconv.Itoa(newPosition) + "]"
+
+	if err := updateListChildPath(tx, submodelDatabaseID, child.oldPath, newPath); err != nil {
+		return err
+	}
+	return updateListChildPosition(tx, submodelDatabaseID, child.id, newPosition)
+}
+
+func updateListChildPath(tx *sql.Tx, submodelDatabaseID int, oldPath string, newPath string) error {
+	dialect := goqu.Dialect("postgres")
+	query, args, err := dialect.Update("submodel_element").
+		Set(goqu.Record{
+			"idshort_path": goqu.L("? || SUBSTRING(idshort_path FROM ?)", newPath, len(oldPath)+1),
+		}).
+		Where(
+			goqu.C("submodel_id").Eq(submodelDatabaseID),
+			goqu.Or(
+				goqu.C("idshort_path").Eq(oldPath),
+				goqu.C("idshort_path").Like(oldPath+".%"),
+				goqu.C("idshort_path").Like(oldPath+"[%"),
+			),
+		).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("SMREPO-DELSMEBPATH-UPDATEPATH-TOSQL Failed to build update path query: " + err.Error())
+	}
+
+	if _, err = tx.Exec(query, args...); err != nil {
+		return common.NewInternalServerError("SMREPO-DELSMEBPATH-UPDATEPATH-EXEC Failed to execute update path query: " + err.Error())
+	}
+	return nil
+}
+
+func updateListChildPosition(tx *sql.Tx, submodelDatabaseID int, childID int, newPosition int) error {
+	dialect := goqu.Dialect("postgres")
+	query, args, err := dialect.Update("submodel_element").
+		Set(goqu.Record{"position": newPosition}).
+		Where(
+			goqu.C("submodel_id").Eq(submodelDatabaseID),
+			goqu.C("id").Eq(childID),
+		).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("SMREPO-DELSMEBPATH-UPDATEPOSITION-TOSQL Failed to build update position query: " + err.Error())
+	}
+
+	if _, err = tx.Exec(query, args...); err != nil {
+		return common.NewInternalServerError("SMREPO-DELSMEBPATH-UPDATEPOSITION-EXEC Failed to execute update position query: " + err.Error())
 	}
 	return nil
 }

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
@@ -1099,12 +1099,13 @@ func readSubmodelElementRowsByPath(ctx context.Context, db dbQueryer, submodelDa
 		}, maskRuntime.Projections()...)...)
 
 	if includeChildren {
+		escapedPath := escapeSQLLikePattern(idShortOrPath)
 		innerQuery = innerQuery.Where(
 			goqu.I("sme.submodel_id").Eq(submodelDatabaseID),
 			goqu.Or(
 				goqu.I("sme.idshort_path").Eq(idShortOrPath),
-				goqu.I("sme.idshort_path").Like(goqu.L("? || '.%'", idShortOrPath)),
-				goqu.I("sme.idshort_path").Like(goqu.L("? || '[%'", idShortOrPath)),
+				idShortPathLikeEscaped(goqu.I("sme.idshort_path"), escapedPath+".%"),
+				idShortPathLikeEscaped(goqu.I("sme.idshort_path"), escapedPath+"[%"),
 			),
 		)
 	} else {

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
@@ -42,3 +42,12 @@ func TestBuildSubmodelElementReferenceBuildsKeyChainForNestedDotPath(t *testing.
 	require.Equal(t, types.KeyTypesProperty, keys[2].Type())
 	require.Equal(t, "child", keys[2].Value())
 }
+
+func TestEscapeSQLLikePatternEscapesWildcardCharacters(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "A!_B", escapeSQLLikePattern("A_B"))
+	require.Equal(t, "A!%B", escapeSQLLikePattern("A%B"))
+	require.Equal(t, "A!!B", escapeSQLLikePattern("A!B"))
+	require.Equal(t, "A!!B!_C!%", escapeSQLLikePattern("A!B_C%"))
+}


### PR DESCRIPTION
## Description of Changes

This PR fixes two Submodel Repository issues:

Deleting elements from a SubmodelElementList could fail with a duplicate key error on uq_sibling_idshort.
The delete flow now safely compacts list entries after a deleted index.
Instead of bulk-updating all remaining paths at once, affected children are selected and shifted one by one.
This prevents temporary idShortPath collisions while preserving the correct list order.
Creating sparse AnnotatedRelationshipElement / RelationshipElement payloads could fail with invalid JSON errors.
Missing first / second references are now stored as SQL NULL instead of an empty string.
The builder now treats missing references as optional when reconstructing relationship elements from the database.
Regression tests were added for both cases.
