### PR TITLE
Enhance ABAC with deterministic matched rule IDs for audit enrichment

### DIFF
--- a/examples/BaSyxHistoryAuditGuardedExample/README.md
+++ b/examples/BaSyxHistoryAuditGuardedExample/README.md
@@ -131,7 +131,7 @@ docker compose exec db psql -U admin -d basyxTestDB -c \
     LIMIT 5"
 ```
 
-For the authenticated API mutation, expect `actor_subject` and `actor_issuer` from Keycloak, `client_id` from the OIDC client, `authorization_result=ALLOW`, the request/correlation headers from the `curl` command, and the route/method that produced the row. `matched_rule_id` is empty in this example until the ABAC evaluator exposes deterministic rule IDs.
+For the authenticated API mutation, expect `actor_subject` and `actor_issuer` from Keycloak, `client_id` from the OIDC client, `authorization_result=ALLOW`, the request/correlation headers from the `curl` command, and the route/method that produced the row. `matched_rule_id` contains deterministic ABAC rule identifiers such as `rule:2:<hash-prefix>`; when multiple allow rules match, the identifiers are stored comma-separated in configured rule order.
 
 ## What Guarded Mode Does
 

--- a/internal/common/canonical_json.go
+++ b/internal/common/canonical_json.go
@@ -1,0 +1,239 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// CanonicalJSONHash returns a SHA-256 hash over CanonicalJSON(value).
+//
+// Use this helper when JSON-compatible values need stable digests independent
+// of Go map iteration order or input object-key order. Raw JSON inputs are
+// parsed before hashing so insignificant whitespace and object-key ordering do
+// not affect the returned digest. JSON numbers are decoded with json.Number to
+// avoid lossy float64 coercion for large integers.
+//
+// Parameters:
+//   - value: JSON-compatible value, raw JSON bytes, or json.RawMessage to hash.
+//
+// Returns:
+//   - string: Lowercase hexadecimal SHA-256 digest.
+//   - error: Error when value cannot be normalized or encoded as canonical JSON.
+//
+// Example:
+//
+//	hash, err := common.CanonicalJSONHash(map[string]any{"id": identifier})
+//	if err != nil {
+//		return err
+//	}
+//	return hash, nil
+func CanonicalJSONHash(value any) (string, error) {
+	canonical, err := CanonicalJSON(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// CanonicalJSON encodes JSON values with stable object-key ordering.
+//
+// The encoder normalizes typed values, raw JSON bytes, and json.RawMessage into
+// JSON data, then writes objects with sorted keys. Array order and scalar values
+// are preserved. The result is intended for hashes, signatures, and audit
+// artifacts where semantically equivalent JSON must produce identical bytes.
+//
+// Parameters:
+//   - value: JSON-compatible value, raw JSON bytes, or json.RawMessage to encode.
+//
+// Returns:
+//   - []byte: Canonical JSON representation.
+//   - error: Error when value cannot be normalized or encoded.
+//
+// Example:
+//
+//	canonical, err := common.CanonicalJSON(payload)
+//	if err != nil {
+//		return nil, err
+//	}
+//	return canonical, nil
+func CanonicalJSON(value any) ([]byte, error) {
+	normalized, err := normalizeJSONValue(value)
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	if err = writeCanonicalJSON(&out, normalized); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+// DecodeJSONPreservingNumbers decodes one JSON document without coercing numbers to float64.
+//
+// The decoder rejects malformed JSON and multiple concatenated JSON documents.
+// Numeric values are returned as json.Number so callers can preserve exact
+// lexical number text during canonicalization or database round trips.
+//
+// Parameters:
+//   - raw: JSON document bytes to decode.
+//   - target: Pointer to the value that should receive the decoded document.
+//
+// Returns:
+//   - error: Error when the input is invalid JSON, contains trailing JSON
+//     values, or cannot be assigned to target.
+//
+// Example:
+//
+//	var payload map[string]any
+//	if err := common.DecodeJSONPreservingNumbers(raw, &payload); err != nil {
+//		return err
+//	}
+//	return payload, nil
+func DecodeJSONPreservingNumbers(raw []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values in payload")
+		}
+		return err
+	}
+	return nil
+}
+
+func normalizeJSONValue(value any) (any, error) {
+	switch typed := value.(type) {
+	case json.RawMessage:
+		return decodeNormalizedJSON(typed)
+	case []byte:
+		return decodeNormalizedJSON(typed)
+	default:
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		return decodeNormalizedJSON(encoded)
+	}
+}
+
+func decodeNormalizedJSON(raw []byte) (any, error) {
+	var normalized any
+	if err := DecodeJSONPreservingNumbers(raw, &normalized); err != nil {
+		return nil, err
+	}
+	return normalized, nil
+}
+
+func writeCanonicalJSON(out *bytes.Buffer, value any) error {
+	switch typed := value.(type) {
+	case map[string]any:
+		return writeCanonicalObject(out, typed)
+	case []any:
+		return writeCanonicalArray(out, typed)
+	default:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Errorf("marshal scalar: %w", err)
+		}
+		return writeCanonicalBytes(out, encoded)
+	}
+}
+
+func writeCanonicalObject(out *bytes.Buffer, value map[string]any) error {
+	if err := writeCanonicalByte(out, '{'); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for index, key := range keys {
+		if index > 0 {
+			if err := writeCanonicalByte(out, ','); err != nil {
+				return err
+			}
+		}
+		keyJSON, err := json.Marshal(key)
+		if err != nil {
+			return fmt.Errorf("marshal object key: %w", err)
+		}
+		if err = writeCanonicalBytes(out, keyJSON); err != nil {
+			return err
+		}
+		if err = writeCanonicalByte(out, ':'); err != nil {
+			return err
+		}
+		if err = writeCanonicalJSON(out, value[key]); err != nil {
+			return err
+		}
+	}
+	return writeCanonicalByte(out, '}')
+}
+
+func writeCanonicalArray(out *bytes.Buffer, value []any) error {
+	if err := writeCanonicalByte(out, '['); err != nil {
+		return err
+	}
+	for index, item := range value {
+		if index > 0 {
+			if err := writeCanonicalByte(out, ','); err != nil {
+				return err
+			}
+		}
+		if err := writeCanonicalJSON(out, item); err != nil {
+			return err
+		}
+	}
+	return writeCanonicalByte(out, ']')
+}
+
+func writeCanonicalBytes(out *bytes.Buffer, value []byte) error {
+	if _, err := out.Write(value); err != nil {
+		return fmt.Errorf("write canonical json: %w", err)
+	}
+	return nil
+}
+
+func writeCanonicalByte(out *bytes.Buffer, value byte) error {
+	if err := out.WriteByte(value); err != nil {
+		return fmt.Errorf("write canonical json byte: %w", err)
+	}
+	return nil
+}

--- a/internal/common/history/append_test.go
+++ b/internal/common/history/append_test.go
@@ -102,6 +102,7 @@ func TestAppendVersionTxSnapshotIntervalOneUsesPreviousHashOnly(t *testing.T) {
 
 func TestAppendVersionTxWritesEvidenceArtifactBeforeCommitWhenEnabled(t *testing.T) {
 	store := &recordingEvidenceStore{}
+	matchedRuleID := "rule:1:abcdef0123456789,rule:3:0123456789abcdef"
 	t.Cleanup(func() {
 		Configure(Config{Mode: ModeOff, Immutability: ImmutabilityNone, AuditIdentityMode: AuditIdentityNone})
 	})
@@ -126,7 +127,7 @@ func TestAppendVersionTxWritesEvidenceArtifactBeforeCommitWhenEnabled(t *testing
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectQuery(`SELECT "history_id" FROM "aas_history"`).
 		WillReturnError(sql.ErrNoRows)
-	mock.ExpectQuery(`INSERT INTO "aas_history".*RETURNING "history_id"`).
+	mock.ExpectQuery(`INSERT INTO "aas_history".*"matched_rule_id".*RETURNING "history_id"`).
 		WillReturnRows(sqlmock.NewRows([]string{"history_id"}).AddRow(1))
 	mock.ExpectExec(`INSERT INTO "aas_history_payload".*"snapshot"`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -136,7 +137,12 @@ func TestAppendVersionTxWritesEvidenceArtifactBeforeCommitWhenEnabled(t *testing
 
 	tx, err := db.Begin()
 	require.NoError(t, err)
-	err = AppendVersionTx(context.Background(), tx, TableAAS, "aas-1", ChangeCreated, map[string]any{"id": "aas-1"}, false)
+	ctx := ContextWithAudit(context.Background(), AuditContext{
+		AuthorizationResult: "ALLOW",
+		PolicyID:            "policy-1",
+		MatchedRuleID:       matchedRuleID,
+	})
+	err = AppendVersionTx(ctx, tx, TableAAS, "aas-1", ChangeCreated, map[string]any{"id": "aas-1"}, false)
 	require.NoError(t, err)
 	require.NoError(t, tx.Commit())
 
@@ -159,6 +165,9 @@ func TestAppendVersionTxWritesEvidenceArtifactBeforeCommitWhenEnabled(t *testing
 	require.Equal(t, "add", operation["op"])
 	require.Equal(t, "/id", operation["path"])
 	require.Equal(t, "aas-1", operation["value"])
+	audit, ok := artifactPayload["audit"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, matchedRuleID, audit["matched_rule_id"])
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/common/history/audit_test.go
+++ b/internal/common/history/audit_test.go
@@ -30,6 +30,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -123,7 +125,10 @@ func TestAuditContextMiddlewarePopulatesAuthenticatedMinimalFields(t *testing.T)
 		"iss":       "https://issuer.example",
 		"client_id": "client-1",
 	})
-	ctx = auth.ContextWithAuthorizationDecision(ctx, auth.AuthorizationDecision{Result: string(auth.DecisionAllow)})
+	ctx = auth.ContextWithAuthorizationDecision(ctx, auth.AuthorizationDecision{
+		Result:        string(auth.DecisionAllow),
+		MatchedRuleID: "rule:1:abcdef0123456789",
+	})
 	ctx = contextWithMutationCoverage(ctx, http.MethodPut, mutationRoute{pattern: "/shells/{aasIdentifier}", operation: "PutAssetAdministrationShellById"}, true)
 
 	handler.ServeHTTP(httptest.NewRecorder(), request.WithContext(ctx))
@@ -136,8 +141,74 @@ func TestAuditContextMiddlewarePopulatesAuthenticatedMinimalFields(t *testing.T)
 	require.Equal(t, string(auth.DecisionAllow), captured.AuthorizationResult)
 	require.Equal(t, "PutAssetAdministrationShellById", captured.Operation)
 	require.Equal(t, "/shells/{aasIdentifier}", captured.Endpoint)
+	require.Empty(t, captured.MatchedRuleID)
 	require.Empty(t, captured.SourceIP)
 	require.Empty(t, captured.UserAgent)
+}
+
+func TestAuditContextMiddlewarePopulatesExtendedAuthorizationFields(t *testing.T) {
+	policyPath := filepath.Join(t.TempDir(), "access-rules.json")
+	require.NoError(t, os.WriteFile(policyPath, []byte(`{"AllAccessPermissionRules":{"rules":[]}}`), 0600))
+
+	cfg := &common.Config{
+		History: common.HistoryConfig{AuditIdentityMode: AuditIdentityExtended},
+		ABAC: common.ABACConfig{
+			Enabled:   true,
+			ModelPath: policyPath,
+		},
+	}
+	var captured AuditContext
+	handler := AuditContextMiddleware(cfg)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = FromContext(r.Context())
+	}))
+	request := httptest.NewRequest(http.MethodPut, "/shells/aas-1", nil)
+	ctx := context.WithValue(request.Context(), auth.ClaimsKey, auth.Claims{
+		"sub":       "user-1",
+		"iss":       "https://issuer.example",
+		"client_id": "client-1",
+	})
+	ctx = auth.ContextWithAuthorizationDecision(ctx, auth.AuthorizationDecision{
+		Result:        string(auth.DecisionAllow),
+		MatchedRuleID: "rule:1:abcdef0123456789,rule:3:0123456789abcdef",
+	})
+
+	handler.ServeHTTP(httptest.NewRecorder(), request.WithContext(ctx))
+
+	require.Equal(t, string(auth.DecisionAllow), captured.AuthorizationResult)
+	require.NotEmpty(t, captured.PolicyID)
+	require.Equal(t, "rule:1:abcdef0123456789,rule:3:0123456789abcdef", captured.MatchedRuleID)
+}
+
+func TestAuditContextMiddlewareLeavesMatchedRuleIDEmptyWhenUnavailable(t *testing.T) {
+	cfg := &common.Config{History: common.HistoryConfig{AuditIdentityMode: AuditIdentityExtended}}
+	var captured AuditContext
+	handler := AuditContextMiddleware(cfg)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = FromContext(r.Context())
+	}))
+	request := httptest.NewRequest(http.MethodPost, "/shells", nil)
+
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	require.Empty(t, captured.AuthorizationResult)
+	require.Empty(t, captured.MatchedRuleID)
+}
+
+func TestAuditContextMiddlewareNoneModeDoesNotStoreMatchedRuleID(t *testing.T) {
+	cfg := &common.Config{History: common.HistoryConfig{AuditIdentityMode: AuditIdentityNone}}
+	var captured AuditContext
+	handler := AuditContextMiddleware(cfg)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = FromContext(r.Context())
+	}))
+	request := httptest.NewRequest(http.MethodPost, "/shells", nil)
+	ctx := auth.ContextWithAuthorizationDecision(request.Context(), auth.AuthorizationDecision{
+		Result:        string(auth.DecisionAllow),
+		MatchedRuleID: "rule:1:abcdef0123456789",
+	})
+
+	handler.ServeHTTP(httptest.NewRecorder(), request.WithContext(ctx))
+
+	require.Empty(t, captured.AuthorizationResult)
+	require.Empty(t, captured.MatchedRuleID)
 }
 
 func TestAuditContextMiddlewareDoesNotInventAnonymousPrincipal(t *testing.T) {
@@ -236,5 +307,6 @@ func TestHistoryEventArtifactContainsMatchingAuditMetadata(t *testing.T) {
 	require.Equal(t, audit.RequestID, decoded.Audit["request_id"])
 	require.Equal(t, audit.ActorSubject, decoded.Audit["actor_subject"])
 	require.Equal(t, audit.AuthorizationResult, decoded.Audit["authorization_result"])
+	require.Equal(t, audit.MatchedRuleID, decoded.Audit["matched_rule_id"])
 	require.Equal(t, audit.Endpoint, decoded.Audit["endpoint"])
 }

--- a/internal/common/history/hash.go
+++ b/internal/common/history/hash.go
@@ -26,15 +26,9 @@
 package history
 
 import (
-	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"sort"
 	"time"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
 
 // CanonicalJSONHash returns a SHA-256 hash over CanonicalJSON(value).
@@ -58,12 +52,7 @@ import (
 //	}
 //	event.ContentHash = hash
 func CanonicalJSONHash(value any) (string, error) {
-	canonical, err := CanonicalJSON(value)
-	if err != nil {
-		return "", err
-	}
-	sum := sha256.Sum256(canonical)
-	return hex.EncodeToString(sum[:]), nil
+	return common.CanonicalJSONHash(value)
 }
 
 // ComputeHistoryRowHash returns the hash-chain row hash for a history event.
@@ -162,30 +151,11 @@ func databaseTimestamp(value time.Time) time.Time {
 //	}
 //	return canonical, nil
 func CanonicalJSON(value any) ([]byte, error) {
-	normalized, err := normalizeJSONValue(value)
-	if err != nil {
-		return nil, err
-	}
-	var out bytes.Buffer
-	if err = writeCanonicalJSON(&out, normalized); err != nil {
-		return nil, err
-	}
-	return out.Bytes(), nil
+	return common.CanonicalJSON(value)
 }
 
-func normalizeJSONValue(value any) (any, error) {
-	switch typed := value.(type) {
-	case json.RawMessage:
-		return decodeNormalizedJSON(typed)
-	case []byte:
-		return decodeNormalizedJSON(typed)
-	default:
-		encoded, err := json.Marshal(value)
-		if err != nil {
-			return nil, err
-		}
-		return decodeNormalizedJSON(encoded)
-	}
+func decodeJSONPreservingNumbers(raw []byte, target any) error {
+	return common.DecodeJSONPreservingNumbers(raw, target)
 }
 
 func decodeNormalizedJSON(raw []byte) (any, error) {
@@ -194,98 +164,4 @@ func decodeNormalizedJSON(raw []byte) (any, error) {
 		return nil, err
 	}
 	return normalized, nil
-}
-
-func decodeJSONPreservingNumbers(raw []byte, target any) error {
-	decoder := json.NewDecoder(bytes.NewReader(raw))
-	decoder.UseNumber()
-	if err := decoder.Decode(target); err != nil {
-		return err
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		if err == nil {
-			return fmt.Errorf("multiple JSON values in payload")
-		}
-		return err
-	}
-	return nil
-}
-
-func writeCanonicalJSON(out *bytes.Buffer, value any) error {
-	switch typed := value.(type) {
-	case map[string]any:
-		return writeCanonicalObject(out, typed)
-	case []any:
-		return writeCanonicalArray(out, typed)
-	default:
-		encoded, err := json.Marshal(typed)
-		if err != nil {
-			return fmt.Errorf("marshal scalar: %w", err)
-		}
-		return writeCanonicalBytes(out, encoded)
-	}
-}
-
-func writeCanonicalObject(out *bytes.Buffer, value map[string]any) error {
-	if err := writeCanonicalByte(out, '{'); err != nil {
-		return err
-	}
-	keys := make([]string, 0, len(value))
-	for key := range value {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for index, key := range keys {
-		if index > 0 {
-			if err := writeCanonicalByte(out, ','); err != nil {
-				return err
-			}
-		}
-		keyJSON, err := json.Marshal(key)
-		if err != nil {
-			return fmt.Errorf("marshal object key: %w", err)
-		}
-		if err = writeCanonicalBytes(out, keyJSON); err != nil {
-			return err
-		}
-		if err = writeCanonicalByte(out, ':'); err != nil {
-			return err
-		}
-		if err = writeCanonicalJSON(out, value[key]); err != nil {
-			return err
-		}
-	}
-	return writeCanonicalByte(out, '}')
-}
-
-func writeCanonicalArray(out *bytes.Buffer, value []any) error {
-	if err := writeCanonicalByte(out, '['); err != nil {
-		return err
-	}
-	for index, item := range value {
-		if index > 0 {
-			if err := writeCanonicalByte(out, ','); err != nil {
-				return err
-			}
-		}
-		if err := writeCanonicalJSON(out, item); err != nil {
-			return err
-		}
-	}
-	return writeCanonicalByte(out, ']')
-}
-
-func writeCanonicalBytes(out *bytes.Buffer, value []byte) error {
-	if _, err := out.Write(value); err != nil {
-		return fmt.Errorf("write canonical json: %w", err)
-	}
-	return nil
-}
-
-func writeCanonicalByte(out *bytes.Buffer, value byte) error {
-	if err := out.WriteByte(value); err != nil {
-		return fmt.Errorf("write canonical json byte: %w", err)
-	}
-	return nil
 }

--- a/internal/common/security/abac_engine.go
+++ b/internal/common/security/abac_engine.go
@@ -153,42 +153,17 @@ type AuthorizationEvaluation struct {
 //
 //nolint:revive // i will refactor this function at some point
 func (m *AccessModel) AuthorizeWithFilter(in EvalInput) (bool, DecisionCode, *QueryFilter) {
-	return m.AuthorizeWithFilterWithOptions(in, grammar.DefaultSimplifyOptions())
-}
-
-// AuthorizeWithFilterWithOptions behaves like AuthorizeWithFilter but allows callers
-// to control backend simplification behavior (e.g., implicit casts).
-func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.SimplifyOptions) (bool, DecisionCode, *QueryFilter) {
-	result := m.AuthorizeWithFilterDetailedWithOptions(in, opts)
+	result := m.AuthorizeWithFilterWithOptions(in, grammar.DefaultSimplifyOptions())
 	return result.Allowed, result.Reason, result.QueryFilter
 }
 
-// AuthorizeWithFilterDetailed evaluates the request and returns audit-friendly metadata.
+// AuthorizeWithFilterWithOptions evaluates the request and returns audit-friendly metadata.
 //
-// The evaluation semantics are identical to AuthorizeWithFilter. In addition to
-// the allow decision and optional query filter, the returned value contains the
-// deterministic matched rule identifiers used by history audit enrichment.
-//
-// Parameters:
-//   - in: Request method, path, and claims used by the ABAC evaluator.
-//
-// Returns:
-//   - AuthorizationEvaluation: Access decision, decision reason, optional query
-//     filter, and comma-separated matched allow rule IDs.
-//
-// Example:
-//
-//	result := model.AuthorizeWithFilterDetailed(input)
-//	if !result.Allowed {
-//		return result.Reason
-//	}
-//	audit.MatchedRuleID = result.MatchedRuleID
-func (m *AccessModel) AuthorizeWithFilterDetailed(in EvalInput) AuthorizationEvaluation {
-	return m.AuthorizeWithFilterDetailedWithOptions(in, grammar.DefaultSimplifyOptions())
-}
-
-// AuthorizeWithFilterDetailedWithOptions behaves like AuthorizeWithFilterWithOptions
-// and additionally returns the deterministic IDs of all matched allow rules.
+// The evaluation semantics are identical to AuthorizeWithFilter, but callers can
+// control backend simplification behavior, for example implicit casts. In
+// addition to the allow decision and optional query filter, the returned value
+// contains the deterministic matched rule identifiers used by history audit
+// enrichment.
 //
 // Parameters:
 //   - in: Request method, path, and claims used by the ABAC evaluator.
@@ -202,7 +177,7 @@ func (m *AccessModel) AuthorizeWithFilterDetailed(in EvalInput) AuthorizationEva
 //
 //	opts := grammar.DefaultSimplifyOptions()
 //	opts.EnableImplicitCasts = true
-//	result := model.AuthorizeWithFilterDetailedWithOptions(input, opts)
+//	result := model.AuthorizeWithFilterWithOptions(input, opts)
 //	if result.Allowed {
 //		ctx = ContextWithAuthorizationDecision(ctx, AuthorizationDecision{
 //			Result:        string(DecisionAllow),
@@ -211,7 +186,7 @@ func (m *AccessModel) AuthorizeWithFilterDetailed(in EvalInput) AuthorizationEva
 //	}
 //
 // nolint:revive // This function is the heart of ABAC and is complicated. Sorry cognitive-complexity!
-func (m *AccessModel) AuthorizeWithFilterDetailedWithOptions(in EvalInput, opts grammar.SimplifyOptions) AuthorizationEvaluation {
+func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.SimplifyOptions) AuthorizationEvaluation {
 	rightAlternatives, mapped, routeFound := m.mapMethodAndPathToRights(in)
 	if !routeFound {
 		return AuthorizationEvaluation{Reason: DecisionRouteNotFound}

--- a/internal/common/security/abac_engine.go
+++ b/internal/common/security/abac_engine.go
@@ -28,6 +28,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/builder"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
@@ -46,6 +47,7 @@ type AccessModel struct {
 }
 
 type materializedRule struct {
+	id         string
 	acl        grammar.ACL
 	attrs      []grammar.AttributeItem
 	objs       []grammar.ObjectItem
@@ -122,6 +124,28 @@ const (
 	DecisionRouteNotFound DecisionCode = "ROUTE_NOT_FOUND"
 )
 
+// AuthorizationEvaluation records the detailed outcome of an ABAC evaluation.
+//
+// ABACMiddleware uses this richer result to pass allow metadata to audit
+// middleware while preserving the older AuthorizeWithFilter return contract for
+// callers that only need access and query-filter decisions.
+type AuthorizationEvaluation struct {
+	// Allowed is true when the request is permitted by at least one allow rule.
+	Allowed bool
+
+	// Reason describes the authorization result, including deny/pass-through cases.
+	Reason DecisionCode
+
+	// QueryFilter contains optional backend filter constraints for allowed requests.
+	QueryFilter *QueryFilter
+
+	// MatchedRuleID contains deterministic IDs for matched allow rules.
+	//
+	// Multiple IDs are comma-separated in configured rule order. The field is
+	// empty when no allow rule matched or rule metadata is unavailable.
+	MatchedRuleID string
+}
+
 // AuthorizeWithFilter evaluates the request against the model rules in order.
 // It returns whether access is allowed, a human-readable reason, and an optional
 // QueryFilter for controllers to enforce (e.g., tenant scoping, redactions).
@@ -134,18 +158,71 @@ func (m *AccessModel) AuthorizeWithFilter(in EvalInput) (bool, DecisionCode, *Qu
 
 // AuthorizeWithFilterWithOptions behaves like AuthorizeWithFilter but allows callers
 // to control backend simplification behavior (e.g., implicit casts).
-// nolint:revive // This function is the heart of ABAC and is complicated. Sorry cognitive-complexity!
 func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.SimplifyOptions) (bool, DecisionCode, *QueryFilter) {
+	result := m.AuthorizeWithFilterDetailedWithOptions(in, opts)
+	return result.Allowed, result.Reason, result.QueryFilter
+}
+
+// AuthorizeWithFilterDetailed evaluates the request and returns audit-friendly metadata.
+//
+// The evaluation semantics are identical to AuthorizeWithFilter. In addition to
+// the allow decision and optional query filter, the returned value contains the
+// deterministic matched rule identifiers used by history audit enrichment.
+//
+// Parameters:
+//   - in: Request method, path, and claims used by the ABAC evaluator.
+//
+// Returns:
+//   - AuthorizationEvaluation: Access decision, decision reason, optional query
+//     filter, and comma-separated matched allow rule IDs.
+//
+// Example:
+//
+//	result := model.AuthorizeWithFilterDetailed(input)
+//	if !result.Allowed {
+//		return result.Reason
+//	}
+//	audit.MatchedRuleID = result.MatchedRuleID
+func (m *AccessModel) AuthorizeWithFilterDetailed(in EvalInput) AuthorizationEvaluation {
+	return m.AuthorizeWithFilterDetailedWithOptions(in, grammar.DefaultSimplifyOptions())
+}
+
+// AuthorizeWithFilterDetailedWithOptions behaves like AuthorizeWithFilterWithOptions
+// and additionally returns the deterministic IDs of all matched allow rules.
+//
+// Parameters:
+//   - in: Request method, path, and claims used by the ABAC evaluator.
+//   - opts: Simplification options for backend filter generation.
+//
+// Returns:
+//   - AuthorizationEvaluation: Access decision, decision reason, optional query
+//     filter, and comma-separated matched allow rule IDs.
+//
+// Example:
+//
+//	opts := grammar.DefaultSimplifyOptions()
+//	opts.EnableImplicitCasts = true
+//	result := model.AuthorizeWithFilterDetailedWithOptions(input, opts)
+//	if result.Allowed {
+//		ctx = ContextWithAuthorizationDecision(ctx, AuthorizationDecision{
+//			Result:        string(DecisionAllow),
+//			MatchedRuleID: result.MatchedRuleID,
+//		})
+//	}
+//
+// nolint:revive // This function is the heart of ABAC and is complicated. Sorry cognitive-complexity!
+func (m *AccessModel) AuthorizeWithFilterDetailedWithOptions(in EvalInput, opts grammar.SimplifyOptions) AuthorizationEvaluation {
 	rightAlternatives, mapped, routeFound := m.mapMethodAndPathToRights(in)
 	if !routeFound {
-		return false, DecisionRouteNotFound, nil
+		return AuthorizationEvaluation{Reason: DecisionRouteNotFound}
 	}
 	if !mapped {
-		return false, DecisionNoMatch, nil
+		return AuthorizationEvaluation{Reason: DecisionNoMatch}
 	}
 
 	var ruleExprs []QueryFilter
 	var allFragments []grammar.FragmentStringPattern
+	matchedRuleIDs := make([]string, 0, len(m.rules))
 	relevantRights := collectRelevantRights(rightAlternatives)
 	ruleExprsByRight := make(map[grammar.RightsEnum][]grammar.LogicalExpression, len(relevantRights))
 
@@ -189,7 +266,7 @@ func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.
 		// Gate 4: formula → adapt for backend filtering
 		if combinedLE == nil {
 			// rule has no formula: should not happen -> deny access
-			return false, DecisionNoMatch, nil
+			return AuthorizationEvaluation{Reason: DecisionNoMatch}
 		}
 
 		resolver := func(attr grammar.AttributeValue) any {
@@ -198,6 +275,9 @@ func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.
 		adapted, decision := combinedLE.SimplifyForBackendFilterWithOptions(resolver, opts)
 		if decision == grammar.SimplifyFalse {
 			continue
+		}
+		if r.id != "" {
+			matchedRuleIDs = append(matchedRuleIDs, r.id)
 		}
 		fragments := make(map[grammar.FragmentStringPattern]grammar.LogicalExpression)
 		fragmentMatch := make(map[grammar.FragmentStringPattern]bool)
@@ -246,7 +326,7 @@ func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.
 	}
 
 	if len(ruleExprs) == 0 {
-		return false, DecisionNoMatch, nil
+		return AuthorizationEvaluation{Reason: DecisionNoMatch}
 	}
 
 	combined := grammar.LogicalExpression{Or: []grammar.LogicalExpression{}}
@@ -313,7 +393,7 @@ func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.
 	hasFormula := true
 	switch decision {
 	case grammar.SimplifyFalse:
-		return false, DecisionNoMatch, nil
+		return AuthorizationEvaluation{Reason: DecisionNoMatch}
 	case grammar.SimplifyTrue:
 		hasFormula = false
 	}
@@ -336,7 +416,12 @@ func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.
 		}
 	}
 
-	return true, DecisionAllow, qf
+	return AuthorizationEvaluation{
+		Allowed:       true,
+		Reason:        DecisionAllow,
+		QueryFilter:   qf,
+		MatchedRuleID: strings.Join(matchedRuleIDs, ","),
+	}
 }
 
 func rightsContainsAny(hay []grammar.RightsEnum, alternatives [][]grammar.RightsEnum) bool {

--- a/internal/common/security/abac_engine_materialization.go
+++ b/internal/common/security/abac_engine_materialization.go
@@ -30,8 +30,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 )
+
+const matchedRuleHashPrefixLength = 16
 
 // definitionIndex caches definitions for fast lookup during materialization.
 type definitionIndex struct {
@@ -56,10 +59,22 @@ func materializeRules(all grammar.AccessRuleModelSchemaJSONAllAccessPermissionRu
 		if err != nil {
 			return nil, fmt.Errorf("rule %d: %w", i+1, err)
 		}
+		mr.id, err = deterministicMatchedRuleID(i+1, r)
+		if err != nil {
+			return nil, fmt.Errorf("rule %d: id: %w", i+1, err)
+		}
 		rules = append(rules, mr)
 	}
 
 	return rules, nil
+}
+
+func deterministicMatchedRuleID(index int, rule grammar.AccessPermissionRule) (string, error) {
+	hash, err := common.CanonicalJSONHash(rule)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("rule:%d:%s", index, hash[:matchedRuleHashPrefixLength]), nil
 }
 
 func buildDefinitionIndex(all grammar.AccessRuleModelSchemaJSONAllAccessPermissionRules) (definitionIndex, error) {

--- a/internal/common/security/abac_matched_rule_id_test.go
+++ b/internal/common/security/abac_matched_rule_id_test.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	apis "github.com/eclipse-basyx/basyx-go-components/pkg/aasregistryapi"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestDeterministicMatchedRuleIDStableForUnchangedRule(t *testing.T) {
+	t.Parallel()
+
+	rule := ruleWithFormulaName("always_true")
+	first, err := deterministicMatchedRuleID(1, rule)
+	if err != nil {
+		t.Fatalf("deterministicMatchedRuleID returned error: %v", err)
+	}
+	second, err := deterministicMatchedRuleID(1, rule)
+	if err != nil {
+		t.Fatalf("deterministicMatchedRuleID returned error: %v", err)
+	}
+
+	if first != second {
+		t.Fatalf("expected stable rule id, got %q and %q", first, second)
+	}
+	if !regexp.MustCompile(`^rule:1:[a-f0-9]{16}$`).MatchString(first) {
+		t.Fatalf("unexpected rule id format: %q", first)
+	}
+}
+
+func TestDeterministicMatchedRuleIDHashChangesWhenRuleContentChanges(t *testing.T) {
+	t.Parallel()
+
+	first, err := deterministicMatchedRuleID(1, ruleWithFormulaName("always_true"))
+	if err != nil {
+		t.Fatalf("deterministicMatchedRuleID returned error: %v", err)
+	}
+	second, err := deterministicMatchedRuleID(1, ruleWithFormulaName("is_admin"))
+	if err != nil {
+		t.Fatalf("deterministicMatchedRuleID returned error: %v", err)
+	}
+
+	if first == second {
+		t.Fatalf("expected different rule ids after rule content changed, got %q", first)
+	}
+	if ruleIDHashPart(first) == ruleIDHashPart(second) {
+		t.Fatalf("expected hash portion to change, got %q and %q", first, second)
+	}
+}
+
+func TestAuthorizeWithFilterDetailedReturnsOrderedMatchedRuleIDs(t *testing.T) {
+	t.Parallel()
+
+	model := mustParseAASRegistryAccessModel(t, matchedRuleModelJSON)
+
+	result := model.AuthorizeWithFilterDetailed(EvalInput{
+		Method: http.MethodGet,
+		Path:   "/shell-descriptors",
+		Claims: Claims{"sub": "anonymous"},
+	})
+
+	if !result.Allowed || result.Reason != DecisionAllow {
+		t.Fatalf("expected allow decision, got allowed=%v reason=%s", result.Allowed, result.Reason)
+	}
+	expected := strings.Join([]string{model.rules[0].id, model.rules[1].id}, ",")
+	if result.MatchedRuleID != expected {
+		t.Fatalf("expected matched rule ids %q, got %q", expected, result.MatchedRuleID)
+	}
+}
+
+func TestABACMiddlewareStoresMatchedRuleIDOnAllowDecision(t *testing.T) {
+	t.Parallel()
+
+	model := mustParseAASRegistryAccessModel(t, matchedRuleModelJSON)
+	var captured AuthorizationDecision
+	handler := ABACMiddleware(ABACSettings{
+		Enabled: true,
+		Model:   model,
+	})(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var ok bool
+		captured, ok = AuthorizationDecisionFromContext(r.Context())
+		if !ok {
+			t.Fatalf("expected authorization decision in request context")
+		}
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, "/shell-descriptors", nil)
+	request = request.WithContext(context.WithValue(request.Context(), ClaimsKey, Claims{"sub": "anonymous"}))
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	expected := strings.Join([]string{model.rules[0].id, model.rules[1].id}, ",")
+	if captured.Result != string(DecisionAllow) {
+		t.Fatalf("expected allow result, got %q", captured.Result)
+	}
+	if captured.MatchedRuleID != expected {
+		t.Fatalf("expected matched rule ids %q, got %q", expected, captured.MatchedRuleID)
+	}
+}
+
+func ruleWithFormulaName(name string) grammar.AccessPermissionRule {
+	acl := "read"
+	objects := []string{"shells"}
+	return grammar.AccessPermissionRule{
+		USEACL:     &acl,
+		USEOBJECTS: objects,
+		USEFORMULA: &name,
+	}
+}
+
+func ruleIDHashPart(id string) string {
+	parts := strings.Split(id, ":")
+	if len(parts) != 3 {
+		return ""
+	}
+	return parts[2]
+}
+
+func mustParseAASRegistryAccessModel(t *testing.T, modelJSON string) *AccessModel {
+	t.Helper()
+
+	router := chi.NewRouter()
+	ctrl := apis.NewAssetAdministrationShellRegistryAPIAPIController(nil, "/*")
+	for _, rt := range ctrl.Routes() {
+		router.Method(rt.Method, rt.Pattern, rt.HandlerFunc)
+	}
+
+	model, err := ParseAccessModel([]byte(modelJSON), router, "")
+	if err != nil {
+		t.Fatalf("parse model failed: %v", err)
+	}
+	return model
+}
+
+const matchedRuleModelJSON = `{
+  "AllAccessPermissionRules": {
+    "DEFATTRIBUTES": [
+      { "name": "anonymous", "attributes": [ { "GLOBAL": "ANONYMOUS" } ] }
+    ],
+    "DEFOBJECTS": [
+      { "name": "shells", "objects": [ { "ROUTE": "/shell-descriptors" } ] }
+    ],
+    "DEFACLS": [
+      { "name": "read", "acl": { "USEATTRIBUTES": "anonymous", "RIGHTS": ["READ"], "ACCESS": "ALLOW" } }
+    ],
+    "DEFFORMULAS": [
+      { "name": "always_true", "formula": { "$boolean": true } }
+    ],
+    "rules": [
+      { "USEACL": "read", "USEOBJECTS": ["shells"], "USEFORMULA": "always_true" },
+      { "USEACL": "read", "USEOBJECTS": ["shells"], "FORMULA": { "$boolean": true } }
+    ]
+  }
+}`

--- a/internal/common/security/abac_matched_rule_id_test.go
+++ b/internal/common/security/abac_matched_rule_id_test.go
@@ -54,16 +54,16 @@ func TestDeterministicMatchedRuleIDHashChangesWhenRuleContentChanges(t *testing.
 	}
 }
 
-func TestAuthorizeWithFilterDetailedReturnsOrderedMatchedRuleIDs(t *testing.T) {
+func TestAuthorizeWithFilterWithOptionsReturnsOrderedMatchedRuleIDs(t *testing.T) {
 	t.Parallel()
 
 	model := mustParseAASRegistryAccessModel(t, matchedRuleModelJSON)
 
-	result := model.AuthorizeWithFilterDetailed(EvalInput{
+	result := model.AuthorizeWithFilterWithOptions(EvalInput{
 		Method: http.MethodGet,
 		Path:   "/shell-descriptors",
 		Claims: Claims{"sub": "anonymous"},
-	})
+	}, grammar.DefaultSimplifyOptions())
 
 	if !result.Allowed || result.Reason != DecisionAllow {
 		t.Fatalf("expected allow decision, got allowed=%v reason=%s", result.Allowed, result.Reason)

--- a/internal/common/security/authorize.go
+++ b/internal/common/security/authorize.go
@@ -98,7 +98,7 @@ func ABACMiddleware(settings ABACSettings) func(http.Handler) http.Handler {
 			if settings.Model != nil {
 				opts := grammar.DefaultSimplifyOptions()
 				opts.EnableImplicitCasts = settings.EnableImplicitCasts
-				evaluation := settings.Model.AuthorizeWithFilterDetailedWithOptions(EvalInput{
+				evaluation := settings.Model.AuthorizeWithFilterWithOptions(EvalInput{
 					Method: r.Method,
 					Path:   r.URL.Path,
 					Claims: claims,

--- a/internal/common/security/authorize.go
+++ b/internal/common/security/authorize.go
@@ -98,18 +98,18 @@ func ABACMiddleware(settings ABACSettings) func(http.Handler) http.Handler {
 			if settings.Model != nil {
 				opts := grammar.DefaultSimplifyOptions()
 				opts.EnableImplicitCasts = settings.EnableImplicitCasts
-				ok, reason, qf := settings.Model.AuthorizeWithFilterWithOptions(EvalInput{
+				evaluation := settings.Model.AuthorizeWithFilterDetailedWithOptions(EvalInput{
 					Method: r.Method,
 					Path:   r.URL.Path,
 					Claims: claims,
 				}, opts)
-				if !ok {
-					if reason == DecisionRouteNotFound {
+				if !evaluation.Allowed {
+					if evaluation.Reason == DecisionRouteNotFound {
 						next.ServeHTTP(w, r)
 						return
 					}
 
-					log.Printf("❌ ABAC(model): %s", reason)
+					log.Printf("❌ ABAC(model): %s", evaluation.Reason)
 
 					resp := common.NewErrorResponse(errors.New("access denied"), http.StatusForbidden, "Middleware", "Rules", "Denied")
 					err := openapi.EncodeJSONResponse(resp.Body, &resp.Code, w)
@@ -121,10 +121,11 @@ func ABACMiddleware(settings ABACSettings) func(http.Handler) http.Handler {
 				}
 
 				ctx := ContextWithAuthorizationDecision(r.Context(), AuthorizationDecision{
-					Result: string(DecisionAllow),
+					Result:        string(DecisionAllow),
+					MatchedRuleID: evaluation.MatchedRuleID,
 				})
-				if qf != nil {
-					ctx = context.WithValue(ctx, filterKey, qf)
+				if evaluation.QueryFilter != nil {
+					ctx = context.WithValue(ctx, filterKey, evaluation.QueryFilter)
 				}
 
 				next.ServeHTTP(w, r.WithContext(ctx))


### PR DESCRIPTION
## Summary

Adds deterministic ABAC matched rule identifiers so history audit rows and WORM `history_event` artifacts can record which configured ABAC allow rule(s) authorized a request.

## What Changed

- Added shared canonical JSON hashing helpers in `internal/common`.
- Kept existing `history.CanonicalJSON*` APIs as wrappers to avoid churn.
- Precomputes deterministic rule IDs during ABAC rule materialization:
  - format: `rule:<1-based-index>:<first16-sha256-hex>`
  - hash input: canonical JSON of the configured rule entry
- Added detailed ABAC evaluation metadata while preserving existing `AuthorizeWithFilter*` signatures.
- Stores matched rule IDs in `AuthorizationDecision.MatchedRuleID`.
- Supports multiple matched allow rules by storing comma-separated IDs in configured rule order.
- Propagates matched rule IDs through extended history audit metadata into PostgreSQL rows and WORM artifacts.
- Updated the guarded history example docs to describe the new `matched_rule_id` behavior.

Closes #350 