### PR TITLE
Fixes Race Condition

### DIFF
--- a/internal/aasenvironment/integration_tests/aasenvironment_registry_sync_race_integration_test.go
+++ b/internal/aasenvironment/integration_tests/aasenvironment_registry_sync_race_integration_test.go
@@ -1,0 +1,186 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+//nolint:all
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistrySyncConcurrentSubmodelReferenceCreationDoesNotRaceAASDescriptorUpsert(t *testing.T) {
+	resetDatabase(t)
+
+	const iterations = 20
+	const parallelReferences = 4
+
+	for iteration := 0; iteration < iterations; iteration++ {
+		suffix := fmt.Sprintf("race-%d-%d", time.Now().UnixNano(), iteration)
+		aasID := fmt.Sprintf("https://example.org/aas/%s", suffix)
+		encodedAASID := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+
+		createRegistrySyncRaceSubmodels(t, suffix, parallelReferences)
+		createRegistrySyncRaceShell(t, aasID, suffix)
+
+		results := postRegistrySyncRaceSubmodelReferences(t, encodedAASID, suffix, parallelReferences)
+		for _, result := range results {
+			require.NoError(t, result.err)
+			require.Equal(t, http.StatusCreated, result.status, "iteration=%d submodel=%d response=%s", iteration, result.index, string(result.body))
+		}
+
+		status, body, _ := doAASEnvRequest(t, aasEnvNoRedirectClient, http.MethodGet, aasEnvBaseURL+"/shells/"+encodedAASID+"/submodel-refs", nil)
+		require.Equal(t, http.StatusOK, status, "response=%s", string(body))
+		requireRegistrySyncRaceReferenceCount(t, body, parallelReferences)
+	}
+}
+
+type registrySyncRacePostResult struct {
+	index  int
+	status int
+	body   []byte
+	err    error
+}
+
+func createRegistrySyncRaceSubmodels(t *testing.T, suffix string, count int) {
+	t.Helper()
+	for index := 0; index < count; index++ {
+		submodelID := registrySyncRaceSubmodelID(suffix, index)
+		payload := map[string]any{
+			"id":        submodelID,
+			"idShort":   fmt.Sprintf("smRace%d", index),
+			"modelType": "Submodel",
+		}
+		status, body, _ := doAASEnvRequest(t, aasEnvNoRedirectClient, http.MethodPost, aasEnvBaseURL+"/submodels", payload)
+		require.Equal(t, http.StatusCreated, status, "response=%s", string(body))
+	}
+}
+
+func createRegistrySyncRaceShell(t *testing.T, aasID string, suffix string) {
+	t.Helper()
+	payload := map[string]any{
+		"id":        aasID,
+		"idShort":   suffix,
+		"modelType": "AssetAdministrationShell",
+		"assetInformation": map[string]any{
+			"assetKind":     "Instance",
+			"globalAssetId": fmt.Sprintf("https://example.org/asset/%s", suffix),
+		},
+	}
+	status, body, _ := doAASEnvRequest(t, aasEnvNoRedirectClient, http.MethodPost, aasEnvBaseURL+"/shells", payload)
+	require.Equal(t, http.StatusCreated, status, "response=%s", string(body))
+}
+
+func postRegistrySyncRaceSubmodelReferences(t *testing.T, encodedAASID string, suffix string, count int) []registrySyncRacePostResult {
+	t.Helper()
+	results := make([]registrySyncRacePostResult, count)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for index := 0; index < count; index++ {
+		index := index
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			status, body, err := doAASEnvRawJSONRequest(
+				http.MethodPost,
+				aasEnvBaseURL+"/shells/"+encodedAASID+"/submodel-refs",
+				map[string]any{
+					"type": "ModelReference",
+					"keys": []map[string]any{
+						{
+							"type":  "Submodel",
+							"value": registrySyncRaceSubmodelID(suffix, index),
+						},
+					},
+				},
+			)
+			results[index] = registrySyncRacePostResult{
+				index:  index,
+				status: status,
+				body:   body,
+				err:    err,
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	return results
+}
+
+func registrySyncRaceSubmodelID(suffix string, index int) string {
+	return fmt.Sprintf("https://example.org/sm/%s-%d", suffix, index)
+}
+
+func doAASEnvRawJSONRequest(method string, endpoint string, payload any) (int, []byte, error) {
+	var body io.Reader
+	if payload != nil {
+		marshaled, err := json.Marshal(payload)
+		if err != nil {
+			return 0, nil, err
+		}
+		body = bytes.NewReader(marshaled)
+	}
+
+	req, err := http.NewRequest(method, endpoint, body)
+	if err != nil {
+		return 0, nil, err
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := aasEnvNoRedirectClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, respBody, nil
+}
+
+func requireRegistrySyncRaceReferenceCount(t *testing.T, body []byte, expectedCount int) {
+	t.Helper()
+	var payload struct {
+		Result []any `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.Len(t, payload.Result, expectedCount)
+}

--- a/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
+++ b/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
@@ -244,30 +244,17 @@ func (p *PostgreSQLAASRegistryDatabase) UpsertAdministrationShellDescriptorInTra
 		return common.NewInternalServerError("AASREG-UPSERTAASDESC-NILTX transaction must not be nil")
 	}
 
-	_, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id)
+	created, err := descriptors.UpsertAdministrationShellDescriptorTx(ctx, tx, aasd)
 	if err != nil {
-		if !common.IsErrNotFound(err) {
-			return err
-		}
-		if err := descriptors.InsertAdministrationShellDescriptorTx(ctx, tx, aasd); err != nil {
-			return err
-		}
-		stored, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id)
-		if err != nil {
-			return err
-		}
-		return appendDescriptorHistoryTx(ctx, tx, stored, history.ChangeCreated, false)
+		return err
 	}
 
-	if err = descriptors.DeleteAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id); err != nil {
-		return err
-	}
-	if err = descriptors.InsertAdministrationShellDescriptorTx(ctx, tx, aasd); err != nil {
-		return err
-	}
 	stored, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id)
 	if err != nil {
 		return err
+	}
+	if created {
+		return appendDescriptorHistoryTx(ctx, tx, stored, history.ChangeCreated, false)
 	}
 	return appendDescriptorHistoryTx(ctx, tx, stored, history.ChangeUpdated, false)
 }

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -232,9 +232,9 @@ func insertAdministrationShellDescriptorDetailsTx(ctx context.Context, tx *sql.T
 // rolling back the supplied transaction `tx`.
 //
 // Parameters:
-//  - ctx: context for cancellation and query filtering.
-//  - tx: database transaction to use for the upsert (must be non-nil).
-//  - aasd: the AssetAdministrationShellDescriptor to insert or replace.
+//   - ctx: context for cancellation and query filtering.
+//   - tx: database transaction to use for the upsert (must be non-nil).
+//   - aasd: the AssetAdministrationShellDescriptor to insert or replace.
 //
 // Note: This function relies on advisory locks and FOR UPDATE row locking to
 // avoid race conditions; it must be invoked inside a transaction.

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -139,6 +139,12 @@ func InsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd
 		return err
 	}
 
+	return insertAdministrationShellDescriptorDetailsTx(ctx, tx, descriptorID, aasd, true)
+}
+
+func insertAdministrationShellDescriptorDetailsTx(ctx context.Context, tx *sql.Tx, descriptorID int64, aasd model.AssetAdministrationShellDescriptor, insertAASDescriptor bool) error {
+	d := goqu.Dialect(common.Dialect)
+
 	descriptionPayload, err := buildLangStringTextPayload(aasd.Description)
 	if err != nil {
 		return common.NewInternalServerError("AASDESC-INSERT-DESCRIPTIONPAYLOAD")
@@ -156,7 +162,7 @@ func InsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd
 		return common.NewInternalServerError("AASDESC-INSERT-EXTENSIONPAYLOAD")
 	}
 
-	sqlStr, args, buildErr = d.
+	sqlStr, args, buildErr := d.
 		Insert(common.TblDescriptorPayload).
 		Rows(goqu.Record{
 			common.ColDescriptorID:              descriptorID,
@@ -173,15 +179,17 @@ func InsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd
 		return err
 	}
 
-	sqlStr, args, buildErr = d.
-		Insert(common.TblAASDescriptor).
-		Rows(buildAASDescriptorInsertRecord(ctx, descriptorID, aasd)).
-		ToSQL()
-	if buildErr != nil {
-		return buildErr
-	}
-	if _, err = tx.Exec(sqlStr, args...); err != nil {
-		return err
+	if insertAASDescriptor {
+		sqlStr, args, buildErr = d.
+			Insert(common.TblAASDescriptor).
+			Rows(buildAASDescriptorInsertRecord(ctx, descriptorID, aasd)).
+			ToSQL()
+		if buildErr != nil {
+			return buildErr
+		}
+		if _, err = tx.Exec(sqlStr, args...); err != nil {
+			return err
+		}
 	}
 
 	if err = CreateEndpoints(tx, descriptorID, aasd.Endpoints); err != nil {
@@ -208,6 +216,136 @@ func InsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd
 	}
 
 	return createSubModelDescriptors(tx, sql.NullInt64{Int64: descriptorID, Valid: true}, aasd.SubmodelDescriptors)
+}
+
+func UpsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd model.AssetAdministrationShellDescriptor) (bool, error) {
+	if err := lockAASDescriptorUpsertTx(ctx, tx, aasd.Id); err != nil {
+		return false, err
+	}
+
+	descriptorID, found, err := selectAASDescriptorIDForUpdateTx(ctx, tx, aasd.Id)
+	if err != nil {
+		return false, err
+	}
+
+	if found {
+		if err = replaceAdministrationShellDescriptorDetailsTx(ctx, tx, descriptorID, aasd); err != nil {
+			return false, err
+		}
+		return false, err
+	}
+
+	return true, InsertAdministrationShellDescriptorTx(ctx, tx, aasd)
+}
+
+func lockAASDescriptorUpsertTx(ctx context.Context, tx *sql.Tx, aasID string) error {
+	d := goqu.Dialect(common.Dialect)
+	sqlStr, args, buildErr := d.
+		Select(goqu.Func("pg_advisory_xact_lock", goqu.Func("hashtext", "aas_descriptor:"+aasID))).
+		ToSQL()
+	if buildErr != nil {
+		return buildErr
+	}
+
+	_, err := tx.ExecContext(ctx, sqlStr, args...)
+	return err
+}
+
+func selectAASDescriptorIDForUpdateTx(ctx context.Context, tx *sql.Tx, aasID string) (int64, bool, error) {
+	d := goqu.Dialect(common.Dialect)
+	aasTbl := goqu.T(common.TblAASDescriptor)
+
+	sqlStr, args, buildErr := d.
+		From(aasTbl).
+		Select(aasTbl.Col(common.ColDescriptorID)).
+		Where(aasTbl.Col(common.ColAASID).Eq(aasID)).
+		ForUpdate(goqu.Wait).
+		ToSQL()
+	if buildErr != nil {
+		return 0, false, buildErr
+	}
+
+	var descriptorID int64
+	if err := tx.QueryRowContext(ctx, sqlStr, args...).Scan(&descriptorID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+
+	return descriptorID, true, nil
+}
+
+func replaceAdministrationShellDescriptorDetailsTx(ctx context.Context, tx *sql.Tx, descriptorID int64, aasd model.AssetAdministrationShellDescriptor) error {
+	if err := updateAASDescriptorRowTx(ctx, tx, descriptorID, aasd); err != nil {
+		return err
+	}
+	if err := deleteAdministrationShellDescriptorDetailsTx(ctx, tx, descriptorID); err != nil {
+		return err
+	}
+	return insertAdministrationShellDescriptorDetailsTx(ctx, tx, descriptorID, aasd, false)
+}
+
+func updateAASDescriptorRowTx(ctx context.Context, tx *sql.Tx, descriptorID int64, aasd model.AssetAdministrationShellDescriptor) error {
+	d := goqu.Dialect(common.Dialect)
+	record := buildAASDescriptorInsertRecord(ctx, descriptorID, aasd)
+	delete(record, common.ColDescriptorID)
+
+	sqlStr, args, buildErr := d.
+		Update(common.TblAASDescriptor).
+		Set(record).
+		Where(goqu.C(common.ColDescriptorID).Eq(descriptorID)).
+		ToSQL()
+	if buildErr != nil {
+		return buildErr
+	}
+
+	_, err := tx.ExecContext(ctx, sqlStr, args...)
+	return err
+}
+
+func deleteAdministrationShellDescriptorDetailsTx(ctx context.Context, tx *sql.Tx, descriptorID int64) error {
+	d := goqu.Dialect(common.Dialect)
+
+	childDescriptorIDs := d.
+		From(common.TblSubmodelDescriptor).
+		Select(common.ColDescriptorID).
+		Where(goqu.C(common.ColAASDescriptorID).Eq(descriptorID))
+	if err := deleteDescriptorRowsBySelectTx(ctx, tx, childDescriptorIDs); err != nil {
+		return err
+	}
+
+	for _, tableName := range []string{
+		common.TblAASDescriptorEndpoint,
+		common.TblSpecificAssetID,
+		common.TblDescriptorPayload,
+	} {
+		sqlStr, args, buildErr := d.
+			Delete(tableName).
+			Where(goqu.C(common.ColDescriptorID).Eq(descriptorID)).
+			ToSQL()
+		if buildErr != nil {
+			return buildErr
+		}
+		if _, err := tx.ExecContext(ctx, sqlStr, args...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteDescriptorRowsBySelectTx(ctx context.Context, tx *sql.Tx, descriptorIDs *goqu.SelectDataset) error {
+	d := goqu.Dialect(common.Dialect)
+	sqlStr, args, buildErr := d.
+		Delete(common.TblDescriptor).
+		Where(goqu.C(common.ColID).In(descriptorIDs)).
+		ToSQL()
+	if buildErr != nil {
+		return buildErr
+	}
+	_, err := tx.ExecContext(ctx, sqlStr, args...)
+	return err
 }
 
 func buildAASDescriptorInsertRecord(

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -252,7 +252,7 @@ func UpsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd
 		if err = replaceAdministrationShellDescriptorDetailsTx(ctx, tx, descriptorID, aasd); err != nil {
 			return false, err
 		}
-		return false, err
+		return false, nil
 	}
 
 	return true, InsertAdministrationShellDescriptorTx(ctx, tx, aasd)

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -239,16 +239,23 @@ func UpsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd
 }
 
 func lockAASDescriptorUpsertTx(ctx context.Context, tx *sql.Tx, aasID string) error {
-	d := goqu.Dialect(common.Dialect)
-	sqlStr, args, buildErr := d.
-		Select(goqu.Func("pg_advisory_xact_lock", goqu.Func("hashtext", "aas_descriptor:"+aasID))).
-		ToSQL()
-	if buildErr != nil {
-		return buildErr
+	sqlStr, args, err := buildAASDescriptorUpsertLockSQL(aasID)
+	if err != nil {
+		return common.NewInternalServerError("AASDESC-LOCKAASUPSERT-BUILDSQL " + err.Error())
 	}
 
-	_, err := tx.ExecContext(ctx, sqlStr, args...)
-	return err
+	if _, err = tx.ExecContext(ctx, sqlStr, args...); err != nil {
+		return common.NewInternalServerError("AASDESC-LOCKAASUPSERT-EXECSQL " + err.Error())
+	}
+	return nil
+}
+
+func buildAASDescriptorUpsertLockSQL(aasID string) (string, []any, error) {
+	return goqu.
+		Dialect(common.Dialect).
+		Select(goqu.Func("pg_advisory_xact_lock", goqu.Func("hashtextextended", "aas_descriptor:"+aasID, 0))).
+		Prepared(true).
+		ToSQL()
 }
 
 func selectAASDescriptorIDForUpdateTx(ctx context.Context, tx *sql.Tx, aasID string) (int64, bool, error) {

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -218,6 +218,26 @@ func insertAdministrationShellDescriptorDetailsTx(ctx context.Context, tx *sql.T
 	return createSubModelDescriptors(tx, sql.NullInt64{Int64: descriptorID, Valid: true}, aasd.SubmodelDescriptors)
 }
 
+// UpsertAdministrationShellDescriptorTx upserts an AssetAdministrationShellDescriptor
+// within the provided transaction. It first acquires an advisory lock scoped to
+// the AAS Id to prevent concurrent upserts for the same AAS. Then it attempts
+// to locate the internal descriptor id for the given AAS Id using a SELECT
+// ... FOR UPDATE to lock the row. If a descriptor is found, the function
+// replaces the descriptor details; otherwise it inserts a new descriptor and
+// related rows.
+//
+// The function returns a boolean indicating whether a new descriptor was
+// created (true) or an existing descriptor was replaced (false), and an error
+// when the operation fails. The caller is responsible for committing or
+// rolling back the supplied transaction `tx`.
+//
+// Parameters:
+//  - ctx: context for cancellation and query filtering.
+//  - tx: database transaction to use for the upsert (must be non-nil).
+//  - aasd: the AssetAdministrationShellDescriptor to insert or replace.
+//
+// Note: This function relies on advisory locks and FOR UPDATE row locking to
+// avoid race conditions; it must be invoked inside a transaction.
 func UpsertAdministrationShellDescriptorTx(ctx context.Context, tx *sql.Tx, aasd model.AssetAdministrationShellDescriptor) (bool, error) {
 	if err := lockAASDescriptorUpsertTx(ctx, tx, aasd.Id); err != nil {
 		return false, err

--- a/internal/common/descriptors/asset_admin_shell_descriptor_insert_test.go
+++ b/internal/common/descriptors/asset_admin_shell_descriptor_insert_test.go
@@ -71,3 +71,19 @@ func TestBuildAASDescriptorInsertRecord_DoesNotWriteCreatedAtWhenMissing(t *test
 		t.Fatalf("expected %q to be absent when payload createdAt is nil", common.ColCreatedAt)
 	}
 }
+
+func TestBuildAASDescriptorUpsertLockSQLUsesPostgresPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	query, args, err := buildAASDescriptorUpsertLockSQL("aas-1")
+
+	if err != nil {
+		t.Fatalf("buildAASDescriptorUpsertLockSQL returned error: %v", err)
+	}
+	if query != "SELECT pg_advisory_xact_lock(hashtextextended($1, $2))" {
+		t.Fatalf("unexpected query: %s", query)
+	}
+	if len(args) != 2 || args[0] != "aas_descriptor:aas-1" || args[1] != int64(0) {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}

--- a/internal/smregistry/persistence/PostgreSQLSMDatabase.go
+++ b/internal/smregistry/persistence/PostgreSQLSMDatabase.go
@@ -32,6 +32,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/doug-martin/goqu/v9"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/descriptors"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
@@ -135,6 +136,10 @@ func (p *PostgreSQLSMDatabase) UpsertSubmodelDescriptorInTransaction(
 		return common.NewInternalServerError("SMREG-UPSERTSMDESC-NILTX transaction must not be nil")
 	}
 
+	if err := lockSubmodelDescriptorUpsertTx(ctx, tx, submodel.Id); err != nil {
+		return err
+	}
+
 	if err := descriptors.DeleteSubmodelDescriptorByIDTx(ctx, tx, submodel.Id); err != nil {
 		if !common.IsErrNotFound(err) {
 			return err
@@ -144,6 +149,19 @@ func (p *PostgreSQLSMDatabase) UpsertSubmodelDescriptorInTransaction(
 	}
 
 	_, err := descriptors.InsertSubmodelDescriptorTx(ctx, tx, submodel)
+	return err
+}
+
+func lockSubmodelDescriptorUpsertTx(ctx context.Context, tx *sql.Tx, submodelID string) error {
+	d := goqu.Dialect(common.Dialect)
+	sqlStr, args, buildErr := d.
+		Select(goqu.Func("pg_advisory_xact_lock", goqu.Func("hashtext", "submodel_descriptor:"+submodelID))).
+		ToSQL()
+	if buildErr != nil {
+		return buildErr
+	}
+
+	_, err := tx.ExecContext(ctx, sqlStr, args...)
 	return err
 }
 

--- a/internal/smregistry/persistence/PostgreSQLSMDatabase.go
+++ b/internal/smregistry/persistence/PostgreSQLSMDatabase.go
@@ -153,16 +153,23 @@ func (p *PostgreSQLSMDatabase) UpsertSubmodelDescriptorInTransaction(
 }
 
 func lockSubmodelDescriptorUpsertTx(ctx context.Context, tx *sql.Tx, submodelID string) error {
-	d := goqu.Dialect(common.Dialect)
-	sqlStr, args, buildErr := d.
-		Select(goqu.Func("pg_advisory_xact_lock", goqu.Func("hashtext", "submodel_descriptor:"+submodelID))).
-		ToSQL()
-	if buildErr != nil {
-		return buildErr
+	sqlStr, args, err := buildSubmodelDescriptorUpsertLockSQL(submodelID)
+	if err != nil {
+		return common.NewInternalServerError("SMREG-LOCKSMDESCUPSERT-BUILDSQL " + err.Error())
 	}
 
-	_, err := tx.ExecContext(ctx, sqlStr, args...)
-	return err
+	if _, err = tx.ExecContext(ctx, sqlStr, args...); err != nil {
+		return common.NewInternalServerError("SMREG-LOCKSMDESCUPSERT-EXECSQL " + err.Error())
+	}
+	return nil
+}
+
+func buildSubmodelDescriptorUpsertLockSQL(submodelID string) (string, []any, error) {
+	return goqu.
+		Dialect(common.Dialect).
+		Select(goqu.Func("pg_advisory_xact_lock", goqu.Func("hashtextextended", "submodel_descriptor:"+submodelID, 0))).
+		Prepared(true).
+		ToSQL()
 }
 
 // GetSubmodelDescriptorByID returns a global Submodel Descriptor by its id.

--- a/internal/smregistry/persistence/postgresql_sm_database_test.go
+++ b/internal/smregistry/persistence/postgresql_sm_database_test.go
@@ -1,3 +1,28 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
 package smregistrypostgresql
 
 import "testing"

--- a/internal/smregistry/persistence/postgresql_sm_database_test.go
+++ b/internal/smregistry/persistence/postgresql_sm_database_test.go
@@ -1,0 +1,19 @@
+package smregistrypostgresql
+
+import "testing"
+
+func TestBuildSubmodelDescriptorUpsertLockSQLUsesPostgresPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	query, args, err := buildSubmodelDescriptorUpsertLockSQL("submodel-1")
+
+	if err != nil {
+		t.Fatalf("buildSubmodelDescriptorUpsertLockSQL returned error: %v", err)
+	}
+	if query != "SELECT pg_advisory_xact_lock(hashtextextended($1, $2))" {
+		t.Fatalf("unexpected query: %s", query)
+	}
+	if len(args) != 2 || args[0] != "submodel_descriptor:submodel-1" || args[1] != int64(0) {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}


### PR DESCRIPTION
## Description

Fixes a race condition in registry descriptor synchronization when `GENERAL_AASREGISTRYINTEGRATION=true`.

Concurrent `POST /shells/{id}/submodel-refs` requests could trigger parallel registry upserts for the same AAS descriptor. The previous SELECT/insert-style flow was vulnerable under PostgreSQL `READ COMMITTED`, allowing both transactions to observe a missing descriptor and then race on insert, causing duplicate key violations and a 500 response.

This change adds coverage for the concurrent submodel-reference creation flow and updates descriptor synchronization to serialize conflicting descriptor upserts by descriptor id. A similar overlapping upsert scope in the submodel registry was also guarded.

## Changes

- Added an integration test for concurrent `POST /shells/{id}/submodel-refs` with registry synchronization enabled.
- Fixed AAS descriptor upsert behavior to avoid duplicate key races during concurrent registry sync.
- Updated AAS descriptor handling to update the main descriptor row in place and replace dependent descriptor details transactionally.
- Added transaction-scoped serialization for overlapping submodel descriptor upserts in the SM registry.
- Checked similar coupled API/DB descriptor synchronization paths for comparable race conditions.

## Problem

With `GENERAL_AASREGISTRYINTEGRATION=true`, two parallel submodel-reference creations for the same shell could both call the AAS descriptor upsert path. Because the old implementation used a SELECT-before-INSERT pattern, PostgreSQL statement snapshots could allow both transactions to see no existing descriptor. One transaction would insert successfully, while the other failed with a duplicate key violation such as:

```text
pq: duplicate key value violates unique constraint "aas_descriptor_id_key" (23505)
```

This surfaced as:

```text
AASREPO-500-PostSubmodelReferenceAasRepository-InternalServerError-CreateSubmodelReferenceInAssetAdministrationShell
```

## Solution

The AAS registry descriptor upsert now serializes concurrent work for the same descriptor id inside the transaction and updates existing descriptor rows instead of deleting/reinserting the root descriptor row. Dependent descriptor data is replaced transactionally so nested descriptor state stays consistent.

A similar race-prone submodel descriptor upsert path was also protected with transaction-scoped per-descriptor serialization.

## Testing

- `go test -v ./internal/common/descriptors ./internal/aasregistry/persistence ./internal/smregistry/persistence`
- `go vet ./internal/common/descriptors ./internal/aasregistry/persistence ./internal/smregistry/persistence ./internal/aasenvironment/integration_tests`
- `go test -v ./internal/aasenvironment/integration_tests`
- `go clean -testcache`
- `go test -v ./internal/submodelrepository/integration_tests`

## Notes

The new race test is concurrency-based, so the pre-fix failure is timing dependent. The test verifies the intended behavior: concurrent submodel-reference creation must not return 500 responses and must not lose created references.
