### PR TITLE
Adds config option to toggle swagger

### DIFF
--- a/cmd/aasrepositoryservice/config.yaml
+++ b/cmd/aasrepositoryservice/config.yaml
@@ -34,6 +34,7 @@ general:
 #   certificateChainPath: "./rsa-cert.pem"
 
 # swagger:
+#   enabled: true
 #   contactName: "Eclipse BaSyx"
 #   contactEmail: "basyx-dev@eclipse.org"
 #   contactUrl: "https://basyx.org"

--- a/cmd/aasxfileserverservice/config.yaml
+++ b/cmd/aasxfileserverservice/config.yaml
@@ -17,6 +17,7 @@ general:
   uploadMaxSizeBytes: 134217728
 
 # swagger:
+#   enabled: true
 #   contactName: "Eclipse BaSyx"
 #   contactEmail: "basyx-dev@eclipse.org"
 #   contactUrl: "https://basyx.org"

--- a/cmd/conceptdescriptionrepositoryservice/config.yaml
+++ b/cmd/conceptdescriptionrepositoryservice/config.yaml
@@ -23,6 +23,7 @@ abac:
   modelPath: "config/access_rules/access-rules.json"
 
 # swagger:
+#   enabled: true
 #   contactName: "Eclipse BaSyx"
 #   contactEmail: "basyx-dev@eclipse.org"
 #   contactUrl: "https://basyx.org"

--- a/cmd/submodelrepositoryservice/config.yaml
+++ b/cmd/submodelrepositoryservice/config.yaml
@@ -34,6 +34,7 @@ general:
 #   certificateChainPath: "./rsa-cert.pem"
 
 # swagger:
+#   enabled: true
 #   contactName: "Eclipse BaSyx"
 #   contactEmail: "basyx-dev@eclipse.org"
 #   contactUrl: "https://basyx.org"

--- a/docu/security/ABAC_POLICY_REPOSITORY.md
+++ b/docu/security/ABAC_POLICY_REPOSITORY.md
@@ -50,7 +50,7 @@ The importer validates the configured JSON, canonicalizes it, materializes refer
 
 ## Management API
 
-The management API is mounted under `/security/abac/**` only when both `abac.enabled` and `abac.managementApi.enabled` are true. Swagger/OpenAPI exposes these endpoints under the same condition.
+The management API is mounted under `/security/abac/**` only when both `abac.enabled` and `abac.managementApi.enabled` are true. Swagger/OpenAPI exposes these endpoints only when the management API is active and `swagger.enabled` is true.
 
 Digital Twin Registry is the exception: it never exposes the management API. Its access-rule file remains the service source of truth and is imported on every restart by default.
 

--- a/internal/common/configuration.go
+++ b/internal/common/configuration.go
@@ -103,6 +103,7 @@ var DefaultConfig = struct {
 	EventingSinks                       []string
 	EventingOutboxEnabled               bool
 	EventingTopicPrefix                 string
+	SwaggerEnabled                      bool
 }{
 	ServerPort:                          5004,
 	ServerContextPath:                   "",
@@ -158,6 +159,7 @@ var DefaultConfig = struct {
 	EventingSinks:                       []string{},
 	EventingOutboxEnabled:               false,
 	EventingTopicPrefix:                 "basyx",
+	SwaggerEnabled:                      true,
 }
 
 const (
@@ -227,7 +229,7 @@ type Config struct {
 	OIDC     OIDCConfig     `mapstructure:"oidc" yaml:"oidc"`         // OpenID Connect authentication
 	ABAC     ABACConfig     `mapstructure:"abac" yaml:"abac"`         // Attribute-Based Access Control
 	JWS      JWSConfig      `mapstructure:"jws" yaml:"jws"`           // JWS signing configuration
-	Swagger  SwaggerConfig  `mapstructure:"swagger" yaml:"swagger"`   // Swagger UI configuration
+	Swagger  SwaggerConfig  `mapstructure:"swagger" yaml:"swagger"`   // Swagger/OpenAPI documentation configuration
 	History  HistoryConfig  `mapstructure:"history" yaml:"history"`   // History/audit behavior
 	Eventing EventingConfig `mapstructure:"eventing" yaml:"eventing"` // Eventing placeholders
 }
@@ -287,8 +289,9 @@ type EventingConfig struct {
 	TopicPrefix   string   `mapstructure:"topicPrefix" yaml:"topicPrefix" json:"topicPrefix"`
 }
 
-// SwaggerConfig contains Swagger UI configuration parameters.
+// SwaggerConfig contains Swagger/OpenAPI documentation configuration parameters.
 type SwaggerConfig struct {
+	Enabled      bool   `mapstructure:"enabled" yaml:"enabled"`           // Enable/disable Swagger UI and OpenAPI spec endpoints
 	ContactName  string `mapstructure:"contactName" yaml:"contactName"`   // Contact name for OpenAPI spec
 	ContactEmail string `mapstructure:"contactEmail" yaml:"contactEmail"` // Contact email for OpenAPI spec
 	ContactURL   string `mapstructure:"contactUrl" yaml:"contactUrl"`     // Contact URL for OpenAPI spec
@@ -885,6 +888,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("eventing.topicPrefix", "basyx")
 
 	// Swagger defaults
+	v.SetDefault("swagger.enabled", DefaultConfig.SwaggerEnabled)
 	v.SetDefault("swagger.contactName", "Eclipse BaSyx")
 	v.SetDefault("swagger.contactEmail", "basyx-dev@eclipse.org")
 	v.SetDefault("swagger.contactUrl", "https://basyx.org")
@@ -1011,6 +1015,9 @@ func PrintConfiguration(cfg *Config) {
 			lines = append(lines, "  Certificate Chain Mounted: false ❌")
 		}
 	}
+
+	lines = append(lines, "🔹 Swagger:")
+	add("Enabled", cfg.Swagger.Enabled, DefaultConfig.SwaggerEnabled)
 
 	// History
 	lines = append(lines, "🔹 History/Audit:")

--- a/internal/common/configuration.go
+++ b/internal/common/configuration.go
@@ -1016,8 +1016,12 @@ func PrintConfiguration(cfg *Config) {
 		}
 	}
 
+	lines = append(lines, divider)
+
 	lines = append(lines, "🔹 Swagger:")
 	add("Enabled", cfg.Swagger.Enabled, DefaultConfig.SwaggerEnabled)
+
+	lines = append(lines, divider)
 
 	// History
 	lines = append(lines, "🔹 History/Audit:")

--- a/internal/common/configuration_test.go
+++ b/internal/common/configuration_test.go
@@ -108,6 +108,16 @@ func TestViperAndStructStrictVerificationDefaultsMatch(t *testing.T) {
 	}
 }
 
+func TestViperAndStructSwaggerEnabledDefaultsMatch(t *testing.T) {
+	v := viper.New()
+	setDefaults(v)
+
+	actual := v.GetBool("swagger.enabled")
+	if actual != DefaultConfig.SwaggerEnabled {
+		t.Fatalf("viper default %t differs from DefaultConfig %t", actual, DefaultConfig.SwaggerEnabled)
+	}
+}
+
 func TestPrintConfigurationMarksPermissiveVerificationModeAsDefault(t *testing.T) {
 	output := captureLogOutput(t)
 	cfg := &Config{
@@ -134,12 +144,18 @@ func TestPrintConfigurationMarksPermissiveVerificationModeAsDefault(t *testing.T
 		ABAC: ABACConfig{
 			Enabled: DefaultConfig.ABACEnabled,
 		},
+		Swagger: SwaggerConfig{
+			Enabled: DefaultConfig.SwaggerEnabled,
+		},
 	}
 
 	PrintConfiguration(cfg)
 
 	if !strings.Contains(output.String(), "Verification Mode: permissive (default)") {
 		t.Fatalf("printed configuration did not mark permissive verification mode as default:\n%s", output.String())
+	}
+	if !strings.Contains(output.String(), "Enabled: true (default)") {
+		t.Fatalf("printed configuration did not mark Swagger enabled as default:\n%s", output.String())
 	}
 }
 
@@ -182,6 +198,28 @@ func TestLoadConfigAcceptsPermissiveStrictVerification(t *testing.T) {
 	}
 	if cfg.Server.StrictVerification != "permissive" {
 		t.Fatalf("unexpected strictVerification mode: %q", cfg.Server.StrictVerification)
+	}
+}
+
+func TestLoadConfigAppliesSwaggerEnabled(t *testing.T) {
+	withUnsetEnv(t, "SWAGGER_ENABLED")
+	captureLogOutput(t)
+
+	cfg, err := LoadConfig("", NORMAL)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+	if !cfg.Swagger.Enabled {
+		t.Fatal("expected Swagger to be enabled by default")
+	}
+
+	path := writeTempConfig(t, "swagger:\n  enabled: false\n")
+	cfg, err = LoadConfig(path, NORMAL)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+	if cfg.Swagger.Enabled {
+		t.Fatal("expected Swagger to be disabled from config")
 	}
 }
 

--- a/internal/common/swagger.go
+++ b/internal/common/swagger.go
@@ -92,6 +92,7 @@ type SwaggerUIConfig struct {
 	ServerURL             string         // Server URL to use in OpenAPI spec (e.g., "http://localhost:5004/api")
 	BasePath              string         // Base path for redirect to Swagger UI (e.g., "/" or "/api")
 	Contact               *ContactConfig // Contact information to inject into OpenAPI spec
+	Enabled               *bool          // nil/default=true, false disables Swagger UI and OpenAPI spec endpoints
 	IncludeVerifyEndpoint *bool          // nil/default=true, false disables /verify injection in OpenAPI spec
 	IncludeABACManagement *bool          // nil/default=false, true injects ABAC management API paths
 }
@@ -1435,10 +1436,19 @@ func injectContact(specContent []byte, contact *ContactConfig) []byte {
 //   - r: Chi router to add endpoints to
 //   - cfg: Swagger UI configuration
 //
-// This adds two endpoints:
+// When enabled, this adds these endpoints:
 //   - cfg.UIPath: Serves the Swagger UI HTML page
 //   - cfg.SpecPath: Serves the OpenAPI specification file
 func AddSwaggerUI(r *chi.Mux, cfg SwaggerUIConfig) {
+	enabled := true
+	if cfg.Enabled != nil {
+		enabled = *cfg.Enabled
+	}
+	if !enabled {
+		log.Printf("📖 Swagger disabled")
+		return
+	}
+
 	// Inject server URL into spec if configured
 	specContent := cfg.SpecContent
 	if cfg.ServerURL != "" {
@@ -1524,7 +1534,8 @@ func AddSwaggerUI(r *chi.Mux, cfg SwaggerUIConfig) {
 	log.Printf("📄 OpenAPI spec available at %s", cfg.SpecPath)
 }
 
-// AddSwaggerUIFromFS adds Swagger UI endpoints using an embedded filesystem
+// AddSwaggerUIFromFS adds Swagger/OpenAPI documentation endpoints using an embedded filesystem.
+// When serverConfig.Swagger.Enabled is false, no documentation endpoints are added.
 //
 // Parameters:
 //   - r: Chi router to add endpoints to
@@ -1535,6 +1546,11 @@ func AddSwaggerUI(r *chi.Mux, cfg SwaggerUIConfig) {
 //   - specPath: URL path for the spec file (e.g., "/api-docs/openapi.yaml")
 //   - serverConfig: Server configuration for building the server URL
 func AddSwaggerUIFromFS(r *chi.Mux, specFS embed.FS, specFile string, title string, uiPath string, specPath string, serverConfig *Config) error {
+	if serverConfig != nil && !serverConfig.Swagger.Enabled {
+		log.Printf("📖 Swagger disabled")
+		return nil
+	}
+
 	content, err := fs.ReadFile(specFS, specFile)
 	if err != nil {
 		return err
@@ -1574,6 +1590,7 @@ func AddSwaggerUIFromFS(r *chi.Mux, specFS embed.FS, specFile string, title stri
 
 	// Build contact config if provided
 	var contact *ContactConfig
+	var enabled *bool
 	var includeVerifyEndpoint *bool
 	var includeABACManagement *bool
 	if serverConfig != nil && (serverConfig.Swagger.ContactName != "" || serverConfig.Swagger.ContactEmail != "" || serverConfig.Swagger.ContactURL != "") {
@@ -1584,6 +1601,7 @@ func AddSwaggerUIFromFS(r *chi.Mux, specFS embed.FS, specFile string, title stri
 		}
 	}
 	if serverConfig != nil {
+		enabled = &serverConfig.Swagger.Enabled
 		includeVerifyEndpoint = &serverConfig.Server.VerificationEndpointAvailable
 		abacManagementEnabled := shouldIncludeABACManagement(serverConfig)
 		includeABACManagement = &abacManagementEnabled
@@ -1598,6 +1616,7 @@ func AddSwaggerUIFromFS(r *chi.Mux, specFS embed.FS, specFile string, title stri
 		ServerURL:             serverURL,
 		BasePath:              basePath,
 		Contact:               contact,
+		Enabled:               enabled,
 		IncludeVerifyEndpoint: includeVerifyEndpoint,
 		IncludeABACManagement: includeABACManagement,
 	})

--- a/internal/common/swagger_test.go
+++ b/internal/common/swagger_test.go
@@ -104,6 +104,80 @@ func TestAddSwaggerUIServesLocalPart2Schemas(t *testing.T) {
 	}
 }
 
+func TestAddSwaggerUIFromFSHonorsSwaggerEnabled(t *testing.T) {
+	r := chi.NewRouter()
+	cfg := &Config{
+		Server: ServerConfig{
+			Host:                          "0.0.0.0",
+			Port:                          5004,
+			VerificationEndpointAvailable: true,
+		},
+		Swagger: SwaggerConfig{
+			Enabled: false,
+		},
+	}
+
+	err := AddSwaggerUIFromFS(r, part2SchemasFS, "swagger_part2_schemas/V3.1.1/openapi.yaml", "test", "/swagger", "/api-docs/openapi.yaml", cfg)
+	if err != nil {
+		t.Fatalf("unexpected AddSwaggerUIFromFS error: %v", err)
+	}
+
+	specRecorder := httptest.NewRecorder()
+	r.ServeHTTP(specRecorder, httptest.NewRequest(http.MethodGet, "/api-docs/openapi.yaml", nil))
+	if specRecorder.Code != http.StatusNotFound {
+		t.Fatalf("expected disabled OpenAPI spec status 404, got %d", specRecorder.Code)
+	}
+
+	uiRecorder := httptest.NewRecorder()
+	r.ServeHTTP(uiRecorder, httptest.NewRequest(http.MethodGet, "/swagger", nil))
+	if uiRecorder.Code != http.StatusNotFound {
+		t.Fatalf("expected disabled Swagger status 404, got %d", uiRecorder.Code)
+	}
+
+	baseRecorder := httptest.NewRecorder()
+	r.ServeHTTP(baseRecorder, httptest.NewRequest(http.MethodGet, "/", nil))
+	if baseRecorder.Code != http.StatusNotFound {
+		t.Fatalf("expected disabled Swagger UI base path status 404, got %d", baseRecorder.Code)
+	}
+}
+
+func TestAddSwaggerUIFromFSDisablesSpecWhenABACManagementIsEnabled(t *testing.T) {
+	r := chi.NewRouter()
+	cfg := &Config{
+		Server: ServerConfig{
+			Host:                          "0.0.0.0",
+			Port:                          5004,
+			VerificationEndpointAvailable: true,
+		},
+		Swagger: SwaggerConfig{
+			Enabled: false,
+		},
+		ABAC: ABACConfig{
+			Enabled: true,
+			ManagementAPI: ABACManagementAPIConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	err := AddSwaggerUIFromFS(r, part2SchemasFS, "swagger_part2_schemas/V3.1.1/openapi.yaml", "test", "/swagger", "/api-docs/openapi.yaml", cfg)
+	if err != nil {
+		t.Fatalf("unexpected AddSwaggerUIFromFS error: %v", err)
+	}
+
+	uiRecorder := httptest.NewRecorder()
+	r.ServeHTTP(uiRecorder, httptest.NewRequest(http.MethodGet, "/swagger", nil))
+	if uiRecorder.Code != http.StatusNotFound {
+		t.Fatalf("expected disabled Swagger UI status 404, got %d", uiRecorder.Code)
+	}
+
+	specRecorder := httptest.NewRecorder()
+	r.ServeHTTP(specRecorder, httptest.NewRequest(http.MethodGet, "/api-docs/openapi.yaml", nil))
+	if specRecorder.Code != http.StatusNotFound {
+		t.Fatalf("expected disabled OpenAPI spec status 404, got %d", specRecorder.Code)
+	}
+}
+
 func TestAddSwaggerUIDoesNotInjectVerifyEndpointWhenDisabled(t *testing.T) {
 	r := chi.NewRouter()
 	includeVerifyEndpoint := false

--- a/internal/common/swagger_test.go
+++ b/internal/common/swagger_test.go
@@ -141,7 +141,7 @@ func TestAddSwaggerUIFromFSHonorsSwaggerEnabled(t *testing.T) {
 	}
 }
 
-func TestAddSwaggerUIFromFSDisablesSpecWhenABACManagementIsEnabled(t *testing.T) {
+func TestAddSwaggerUIFromFSDisablesAllDocumentationWhenABACManagementIsEnabled(t *testing.T) {
 	r := chi.NewRouter()
 	cfg := &Config{
 		Server: ServerConfig{


### PR DESCRIPTION
This pull request introduces a new configuration option to enable or disable Swagger/OpenAPI documentation endpoints across services, making the exposure of API documentation endpoints configurable and off by default in certain scenarios. The implementation includes changes to configuration files, core configuration logic, and comprehensive test coverage to ensure the new option works as expected.

The most important changes are:

**Configuration and Defaults:**

* Added a new `enabled` option under the `swagger` section in all service configuration files (e.g., `config.yaml`), allowing Swagger/OpenAPI endpoints to be toggled on or off. This is now set to `true` by default. [[1]](diffhunk://#diff-975e30ea8bfc1996f7478de945d564f2a1e1f174df8f959c5180e5d4e0bb478fR37) [[2]](diffhunk://#diff-abbf795d76289d5c92fa9c0bd16d3db01115b995d7690dd6a5d5a9eafb008c06R20) [[3]](diffhunk://#diff-b2e5a6912f895a6c986fdcc414f7a510bd832ce830956d5f98413a7b8d013abbR26) [[4]](diffhunk://#diff-3ae41d49518d727faf493a93d35c39b029366df73f8ef4f8534a956f8e095e1eR37)
* Updated the central configuration struct (`SwaggerConfig` in `configuration.go`) to include the `Enabled` field and set its default value. The configuration printout and documentation have also been updated to reflect this new option. [[1]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R106) [[2]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R162) [[3]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21L230-R232) [[4]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21L290-R294) [[5]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R891) [[6]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R1019-R1021)

**Swagger/OpenAPI Endpoint Logic:**

* Modified the logic in `swagger.go` so that Swagger/OpenAPI endpoints are only added to the router if the `enabled` flag is set. This affects both direct and embedded filesystem-based endpoint registration. [[1]](diffhunk://#diff-2922cc8adea355f39d9e5098e6bd2788255ba44fa92edea0a3bd574136b151d4R95) [[2]](diffhunk://#diff-2922cc8adea355f39d9e5098e6bd2788255ba44fa92edea0a3bd574136b151d4L1438-R1451) [[3]](diffhunk://#diff-2922cc8adea355f39d9e5098e6bd2788255ba44fa92edea0a3bd574136b151d4L1527-R1538) [[4]](diffhunk://#diff-2922cc8adea355f39d9e5098e6bd2788255ba44fa92edea0a3bd574136b151d4R1549-R1553) [[5]](diffhunk://#diff-2922cc8adea355f39d9e5098e6bd2788255ba44fa92edea0a3bd574136b151d4R1593) [[6]](diffhunk://#diff-2922cc8adea355f39d9e5098e6bd2788255ba44fa92edea0a3bd574136b151d4R1604) [[7]](diffhunk://#diff-2922cc8adea355f39d9e5098e6bd2788255ba44fa92edea0a3bd574136b151d4R1619)

**Documentation:**

* Clarified in the ABAC policy repository documentation that Swagger/OpenAPI endpoints for the management API are only exposed when both the management API and the new `swagger.enabled` flag are true.

**Testing:**

* Added and updated tests to verify the correct behavior of the `swagger.enabled` flag, including default value checks, configuration loading, and endpoint exposure or suppression. [[1]](diffhunk://#diff-160e618ebbfc84b3000fb7dcfffc15c6f9dfadaafe3d1915e5a47f3393dcc46cR111-R120) [[2]](diffhunk://#diff-160e618ebbfc84b3000fb7dcfffc15c6f9dfadaafe3d1915e5a47f3393dcc46cR147-R159) [[3]](diffhunk://#diff-160e618ebbfc84b3000fb7dcfffc15c6f9dfadaafe3d1915e5a47f3393dcc46cR204-R225) [[4]](diffhunk://#diff-586200c210559d658be2738a1d4c51c770a07ba9ddde53c56a2158555b21a3efR107-R180)

These changes ensure that API documentation endpoints can be easily disabled in production or sensitive environments, improving security and configuration flexibility.

Closes #339 