### PR TITLE
Add EDC-PROTOCOL as allowed endpoint interface to Company Lookup

### DIFF
--- a/internal/common/model/model_company_descriptor.go
+++ b/internal/common/model/model_company_descriptor.go
@@ -27,6 +27,7 @@ var allowedCompanyEndpointInterfaces = map[string]struct{}{
 	"AASX-FILE-3.0":           {},
 	"AASX-FILE-3.1":           {},
 	"MQTT-BROKER-3.1.1":       {},
+	"EDC-PROTOCOL":            {},
 }
 
 var requiredCoreCompanyEndpointInterfaces = map[string]struct{}{


### PR DESCRIPTION
This PR adds EDC-PROTOCOL as an allowed endpoint interface to the Company Lookup service.
