### PR TITLE
Removes verification Operation from DPP API Swagger UI

### DIFF
--- a/cmd/dppapiservice/config.yaml
+++ b/cmd/dppapiservice/config.yaml
@@ -2,7 +2,6 @@ server:
   port: 8080
   contextPath: ""
   host: 0.0.0.0
-  verificationEndpointAvailable: false
 
 postgres:
   host: localhost

--- a/cmd/dppapiservice/config.yaml
+++ b/cmd/dppapiservice/config.yaml
@@ -2,6 +2,7 @@ server:
   port: 8080
   contextPath: ""
   host: 0.0.0.0
+  verificationEndpointAvailable: false
 
 postgres:
   host: localhost

--- a/internal/common/swagger.go
+++ b/internal/common/swagger.go
@@ -1534,18 +1534,18 @@ func AddSwaggerUI(r *chi.Mux, cfg SwaggerUIConfig) {
 	log.Printf("📄 OpenAPI spec available at %s", cfg.SpecPath)
 }
 
-// AddSwaggerUIFromFS adds Swagger/OpenAPI documentation endpoints using an embedded filesystem.
+// AddSwaggerUIFromFS adds Swagger/OpenAPI documentation endpoints using a filesystem.
 // When serverConfig.Swagger.Enabled is false, no documentation endpoints are added.
 //
 // Parameters:
 //   - r: Chi router to add endpoints to
-//   - specFS: Embedded filesystem containing the OpenAPI spec
-//   - specFile: Path to the spec file within the embedded FS
+//   - specFS: Filesystem containing the OpenAPI spec
+//   - specFile: Path to the spec file within the filesystem
 //   - title: Title for the Swagger UI page
 //   - uiPath: URL path for Swagger UI (e.g., "/swagger")
 //   - specPath: URL path for the spec file (e.g., "/api-docs/openapi.yaml")
 //   - serverConfig: Server configuration for building the server URL
-func AddSwaggerUIFromFS(r *chi.Mux, specFS embed.FS, specFile string, title string, uiPath string, specPath string, serverConfig *Config) error {
+func AddSwaggerUIFromFS(r *chi.Mux, specFS fs.FS, specFile string, title string, uiPath string, specPath string, serverConfig *Config) error {
 	if serverConfig != nil && !serverConfig.Swagger.Enabled {
 		log.Printf("📖 Swagger disabled")
 		return nil

--- a/internal/dppapiservice/server.go
+++ b/internal/dppapiservice/server.go
@@ -29,7 +29,7 @@ package dppapiservice
 
 import (
 	"context"
-	"embed"
+	"io/fs"
 	"log"
 	"net/http"
 
@@ -54,7 +54,7 @@ import (
 // Returns:
 //   - http.Handler: Configured root HTTP handler for the DPP API service
 //   - error: Setup error if security or router assembly fails
-func NewHTTPHandler(ctx context.Context, cfg *common.Config, openapiSpec embed.FS, aasRepo *aasrepositorydb.AssetAdministrationShellDatabase, submodelRepo *submodelrepositorydb.SubmodelDatabase) (http.Handler, error) {
+func NewHTTPHandler(ctx context.Context, cfg *common.Config, openapiSpec fs.FS, aasRepo *aasrepositorydb.AssetAdministrationShellDatabase, submodelRepo *submodelrepositorydb.SubmodelDatabase) (http.Handler, error) {
 	dppService := dppapi.NewDPPRepositoryService(aasRepo, submodelRepo)
 	dppRouter := dppapi.NewDPPRepositoryRouter(dppService)
 	contextPath := common.NormalizeBasePath(cfg.Server.ContextPath)
@@ -63,7 +63,7 @@ func NewHTTPHandler(ctx context.Context, cfg *common.Config, openapiSpec embed.F
 	rootRouter.Use(common.ConfigMiddleware(cfg))
 	common.AddCors(rootRouter, cfg)
 	common.AddHealthEndpoint(rootRouter, cfg)
-	if err := common.AddSwaggerUIFromFS(rootRouter, openapiSpec, "openapi.yaml", "Digital Product Passport API", "/swagger", "/api-docs/openapi.yaml", cfg); err != nil {
+	if err := common.AddSwaggerUIFromFS(rootRouter, openapiSpec, "openapi.yaml", "Digital Product Passport API", "/swagger", "/api-docs/openapi.yaml", dppSwaggerConfig(cfg)); err != nil {
 		log.Printf("Warning: failed to load OpenAPI spec for Swagger UI: %v", err)
 	}
 	rootRouter.Get(rootRedirectPath(contextPath), func(w http.ResponseWriter, r *http.Request) {
@@ -100,6 +100,16 @@ func ConfigureHistory(cfg common.HistoryConfig) {
 		Immutability:         cfg.Immutability,
 		AuditIdentityMode:    cfg.AuditIdentityMode,
 	})
+}
+
+func dppSwaggerConfig(cfg *common.Config) *common.Config {
+	if cfg == nil {
+		return nil
+	}
+
+	swaggerConfig := *cfg
+	swaggerConfig.Server.VerificationEndpointAvailable = false
+	return &swaggerConfig
 }
 
 func classifyDPPRoute(versioningGuard *history.MutationCoverageGuard, route dppapi.Route) {

--- a/internal/dppapiservice/server.go
+++ b/internal/dppapiservice/server.go
@@ -47,7 +47,7 @@ import (
 // Parameters:
 //   - ctx: Request-independent context used for security setup
 //   - cfg: Runtime configuration for routing, security, CORS, and context path
-//   - openapiSpec: Embedded OpenAPI specification used for Swagger UI
+//   - openapiSpec: Filesystem containing the OpenAPI specification used for Swagger UI
 //   - aasRepo: Asset Administration Shell repository persistence dependency
 //   - submodelRepo: Submodel repository persistence dependency
 //

--- a/internal/dppapiservice/server_test.go
+++ b/internal/dppapiservice/server_test.go
@@ -1,0 +1,73 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package dppapiservice
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+)
+
+var testOpenAPISpec = fstest.MapFS{
+	"openapi.yaml": {
+		Data: []byte("openapi: 3.0.3\ninfo:\n  title: DPP API Test\n  version: V3.2.0\npaths:\n  /v1/dpps:\n    get:\n      responses:\n        '200':\n          description: ok\n"),
+	},
+}
+
+func TestNewHTTPHandlerDoesNotShowVerifyEndpointInSwagger(t *testing.T) {
+	cfg := &common.Config{
+		Server: common.ServerConfig{
+			Host:                          "0.0.0.0",
+			Port:                          8080,
+			VerificationEndpointAvailable: true,
+		},
+		Swagger: common.SwaggerConfig{
+			Enabled: true,
+		},
+	}
+
+	handler, err := NewHTTPHandler(context.TODO(), cfg, testOpenAPISpec, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected NewHTTPHandler error: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api-docs/openapi.yaml", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected OpenAPI spec status 200, got %d", recorder.Code)
+	}
+	if strings.Contains(recorder.Body.String(), "\n  /verify:\n") {
+		t.Fatal("expected DPP Swagger spec to not include /verify")
+	}
+	if !cfg.Server.VerificationEndpointAvailable {
+		t.Fatal("expected DPP Swagger setup to not mutate runtime config")
+	}
+}


### PR DESCRIPTION
This pull request refactors how the OpenAPI/Swagger documentation is served in the DPP API service, making the Swagger UI setup more flexible and testable. It replaces the use of `embed.FS` with the more general `fs.FS` interface, adds a helper to control Swagger config, and introduces a test to verify that the `/verify` endpoint is not exposed in the Swagger spec when not intended.

Key changes:

**Swagger/OpenAPI configuration and flexibility:**

* Refactored the Swagger UI setup to use the generic `fs.FS` interface instead of `embed.FS`, allowing for easier testing and greater flexibility in how the OpenAPI spec is provided. (`internal/common/swagger.go`, `internal/dppapiservice/server.go`) [[1]](diffhunk://#diff-2922cc8adea355f39d9e5098e6bd2788255ba44fa92edea0a3bd574136b151d4L1537-R1548) [[2]](diffhunk://#diff-c31f1b54c2067dabde1120a4374bb5b400e50b5e0fb0e3d6808f908f439146ebL32-R32) [[3]](diffhunk://#diff-c31f1b54c2067dabde1120a4374bb5b400e50b5e0fb0e3d6808f908f439146ebL57-R57)
* Added a helper function `dppSwaggerConfig` to ensure the Swagger UI is configured with `VerificationEndpointAvailable` set to `false`, preventing the `/verify` endpoint from appearing in the Swagger docs. (`internal/dppapiservice/server.go`)
* Updated the server config (`config.yaml`) to include the `verificationEndpointAvailable` flag, defaulting to `false`.

**Testing and safety:**

* Added a unit test (`TestNewHTTPHandlerDoesNotShowVerifyEndpointInSwagger`) to verify that the `/verify` endpoint is not present in the Swagger spec and that the runtime config is not mutated during Swagger setup. (`internal/dppapiservice/server_test.go`)

**Documentation and comments:**

* Improved documentation/comments to clarify the use of `fs.FS` in Swagger UI setup functions. (`internal/common/swagger.go`)