### PR TITLE
Adapts Postgres Configuration Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,39 @@ If a setup uses mutable tags and pulls images on every start or restart, include
 Configuration is managed via YAML files in `cmd/<service>/config.yaml` and environment variables. Key variables include database connection settings (see [docu/errors.md](docu/errors.md) for troubleshooting):
 
 ```yaml
-maxOpenConnections: 500
-maxIdleConnections: 500
-connMaxLifetimeMinutes: 5
+postgres:
+    # Either set dsn or the individual connection fields below. Do not mix them.
+    # dsn: postgres://user:password@db:5432/basyx?sslmode=require
+    sslmode: disable
+    sslcert: ""
+    sslkey: ""
+    sslrootcert: ""
+    connectTimeoutSeconds: 0
+    applicationName: ""
+    fallbackApplicationName: ""
+    searchPath: ""
+    options: ""
+    timezone: ""
+    maxOpenConnections: 500
+    maxIdleConnections: 500
+    connMaxLifetimeMinutes: 5
 ```
 
 Or via `.env`:
 
 ```env
+# Either set POSTGRES_DSN or the individual connection variables below. Do not mix them.
+# POSTGRES_DSN=postgres://user:password@db:5432/basyx?sslmode=require
+POSTGRES_SSLMODE=disable
+POSTGRES_SSLCERT=
+POSTGRES_SSLKEY=
+POSTGRES_SSLROOTCERT=
+POSTGRES_CONNECTTIMEOUTSECONDS=0
+POSTGRES_APPLICATIONNAME=
+POSTGRES_FALLBACKAPPLICATIONNAME=
+POSTGRES_SEARCHPATH=
+POSTGRES_OPTIONS=
+POSTGRES_TIMEZONE=
 POSTGRES_MAXOPENCONNECTIONS=500
 POSTGRES_MAXIDLECONNECTIONS=500
 POSTGRES_CONNMAXLIFETIMEMINUTES=5

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Configuration is managed via YAML files in `cmd/<service>/config.yaml` and envir
 postgres:
     # Either set dsn or the individual connection fields below. Do not mix them.
     # dsn: postgres://user:password@db:5432/basyx?sslmode=require
+    host: localhost
+    port: 5432
+    user: postgres
+    password: postgres
+    dbname: basyx
     sslmode: disable
     sslcert: ""
     sslkey: ""
@@ -120,6 +125,11 @@ Or via `.env`:
 ```env
 # Either set POSTGRES_DSN or the individual connection variables below. Do not mix them.
 # POSTGRES_DSN=postgres://user:password@db:5432/basyx?sslmode=require
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DBNAME=basyx
 POSTGRES_SSLMODE=disable
 POSTGRES_SSLCERT=
 POSTGRES_SSLKEY=

--- a/cmd/aasenvironmentservice/config.yaml
+++ b/cmd/aasenvironmentservice/config.yaml
@@ -6,11 +6,25 @@ server:
   verificationEndpointAvailable: true
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyxTestDB?sslmode=require
   host: localhost
   port: 5432
   user: admin
   password: admin123
   dbname: basyxTestDB
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/cmd/aasregistryservice/config.yaml
+++ b/cmd/aasregistryservice/config.yaml
@@ -6,11 +6,25 @@ server:
   verificationEndpointAvailable: true
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyxTestDB?sslmode=require
   host: localhost
   port: 5432
   user: admin
   password: admin123
   dbname: basyxTestDB
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/cmd/aasrepositoryservice/config.yaml
+++ b/cmd/aasrepositoryservice/config.yaml
@@ -6,12 +6,26 @@ server:
   verificationEndpointAvailable: true
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyxTestDB?sslmode=require
   host: localhost
   port: 5432
   user: admin
   password: admin123
   # dbname: basyxGoBenchmarkTest
   dbname: basyxTestDB
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/cmd/aasxfileserverservice/config.yaml
+++ b/cmd/aasxfileserverservice/config.yaml
@@ -4,11 +4,25 @@ server:
   host: 0.0.0.0
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyxTestDB?sslmode=require
   host: localhost
   port: 5432
   user: admin
   password: admin123
   dbname: basyxTestDB
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/cmd/basyxconfigurationservice/config.yaml
+++ b/cmd/basyxconfigurationservice/config.yaml
@@ -1,9 +1,23 @@
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyxConfigService?sslmode=require
   host: localhost
   port: 5432
   user: postgres
   password: change-me
   dbname: basyxConfigService
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 50
   maxIdleConnections: 25
   connMaxLifetimeMinutes: 5

--- a/cmd/companylookupservice/config.yaml
+++ b/cmd/companylookupservice/config.yaml
@@ -6,11 +6,25 @@ server:
   verificationEndpointAvailable: true
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyxTestDB?sslmode=require
   host: localhost
   port: 5432
   user: admin
   password: admin123
   dbname: basyxTestDB
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/cmd/conceptdescriptionrepositoryservice/config.yaml
+++ b/cmd/conceptdescriptionrepositoryservice/config.yaml
@@ -6,11 +6,25 @@ server:
   verificationEndpointAvailable: true
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyx?sslmode=require
   host: localhost
   port: 5432
   user: postgres
   password: postgres
   dbname: basyx
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/cmd/digitaltwinregistryservice/config.yaml
+++ b/cmd/digitaltwinregistryservice/config.yaml
@@ -6,11 +6,25 @@ server:
   verificationEndpointAvailable: true
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyxTestDB?sslmode=require
   host: localhost
   port: 5432
   user: admin
   password: admin123
   dbname: basyxTestDB
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/cmd/discoveryservice/config.yaml
+++ b/cmd/discoveryservice/config.yaml
@@ -6,11 +6,25 @@ server:
   verificationEndpointAvailable: true
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyxTestDB?sslmode=require
   host: localhost
   port: 5432
   user: admin
   password: admin123
   dbname: basyxTestDB
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/cmd/dppapiservice/config.yaml
+++ b/cmd/dppapiservice/config.yaml
@@ -4,11 +4,25 @@ server:
   host: 0.0.0.0
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyx?sslmode=require
   host: localhost
   port: 5432
   user: postgres
   password: change-me
   dbname: basyx
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 50
   maxIdleConnections: 50
   connMaxLifetimeMinutes: 5

--- a/cmd/submodelregistryservice/config.yaml
+++ b/cmd/submodelregistryservice/config.yaml
@@ -6,11 +6,25 @@ server:
   verificationEndpointAvailable: true
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyxTestDB?sslmode=require
   host: localhost
   port: 5432
   user: admin
   password: admin123
   dbname: basyxTestDB
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/cmd/submodelrepositoryservice/config.yaml
+++ b/cmd/submodelrepositoryservice/config.yaml
@@ -6,12 +6,26 @@ server:
   verificationEndpointAvailable: true
 
 postgres:
+  # Choose exactly one connection variant:
+  # 1) individual fields below, or 2) dsn. Do not mix dsn with host/port/user/password/dbname/ssl settings.
+  # Pool settings may be used with either variant.
+  # dsn: postgres://user:password@localhost:5432/basyx?sslmode=require
   host: localhost
   port: 5432
   user: postgres
   password: postgres
   # dbname: basyxGoBenchmarkTest
   dbname: basyx
+  # sslmode: disable
+  # sslcert: ""
+  # sslkey: ""
+  # sslrootcert: ""
+  # connectTimeoutSeconds: 0
+  # applicationName: ""
+  # fallbackApplicationName: ""
+  # searchPath: ""
+  # options: ""
+  # timezone: ""
   maxOpenConnections: 500
   maxIdleConnections: 500
   connMaxLifetimeMinutes: 5

--- a/internal/common/configuration.go
+++ b/internal/common/configuration.go
@@ -56,6 +56,7 @@ var DefaultConfig = struct {
 	ServerVerificationEndpointAvailable bool
 	PgPort                              int
 	PgDBName                            string
+	PgSSLMode                           string
 	PgMaxOpen                           int
 	PgMaxIdle                           int
 	PgConnLifetime                      int
@@ -112,6 +113,7 @@ var DefaultConfig = struct {
 	ServerVerificationEndpointAvailable: true,
 	PgPort:                              5432,
 	PgDBName:                            "basyxTestDB",
+	PgSSLMode:                           "disable",
 	PgMaxOpen:                           50,
 	PgMaxIdle:                           50,
 	PgConnLifetime:                      5,
@@ -310,14 +312,25 @@ type ServerConfig struct {
 // PostgresConfig contains PostgreSQL database connection parameters.
 // It includes connection pooling settings for optimal performance.
 type PostgresConfig struct {
-	Host                   string `mapstructure:"host" yaml:"host"`                                     // Database host address
-	Port                   int    `mapstructure:"port" yaml:"port"`                                     // Database port (default: 5432)
-	User                   string `mapstructure:"user" yaml:"user"`                                     // Database username
-	Password               string `mapstructure:"password" yaml:"password"`                             // Database password
-	DBName                 string `mapstructure:"dbname" yaml:"dbname"`                                 // Database name
-	MaxOpenConnections     int    `mapstructure:"maxOpenConnections" yaml:"maxOpenConnections"`         // Maximum open connections
-	MaxIdleConnections     int    `mapstructure:"maxIdleConnections" yaml:"maxIdleConnections"`         // Maximum idle connections
-	ConnMaxLifetimeMinutes int    `mapstructure:"connMaxLifetimeMinutes" yaml:"connMaxLifetimeMinutes"` // Connection lifetime in minutes
+	DSN                     string `mapstructure:"dsn" yaml:"dsn"`                                         // Complete PostgreSQL DSN; mutually exclusive with connection fields
+	Host                    string `mapstructure:"host" yaml:"host"`                                       // Database host address
+	Port                    int    `mapstructure:"port" yaml:"port"`                                       // Database port (default: 5432)
+	User                    string `mapstructure:"user" yaml:"user"`                                       // Database username
+	Password                string `mapstructure:"password" yaml:"password"`                               // Database password
+	DBName                  string `mapstructure:"dbname" yaml:"dbname"`                                   // Database name
+	SSLMode                 string `mapstructure:"sslmode" yaml:"sslmode"`                                 // SSL mode: disable|allow|prefer|require|verify-ca|verify-full
+	SSLCert                 string `mapstructure:"sslcert" yaml:"sslcert"`                                 // Client certificate path
+	SSLKey                  string `mapstructure:"sslkey" yaml:"sslkey"`                                   // Client private key path
+	SSLRootCert             string `mapstructure:"sslrootcert" yaml:"sslrootcert"`                         // Root certificate path
+	ConnectTimeoutSeconds   int    `mapstructure:"connectTimeoutSeconds" yaml:"connectTimeoutSeconds"`     // Connection timeout in seconds
+	ApplicationName         string `mapstructure:"applicationName" yaml:"applicationName"`                 // PostgreSQL application_name
+	FallbackApplicationName string `mapstructure:"fallbackApplicationName" yaml:"fallbackApplicationName"` // PostgreSQL fallback_application_name
+	SearchPath              string `mapstructure:"searchPath" yaml:"searchPath"`                           // PostgreSQL search_path
+	Options                 string `mapstructure:"options" yaml:"options"`                                 // PostgreSQL startup options
+	TimeZone                string `mapstructure:"timezone" yaml:"timezone"`                               // PostgreSQL session timezone
+	MaxOpenConnections      int    `mapstructure:"maxOpenConnections" yaml:"maxOpenConnections"`           // Maximum open connections
+	MaxIdleConnections      int    `mapstructure:"maxIdleConnections" yaml:"maxIdleConnections"`           // Maximum idle connections
+	ConnMaxLifetimeMinutes  int    `mapstructure:"connMaxLifetimeMinutes" yaml:"connMaxLifetimeMinutes"`   // Connection lifetime in minutes
 }
 
 // CorsConfig contains Cross-Origin Resource Sharing (CORS) policy settings.
@@ -448,6 +461,9 @@ func LoadConfig(configPath string, configMode ConfigMode) (*Config, error) {
 	}
 	cfg.Server.StrictVerification = string(verificationMode)
 	applyAASPreconfigPathOverrides(cfg)
+	if err = validatePostgresConfig(v, cfg.Postgres); err != nil {
+		return nil, err
+	}
 	applyABACEnvOverrides(cfg)
 	if err = validateABACConfig(cfg); err != nil {
 		return nil, err
@@ -462,6 +478,61 @@ func LoadConfig(configPath string, configMode ConfigMode) (*Config, error) {
 		PrintConfiguration(cfg)
 	}
 	return cfg, nil
+}
+
+func validatePostgresConfig(v *viper.Viper, cfg PostgresConfig) error {
+	if strings.TrimSpace(cfg.DSN) != "" {
+		conflictingKeys := explicitlyConfiguredPostgresConnectionKeys(v)
+		if len(conflictingKeys) > 0 {
+			return fmt.Errorf("CONFIG-POSTGRES-DSN-CONFLICT postgres.dsn is mutually exclusive with individual postgres connection fields; remove postgres.dsn or remove these fields: %s", strings.Join(conflictingKeys, ", "))
+		}
+		return nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(cfg.SSLMode)) {
+	case "", "disable", "allow", "prefer", "require", "verify-ca", "verify-full":
+	default:
+		return fmt.Errorf("CONFIG-POSTGRES-SSLMODE unsupported postgres.sslmode %q", cfg.SSLMode)
+	}
+	if cfg.ConnectTimeoutSeconds < 0 {
+		return fmt.Errorf("CONFIG-POSTGRES-CONNECTTIMEOUT postgres.connectTimeoutSeconds must not be negative")
+	}
+	return nil
+}
+
+func explicitlyConfiguredPostgresConnectionKeys(v *viper.Viper) []string {
+	keys := []string{
+		"host",
+		"port",
+		"user",
+		"password",
+		"dbname",
+		"sslmode",
+		"sslcert",
+		"sslkey",
+		"sslrootcert",
+		"connectTimeoutSeconds",
+		"applicationName",
+		"fallbackApplicationName",
+		"searchPath",
+		"options",
+		"timezone",
+	}
+
+	conflictingKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		configKey := "postgres." + key
+		if v.InConfig(configKey) || postgresEnvConfigured(configKey) {
+			conflictingKeys = append(conflictingKeys, configKey)
+		}
+	}
+	return conflictingKeys
+}
+
+func postgresEnvConfigured(configKey string) bool {
+	envKey := strings.ToUpper(strings.ReplaceAll(configKey, ".", "_"))
+	_, ok := os.LookupEnv(envKey)
+	return ok
 }
 
 func applyABACEnvOverrides(cfg *Config) {
@@ -835,6 +906,17 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("postgres.user", "admin")
 	v.SetDefault("postgres.password", "admin123")
 	v.SetDefault("postgres.dbname", "basyxTestDB")
+	v.SetDefault("postgres.dsn", "")
+	v.SetDefault("postgres.sslmode", DefaultConfig.PgSSLMode)
+	v.SetDefault("postgres.sslcert", "")
+	v.SetDefault("postgres.sslkey", "")
+	v.SetDefault("postgres.sslrootcert", "")
+	v.SetDefault("postgres.connectTimeoutSeconds", 0)
+	v.SetDefault("postgres.applicationName", "")
+	v.SetDefault("postgres.fallbackApplicationName", "")
+	v.SetDefault("postgres.searchPath", "")
+	v.SetDefault("postgres.options", "")
+	v.SetDefault("postgres.timezone", "")
 	v.SetDefault("postgres.maxOpenConnections", 50)
 	v.SetDefault("postgres.maxIdleConnections", 50)
 	v.SetDefault("postgres.connMaxLifetimeMinutes", 5)
@@ -964,6 +1046,7 @@ func PrintConfiguration(cfg *Config) {
 	lines = append(lines, "🔹 Postgres:")
 	add("Port", cfg.Postgres.Port, DefaultConfig.PgPort)
 	add("DB Name", cfg.Postgres.DBName, DefaultConfig.PgDBName)
+	add("SSL Mode", cfg.Postgres.SSLMode, DefaultConfig.PgSSLMode)
 	add("Max Open Connections", cfg.Postgres.MaxOpenConnections, DefaultConfig.PgMaxOpen)
 	add("Max Idle Connections", cfg.Postgres.MaxIdleConnections, DefaultConfig.PgMaxIdle)
 	add("Conn Max Lifetime (min)", cfg.Postgres.ConnMaxLifetimeMinutes, DefaultConfig.PgConnLifetime)

--- a/internal/common/configuration_test.go
+++ b/internal/common/configuration_test.go
@@ -131,6 +131,7 @@ func TestPrintConfigurationMarksPermissiveVerificationModeAsDefault(t *testing.T
 		Postgres: PostgresConfig{
 			Port:                   DefaultConfig.PgPort,
 			DBName:                 DefaultConfig.PgDBName,
+			SSLMode:                DefaultConfig.PgSSLMode,
 			MaxOpenConnections:     DefaultConfig.PgMaxOpen,
 			MaxIdleConnections:     DefaultConfig.PgMaxIdle,
 			ConnMaxLifetimeMinutes: DefaultConfig.PgConnLifetime,
@@ -220,6 +221,164 @@ func TestLoadConfigAppliesSwaggerEnabled(t *testing.T) {
 	}
 	if cfg.Swagger.Enabled {
 		t.Fatal("expected Swagger to be disabled from config")
+	}
+}
+
+func TestLoadConfigAppliesPostgresConnectionParameters(t *testing.T) {
+	captureLogOutput(t)
+	path := writeTempConfig(t, `postgres:
+  sslmode: verify-full
+  sslcert: /certs/client.crt
+  sslkey: /certs/client.key
+  sslrootcert: /certs/root.crt
+  connectTimeoutSeconds: 15
+  applicationName: basyx-service
+  fallbackApplicationName: basyx
+  searchPath: tenant_a,public
+  options: "-c statement_timeout=5000"
+  timezone: Europe/Berlin
+`)
+
+	cfg, err := LoadConfig(path, NORMAL)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+
+	if cfg.Postgres.SSLMode != "verify-full" ||
+		cfg.Postgres.SSLCert != "/certs/client.crt" ||
+		cfg.Postgres.SSLKey != "/certs/client.key" ||
+		cfg.Postgres.SSLRootCert != "/certs/root.crt" ||
+		cfg.Postgres.ConnectTimeoutSeconds != 15 ||
+		cfg.Postgres.ApplicationName != "basyx-service" ||
+		cfg.Postgres.FallbackApplicationName != "basyx" ||
+		cfg.Postgres.SearchPath != "tenant_a,public" ||
+		cfg.Postgres.Options != "-c statement_timeout=5000" ||
+		cfg.Postgres.TimeZone != "Europe/Berlin" {
+		t.Fatalf("unexpected postgres config: %+v", cfg.Postgres)
+	}
+}
+
+func TestLoadConfigAppliesPostgresEnvironmentOverrides(t *testing.T) {
+	t.Setenv("POSTGRES_SSLMODE", "require")
+	t.Setenv("POSTGRES_SSLCERT", "/env/client.crt")
+	t.Setenv("POSTGRES_SSLKEY", "/env/client.key")
+	t.Setenv("POSTGRES_SSLROOTCERT", "/env/root.crt")
+	t.Setenv("POSTGRES_CONNECTTIMEOUTSECONDS", "7")
+	t.Setenv("POSTGRES_APPLICATIONNAME", "basyx-env-service")
+	t.Setenv("POSTGRES_FALLBACKAPPLICATIONNAME", "basyx-env")
+	t.Setenv("POSTGRES_SEARCHPATH", "env_schema,public")
+	t.Setenv("POSTGRES_OPTIONS", "-c lock_timeout=1000")
+	t.Setenv("POSTGRES_TIMEZONE", "UTC")
+	captureLogOutput(t)
+
+	cfg, err := LoadConfig("", NORMAL)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+
+	if cfg.Postgres.SSLMode != "require" ||
+		cfg.Postgres.SSLCert != "/env/client.crt" ||
+		cfg.Postgres.SSLKey != "/env/client.key" ||
+		cfg.Postgres.SSLRootCert != "/env/root.crt" ||
+		cfg.Postgres.ConnectTimeoutSeconds != 7 ||
+		cfg.Postgres.ApplicationName != "basyx-env-service" ||
+		cfg.Postgres.FallbackApplicationName != "basyx-env" ||
+		cfg.Postgres.SearchPath != "env_schema,public" ||
+		cfg.Postgres.Options != "-c lock_timeout=1000" ||
+		cfg.Postgres.TimeZone != "UTC" {
+		t.Fatalf("unexpected postgres env config: %+v", cfg.Postgres)
+	}
+}
+
+func TestLoadConfigAppliesPostgresDSN(t *testing.T) {
+	captureLogOutput(t)
+	path := writeTempConfig(t, `postgres:
+  dsn: postgres://postgres.example:5432/basyx?sslmode=require
+  maxOpenConnections: 100
+`)
+
+	cfg, err := LoadConfig(path, NORMAL)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+
+	if cfg.Postgres.DSN != "postgres://postgres.example:5432/basyx?sslmode=require" {
+		t.Fatalf("unexpected postgres dsn: %q", cfg.Postgres.DSN)
+	}
+	if cfg.Postgres.MaxOpenConnections != 100 {
+		t.Fatalf("unexpected max open connections: %d", cfg.Postgres.MaxOpenConnections)
+	}
+}
+
+func TestLoadConfigAppliesPostgresDSNEnvironmentOverride(t *testing.T) {
+	t.Setenv("POSTGRES_DSN", "postgres://postgres.example:5432/basyx?sslmode=require")
+	captureLogOutput(t)
+
+	cfg, err := LoadConfig("", NORMAL)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+
+	if cfg.Postgres.DSN != "postgres://postgres.example:5432/basyx?sslmode=require" {
+		t.Fatalf("unexpected postgres dsn: %q", cfg.Postgres.DSN)
+	}
+}
+
+func TestLoadConfigRejectsPostgresDSNWithConnectionField(t *testing.T) {
+	captureLogOutput(t)
+	path := writeTempConfig(t, `postgres:
+  dsn: postgres://postgres.example:5432/basyx?sslmode=require
+  host: db
+`)
+
+	_, err := LoadConfig(path, NORMAL)
+	if err == nil {
+		t.Fatal("expected postgres dsn conflict error")
+	}
+	if !strings.Contains(err.Error(), "CONFIG-POSTGRES-DSN-CONFLICT") ||
+		!strings.Contains(err.Error(), "postgres.host") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfigRejectsPostgresDSNWithConnectionFieldEnv(t *testing.T) {
+	t.Setenv("POSTGRES_DSN", "postgres://postgres.example:5432/basyx?sslmode=require")
+	t.Setenv("POSTGRES_SSLMODE", "disable")
+	captureLogOutput(t)
+
+	_, err := LoadConfig("", NORMAL)
+	if err == nil {
+		t.Fatal("expected postgres dsn conflict error")
+	}
+	if !strings.Contains(err.Error(), "CONFIG-POSTGRES-DSN-CONFLICT") ||
+		!strings.Contains(err.Error(), "postgres.sslmode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfigRejectsUnsupportedPostgresSSLMode(t *testing.T) {
+	captureLogOutput(t)
+	path := writeTempConfig(t, "postgres:\n  sslmode: invalid\n")
+
+	_, err := LoadConfig(path, NORMAL)
+	if err == nil {
+		t.Fatal("expected unsupported postgres sslmode error")
+	}
+	if !strings.Contains(err.Error(), "CONFIG-POSTGRES-SSLMODE") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfigRejectsNegativePostgresConnectTimeout(t *testing.T) {
+	captureLogOutput(t)
+	path := writeTempConfig(t, "postgres:\n  connectTimeoutSeconds: -1\n")
+
+	_, err := LoadConfig(path, NORMAL)
+	if err == nil {
+		t.Fatal("expected negative postgres connect timeout error")
+	}
+	if !strings.Contains(err.Error(), "CONFIG-POSTGRES-CONNECTTIMEOUT") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/common/postgres_dsn.go
+++ b/internal/common/postgres_dsn.go
@@ -33,15 +33,57 @@ import (
 
 // BuildPostgresDSN creates a PostgreSQL DSN with URL-encoded credentials.
 func BuildPostgresDSN(cfg PostgresConfig) string {
+	if strings.TrimSpace(cfg.DSN) != "" {
+		return NormalizePostgresDSN(cfg.DSN)
+	}
+
 	postgresURL := &url.URL{
-		Scheme:   "postgres",
-		Host:     fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
-		Path:     cfg.DBName,
-		RawQuery: "sslmode=disable",
+		Scheme: "postgres",
+		Host:   fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
+		Path:   cfg.DBName,
 	}
 	postgresURL.User = url.UserPassword(cfg.User, cfg.Password)
+	postgresURL.RawQuery = buildPostgresQuery(cfg).Encode()
 
 	return postgresURL.String()
+}
+
+func buildPostgresQuery(cfg PostgresConfig) url.Values {
+	query := url.Values{}
+	addQueryValue(query, "sslmode", effectivePostgresSSLMode(cfg.SSLMode))
+	addQueryValue(query, "sslcert", cfg.SSLCert)
+	addQueryValue(query, "sslkey", cfg.SSLKey)
+	addQueryValue(query, "sslrootcert", cfg.SSLRootCert)
+	addPositiveIntQueryValue(query, "connect_timeout", cfg.ConnectTimeoutSeconds)
+	addQueryValue(query, "application_name", cfg.ApplicationName)
+	addQueryValue(query, "fallback_application_name", cfg.FallbackApplicationName)
+	addQueryValue(query, "search_path", cfg.SearchPath)
+	addQueryValue(query, "options", cfg.Options)
+	addQueryValue(query, "TimeZone", cfg.TimeZone)
+
+	return query
+}
+
+func effectivePostgresSSLMode(sslMode string) string {
+	trimmed := strings.TrimSpace(sslMode)
+	if trimmed == "" {
+		return DefaultConfig.PgSSLMode
+	}
+	return trimmed
+}
+
+func addQueryValue(query url.Values, key string, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	query.Set(key, value)
+}
+
+func addPositiveIntQueryValue(query url.Values, key string, value int) {
+	if value <= 0 {
+		return
+	}
+	query.Set(key, fmt.Sprintf("%d", value))
 }
 
 // NormalizePostgresDSN ensures URL-based PostgreSQL DSNs are encoded correctly.

--- a/internal/common/postgres_dsn_test.go
+++ b/internal/common/postgres_dsn_test.go
@@ -73,6 +73,76 @@ func TestBuildPostgresDSN(t *testing.T) {
 	}
 }
 
+func TestBuildPostgresDSNUsesConfiguredDSN(t *testing.T) {
+	cfg := PostgresConfig{
+		DSN: "  postgres://user:p@ss@localhost:5432/basyx?sslmode=require&application_name=svc  ",
+	}
+
+	dsn := BuildPostgresDSN(cfg)
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+
+	if parsed.Scheme != "postgres" {
+		t.Fatalf("unexpected scheme: %s", parsed.Scheme)
+	}
+	pass, ok := parsed.User.Password()
+	if !ok {
+		t.Fatal("expected password")
+	}
+	if pass != "p@ss" {
+		t.Fatalf("unexpected password: %s", pass)
+	}
+	assertQueryValue(t, parsed.Query(), "sslmode", "require")
+	assertQueryValue(t, parsed.Query(), "application_name", "svc")
+}
+
+func TestBuildPostgresDSNWithConfiguredParameters(t *testing.T) {
+	cfg := PostgresConfig{
+		Host:                    "localhost",
+		Port:                    5432,
+		User:                    "user",
+		Password:                "password",
+		DBName:                  "basyx",
+		SSLMode:                 "verify-full",
+		SSLCert:                 "/certs/client.crt",
+		SSLKey:                  "/certs/client.key",
+		SSLRootCert:             "/certs/root.crt",
+		ConnectTimeoutSeconds:   15,
+		ApplicationName:         "basyx-service",
+		FallbackApplicationName: "basyx",
+		SearchPath:              "tenant_a,public",
+		Options:                 "-c statement_timeout=5000",
+		TimeZone:                "Europe/Berlin",
+	}
+
+	dsn := BuildPostgresDSN(cfg)
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+
+	query := parsed.Query()
+	assertQueryValue(t, query, "sslmode", "verify-full")
+	assertQueryValue(t, query, "sslcert", "/certs/client.crt")
+	assertQueryValue(t, query, "sslkey", "/certs/client.key")
+	assertQueryValue(t, query, "sslrootcert", "/certs/root.crt")
+	assertQueryValue(t, query, "connect_timeout", "15")
+	assertQueryValue(t, query, "application_name", "basyx-service")
+	assertQueryValue(t, query, "fallback_application_name", "basyx")
+	assertQueryValue(t, query, "search_path", "tenant_a,public")
+	assertQueryValue(t, query, "options", "-c statement_timeout=5000")
+	assertQueryValue(t, query, "TimeZone", "Europe/Berlin")
+}
+
+func assertQueryValue(t *testing.T, query url.Values, key string, want string) {
+	t.Helper()
+	if got := query.Get(key); got != want {
+		t.Fatalf("unexpected %s: %q, want %q", key, got, want)
+	}
+}
+
 func TestNormalizePostgresDSN(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Description of Changes

Added configurable PostgreSQL connection options to the shared BaSyx configuration.

Changes include:
- Added `postgres.sslmode` instead of hard-coded `sslmode=disable`.
- Added optional PostgreSQL DSN configuration via `postgres.dsn` / `POSTGRES_DSN`.
- Added additional Postgres connection parameters: TLS cert paths, connect timeout, application name, fallback application name, search path, options, and timezone.
- Added validation to prevent mixing `postgres.dsn` with individual connection fields.
- Updated all `cmd/*/config.yaml` samples with commented configuration variants and usage guidance.
- Updated README documentation.
- Added unit tests for DSN generation, config loading, env overrides, and invalid mixed configuration.

## Related Issue

closes #382

## BaSyx Configuration for Testing

No special configuration is required for the default path. Existing configurations continue to use individual Postgres fields and default to `sslmode=disable`.

New configuration variants can be tested with either:

```yaml
postgres:
  host: localhost
  port: 5432
  user: postgres
  password: postgres
  dbname: basyx
  sslmode: disable
```

or:

```yaml
postgres:
  dsn: postgres://postgres:postgres@localhost:5432/basyx?sslmode=disable
```

Do not mix `postgres.dsn` with individual connection fields. Pool settings such as `maxOpenConnections`, `maxIdleConnections`, and `connMaxLifetimeMinutes` may be used with either variant.

## AAS Files Used for Testing

No specific AAS files were required for this change. The change is limited to shared PostgreSQL configuration and DSN construction.

## Additional Information

Validation and tests performed:
- `go test ./internal/common`
- `go clean -testcache`
- `go test -v ./internal/submodelrepository/integration_tests`
- `sh scripts/lint.sh`
- `git diff --check`

The DSN variant is intentionally mutually exclusive with individual connection fields to avoid ambiguous database configuration.