### PR TITLE
Adds missing support for date type in property handling

### DIFF
--- a/internal/common/model/grammar/field_column_mapping.go
+++ b/internal/common/model/grammar/field_column_mapping.go
@@ -116,7 +116,7 @@ var terminalColumnMappings = map[string]terminalColumnMapping{
 	"value": {
 		ByContext: map[resolveContext]string{
 			ctxSpecificAssetID: "specific_asset_id.value",
-			ctxSME:             "COALESCE(property_element.value_text, property_element.value_num::text, property_element.value_bool::text, property_element.value_time::text, property_element.value_datetime::text)",
+			ctxSME:             "COALESCE(property_element.value_text, property_element.value_num::text, property_element.value_bool::text, property_element.value_time::text, property_element.value_date::text, property_element.value_datetime::text)",
 		},
 		ByParentSimple: map[string]map[resolveContext]string{
 			// submodelDescriptor semanticId mapping (used by $aasdesc#submodelDescriptors[].semanticId.* and $smdesc#semanticId.*).
@@ -178,7 +178,7 @@ var terminalColumnMappings = map[string]terminalColumnMapping{
 
 	"valueType": {
 		ByContext: map[resolveContext]string{
-			ctxSME: "(CASE WHEN property_element.value_bool IS NOT NULL THEN 'xs:boolean' WHEN property_element.value_time IS NOT NULL THEN 'xs:time' WHEN property_element.value_datetime IS NOT NULL THEN 'xs:dateTime' WHEN property_element.value_num IS NOT NULL THEN 'xs:double' ELSE 'xs:string' END)",
+			ctxSME: "(CASE WHEN property_element.value_bool IS NOT NULL THEN 'xs:boolean' WHEN property_element.value_time IS NOT NULL THEN 'xs:time' WHEN property_element.value_date IS NOT NULL THEN 'xs:date' WHEN property_element.value_datetime IS NOT NULL THEN 'xs:dateTime' WHEN property_element.value_num IS NOT NULL THEN 'xs:double' ELSE 'xs:string' END)",
 		},
 	},
 

--- a/internal/common/model/grammar/fieldidentifier_processing_test.go
+++ b/internal/common/model/grammar/fieldidentifier_processing_test.go
@@ -381,7 +381,7 @@ var fieldIdentifierProcessingCases = []fidTestCase{
 		Name:       "sql_scalar_sme_value",
 		Kind:       "scalar",
 		Input:      `$sme#value`,
-		WantScalar: &expectedScalar{Column: "COALESCE(property_element.value_text, property_element.value_num::text, property_element.value_bool::text, property_element.value_time::text, property_element.value_datetime::text)", Bindings: []expectedBinding{}},
+		WantScalar: &expectedScalar{Column: "COALESCE(property_element.value_text, property_element.value_num::text, property_element.value_bool::text, property_element.value_time::text, property_element.value_date::text, property_element.value_datetime::text)", Bindings: []expectedBinding{}},
 	},
 	{
 		Name:         "sql_fragment_sme_semanticId_keys_indexed",
@@ -399,19 +399,19 @@ var fieldIdentifierProcessingCases = []fidTestCase{
 		Name:       "sme_valueType_scalar",
 		Kind:       "scalar",
 		Input:      `$sme.MyList[2].temp#valueType`,
-		WantScalar: &expectedScalar{Column: "(CASE WHEN property_element.value_bool IS NOT NULL THEN 'xs:boolean' WHEN property_element.value_time IS NOT NULL THEN 'xs:time' WHEN property_element.value_datetime IS NOT NULL THEN 'xs:dateTime' WHEN property_element.value_num IS NOT NULL THEN 'xs:double' ELSE 'xs:string' END)", Bindings: []expectedBinding{{Alias: "submodel_element.idshort_path", Index: sidx("MyList.temp")}, {Alias: "submodel_element.position", Index: idx(2)}}},
+		WantScalar: &expectedScalar{Column: "(CASE WHEN property_element.value_bool IS NOT NULL THEN 'xs:boolean' WHEN property_element.value_time IS NOT NULL THEN 'xs:time' WHEN property_element.value_date IS NOT NULL THEN 'xs:date' WHEN property_element.value_datetime IS NOT NULL THEN 'xs:dateTime' WHEN property_element.value_num IS NOT NULL THEN 'xs:double' ELSE 'xs:string' END)", Bindings: []expectedBinding{{Alias: "submodel_element.idshort_path", Index: sidx("MyList.temp")}, {Alias: "submodel_element.position", Index: idx(2)}}},
 	},
 	{
 		Name:       "sme_value_scalar_terminal_list_index",
 		Kind:       "scalar",
 		Input:      `$sme.NewTestList[0]#value`,
-		WantScalar: &expectedScalar{Column: "COALESCE(property_element.value_text, property_element.value_num::text, property_element.value_bool::text, property_element.value_time::text, property_element.value_datetime::text)", Bindings: []expectedBinding{{Alias: "submodel_element.idshort_path", Index: sidx("NewTestList[0]")}, {Alias: "submodel_element.position", Index: idx(0)}}},
+		WantScalar: &expectedScalar{Column: "COALESCE(property_element.value_text, property_element.value_num::text, property_element.value_bool::text, property_element.value_time::text, property_element.value_date::text, property_element.value_datetime::text)", Bindings: []expectedBinding{{Alias: "submodel_element.idshort_path", Index: sidx("NewTestList[0]")}, {Alias: "submodel_element.position", Index: idx(0)}}},
 	},
 	{
 		Name:       "sme_valueType_scalar_terminal_list_wildcard",
 		Kind:       "scalar",
 		Input:      `$sme.NewTestList[]#valueType`,
-		WantScalar: &expectedScalar{Column: "(CASE WHEN property_element.value_bool IS NOT NULL THEN 'xs:boolean' WHEN property_element.value_time IS NOT NULL THEN 'xs:time' WHEN property_element.value_datetime IS NOT NULL THEN 'xs:dateTime' WHEN property_element.value_num IS NOT NULL THEN 'xs:double' ELSE 'xs:string' END)", Bindings: []expectedBinding{{Alias: "submodel_element.idshort_path", Index: sidx("NewTestList[]")}}},
+		WantScalar: &expectedScalar{Column: "(CASE WHEN property_element.value_bool IS NOT NULL THEN 'xs:boolean' WHEN property_element.value_time IS NOT NULL THEN 'xs:time' WHEN property_element.value_date IS NOT NULL THEN 'xs:date' WHEN property_element.value_datetime IS NOT NULL THEN 'xs:dateTime' WHEN property_element.value_num IS NOT NULL THEN 'xs:double' ELSE 'xs:string' END)", Bindings: []expectedBinding{{Alias: "submodel_element.idshort_path", Index: sidx("NewTestList[]")}}},
 	},
 	{
 		Name:       "sme_semanticId_keys_type_indexed_scalar",

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -340,20 +340,43 @@ func getRangeValuesByIDShort(t *testing.T, submodel map[string]any, idShort stri
 	return "", ""
 }
 
+func getPropertyValueByEndpoint(t *testing.T, endpoint string) string {
+	t.Helper()
+
+	statusCode, body, err := requestJSON(http.MethodGet, endpoint, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
+
+	var property map[string]any
+	require.NoError(t, json.Unmarshal(body, &property), "response=%s", string(body))
+	value, ok := property["value"].(string)
+	require.True(t, ok, "Property value must be string")
+
+	return value
+}
+
+func parseXSDDateTimeValue(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	layouts := []string{time.RFC3339Nano, "2006-01-02T15:04:05.999999999-07:00", "2006-01-02T15:04:05-07:00"}
+	for _, layout := range layouts {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed
+		}
+	}
+
+	t.Fatalf("xs:dateTime value is not parseable with expected lexical forms: %s", value)
+	return time.Time{}
+}
+
 func assertXSDDateTimeLexical(t *testing.T, value string) {
 	t.Helper()
 
 	assert.NotContains(t, value, " ", "xs:dateTime must not contain a space separator")
 	assert.Contains(t, value, "T", "xs:dateTime must contain T separator")
 
-	layouts := []string{time.RFC3339Nano, "2006-01-02T15:04:05.999999999-07:00", "2006-01-02T15:04:05-07:00"}
-	for _, layout := range layouts {
-		if _, err := time.Parse(layout, value); err == nil {
-			return
-		}
-	}
-
-	t.Fatalf("xs:dateTime value is not parseable with expected lexical forms: %s", value)
+	_ = parseXSDDateTimeValue(t, value)
 }
 
 func assertXSDDateLexical(t *testing.T, value string) {
@@ -519,6 +542,126 @@ func TestTemporalXSDRoundTripFormatting(t *testing.T) {
 		require.True(t, ok, "Range max value must be string")
 		assertXSDDateTimeLexical(t, minValue)
 		assertXSDDateTimeLexical(t, maxValue)
+	})
+}
+
+func TestTemporalPropertyUpdateRoundTrip(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	submodelID := fmt.Sprintf("urn:basyx:integration:temporal-update-%d", time.Now().UnixNano())
+	submodelIDEncoded := common.EncodeString(submodelID)
+	elementEndpoint := func(idShort string) string {
+		return fmt.Sprintf("%s/submodels/%s/submodel-elements/%s", baseURL, submodelIDEncoded, idShort)
+	}
+
+	t.Cleanup(func() {
+		statusCode, body, err := requestJSON(http.MethodDelete, fmt.Sprintf("%s/submodels/%s", baseURL, submodelIDEncoded), nil)
+		if err != nil {
+			t.Logf("cleanup delete failed for temporal update test submodel: %v", err)
+			return
+		}
+		if statusCode != http.StatusNoContent && statusCode != http.StatusNotFound {
+			t.Logf("cleanup delete returned unexpected status=%d body=%s", statusCode, string(body))
+		}
+	})
+
+	statusCode, body, err := requestJSON(http.MethodPost, fmt.Sprintf("%s/submodels", baseURL), map[string]any{
+		"id":        submodelID,
+		"idShort":   "TemporalUpdateSubmodel",
+		"kind":      "Instance",
+		"modelType": "Submodel",
+		"submodelElements": []map[string]any{
+			{
+				"idShort":   "DateProperty",
+				"valueType": "xs:date",
+				"value":     "2024-01-01",
+				"modelType": "Property",
+			},
+			{
+				"idShort":   "DateTimeProperty",
+				"valueType": "xs:dateTime",
+				"value":     "2024-01-01T10:11:12Z",
+				"modelType": "Property",
+			},
+			{
+				"idShort":   "TimeProperty",
+				"valueType": "xs:time",
+				"value":     "10:11:12.123",
+				"modelType": "Property",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
+
+	assertExactValue := func(t *testing.T, expected string, actual string) {
+		t.Helper()
+		assert.Equal(t, expected, actual)
+	}
+	assertDateTimeInstant := func(t *testing.T, expected string, actual string) {
+		t.Helper()
+		expectedTime := parseXSDDateTimeValue(t, expected)
+		actualTime := parseXSDDateTimeValue(t, actual)
+		assert.True(t, expectedTime.Equal(actualTime), "expected instant %s, got %s", expectedTime, actualTime)
+	}
+
+	testCases := []struct {
+		name        string
+		idShort     string
+		valueType   string
+		updated     string
+		assertValue func(*testing.T, string, string)
+	}{
+		{
+			name:        "date",
+			idShort:     "DateProperty",
+			valueType:   "xs:date",
+			updated:     "2024-06-15",
+			assertValue: assertExactValue,
+		},
+		{
+			name:        "dateTime",
+			idShort:     "DateTimeProperty",
+			valueType:   "xs:dateTime",
+			updated:     "2024-06-15T13:14:15.123Z",
+			assertValue: assertDateTimeInstant,
+		},
+		{
+			name:        "time",
+			idShort:     "TimeProperty",
+			valueType:   "xs:time",
+			updated:     "13:14:15.987",
+			assertValue: assertExactValue,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("PUT updates xs:"+tc.name, func(t *testing.T) {
+			statusCode, body, err := requestJSON(http.MethodPut, elementEndpoint(tc.idShort), map[string]any{
+				"idShort":   tc.idShort,
+				"valueType": tc.valueType,
+				"value":     tc.updated,
+				"modelType": "Property",
+			})
+			require.NoError(t, err)
+			require.Equal(t, http.StatusNoContent, statusCode, "response=%s", string(body))
+
+			actualValue := getPropertyValueByEndpoint(t, elementEndpoint(tc.idShort))
+			tc.assertValue(t, tc.updated, actualValue)
+		})
+	}
+
+	t.Run("PATCH updates xs:date", func(t *testing.T) {
+		updated := "2024-06-16"
+		statusCode, body, err := requestJSON(http.MethodPatch, elementEndpoint("DateProperty"), map[string]any{
+			"valueType": "xs:date",
+			"value":     updated,
+			"modelType": "Property",
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, statusCode, "response=%s", string(body))
+
+		actualValue := getPropertyValueByEndpoint(t, elementEndpoint("DateProperty"))
+		assert.Equal(t, updated, actualValue)
 	})
 }
 

--- a/internal/submodelrepository/persistence/submodelElements/PropertyHandler.go
+++ b/internal/submodelrepository/persistence/submodelElements/PropertyHandler.go
@@ -318,6 +318,7 @@ func buildUpdatePropertyRecordObject(property *types.Property, isPut bool, local
 		updateRecord["value_num"] = typedValue.Numeric
 		updateRecord["value_bool"] = typedValue.Boolean
 		updateRecord["value_time"] = typedValue.Time
+		updateRecord["value_date"] = typedValue.Date
 		updateRecord["value_datetime"] = typedValue.DateTime
 	}
 


### PR DESCRIPTION
This pull request extends support for the `xs:date` value type in the submodel repository, ensuring that date properties are correctly handled in both persistence and API layers. It updates SQL mappings and test cases to include `value_date`, and adds comprehensive integration tests for property updates involving temporal types (`xs:date`, `xs:dateTime`, and `xs:time`).

**Support for xs:date value type:**

- Updated the SQL column mappings for the SME context in `field_column_mapping.go` to include `property_element.value_date` in both the `value` and `valueType` expressions, ensuring that date values are correctly queried and typed. [[1]](diffhunk://#diff-136d354acba0bdbca7d7271e06e9791b34693aeb100d7916d8d629dfc2f9a939L119-R119) [[2]](diffhunk://#diff-136d354acba0bdbca7d7271e06e9791b34693aeb100d7916d8d629dfc2f9a939L181-R181)
- Modified the persistence layer in `PropertyHandler.go` to set the `value_date` field when updating property records, enabling proper storage of date values.

**Test coverage improvements:**

- Enhanced test cases in `fieldidentifier_processing_test.go` to expect the presence of `property_element.value_date` in SQL expressions for both `value` and `valueType` fields, aligning tests with the new mapping logic. [[1]](diffhunk://#diff-16f50e6185cfb31b29931f8d3b0c1db171455eb978e3e36d302bf19a6fc9d08bL384-R384) [[2]](diffhunk://#diff-16f50e6185cfb31b29931f8d3b0c1db171455eb978e3e36d302bf19a6fc9d08bL402-R414)
- Refactored integration test helpers and added a new test `TestTemporalPropertyUpdateRoundTrip` in `submodelrepository_integration_test.go` to verify that properties of type `xs:date`, `xs:dateTime`, and `xs:time` can be created, updated (via PUT and PATCH), and round-tripped with correct values and lexical forms. [[1]](diffhunk://#diff-49f0f31785aa031fcb93875dcd2bb7cc7500537a2053bff1d6dd4351242d4d29L343-R379) [[2]](diffhunk://#diff-49f0f31785aa031fcb93875dcd2bb7cc7500537a2053bff1d6dd4351242d4d29R548-R667)

Closes #395 