### PR TITLE
Makes policy service scope configurable

### DIFF
--- a/cmd/digitaltwinregistryservice/main.go
+++ b/cmd/digitaltwinregistryservice/main.go
@@ -63,9 +63,6 @@ func runServer(ctx context.Context, configPath string) error {
 	if err != nil {
 		return err
 	}
-	if !abacpolicy.ManagementAPIAllowed("digitaltwinregistryservice") {
-		cfg.ABAC.ManagementAPI.Enabled = false
-	}
 	if err := commonmodel.SetVerificationMode(cfg.Server.StrictVerification); err != nil {
 		return err
 	}

--- a/docu/security/ABAC_POLICY_REPOSITORY.md
+++ b/docu/security/ABAC_POLICY_REPOSITORY.md
@@ -16,6 +16,7 @@ abac:
   enabled: true
   modelPath: config/access_rules/access-rules.json
   policyFileImport: if_missing
+  policyScope: aasregistryservice
   managementApi:
     enabled: false
 ```
@@ -25,13 +26,25 @@ Environment variables:
 - `ABAC_ENABLED=true`
 - `ABAC_MODELPATH=/security_env/access-rules.json`
 - `ABAC_POLICY_FILE_IMPORT=always|if_missing|never`
+- `ABAC_POLICY_SCOPE=aasregistryservice`
 - `ABAC_MANAGEMENT_API_ENABLED=true|false`
+
+`abac.policyScope` controls the database namespace used for stored policy versions, rule rows, events, and activation evidence. When it is empty, the service uses its built-in scope, such as `digitaltwinregistryservice` or `aasregistryservice`, so existing deployments keep their current behavior.
+
+Use different scopes when two instances or deployments must not share access rules even though they use the same PostgreSQL database:
+
+```yaml
+abac:
+  policyScope: aasregistry-internal
+```
+
+Use the same scope only when the services are meant to share one active policy. Sharing a scope across services with different route surfaces can make a policy valid for one service but incomplete or unsafe for another service, so do it deliberately and test the effective routes.
 
 `abac.policyFileImport` controls startup file import:
 
 - `always`: import `abac.modelPath` on every startup. Use this when the configured file is the source of truth.
-- `if_missing`: import `abac.modelPath` only when no active database-backed policy exists for the service scope.
-- `never`: do not import the file. ABAC startup fails closed unless an active database-backed policy already exists.
+- `if_missing`: import `abac.modelPath` only when no active database-backed policy exists for the effective policy scope.
+- `never`: do not import the file. ABAC startup fails closed unless an active database-backed policy already exists for the effective policy scope.
 
 When the value is empty, each service uses its default. Digital Twin Registry defaults to `always`; other ABAC-enabled services default to `if_missing`.
 
@@ -52,7 +65,7 @@ The importer validates the configured JSON, canonicalizes it, materializes refer
 
 The management API is mounted under `/security/abac/**` only when both `abac.enabled` and `abac.managementApi.enabled` are true. Swagger/OpenAPI exposes these endpoints only when the management API is active and `swagger.enabled` is true.
 
-Digital Twin Registry is the exception: it never exposes the management API. Its access-rule file remains the service source of truth and is imported on every restart by default.
+Digital Twin Registry keeps the same defaults as before: its startup policy-file import defaults to `always`, and its management API remains disabled unless explicitly enabled.
 
 The API supports:
 
@@ -539,9 +552,11 @@ Normal history event artifacts continue to store only `policy_id` and `matched_r
 
 ## Shared Database Operation
 
-Different components can run against the same database because policy state is separated by `service_scope` and the schema enforces one active policy per service scope.
+Different components can run against the same database because policy state is separated by `service_scope` and the schema enforces one active policy per service scope. Operators can override the default service scope with `abac.policyScope` to split same-service deployments or intentionally share a policy namespace.
 
-For a given service scope, operate only one startup file-import owner at a time. If several instances of the same component are deployed, prefer `if_missing` or `never` for follower instances after the first active policy exists. A future configuration service flow can centralize policy import and activation.
+For a given effective policy scope, operate only one startup file-import owner at a time. If several instances of the same component are deployed, prefer `if_missing` or `never` for follower instances after the first active policy exists. A future configuration service flow can centralize policy import and activation.
+
+This is especially important for Digital Twin Registry: two DTR instances using the same database, the default `digitaltwinregistryservice` policy scope, and different mounted access-rule files will both import with the default `always` mode. The instance that starts later can supersede the active policy imported by the other instance. Use distinct `abac.policyScope` values when the DTRs must be isolated, or configure exactly one DTR as the import owner and run the others with `if_missing` or `never`.
 
 ## NIS2 Support Scope
 

--- a/docu/security/README.md
+++ b/docu/security/README.md
@@ -128,7 +128,8 @@ sequenceDiagram
   - Example trustlist: [cmd/aasregistryservice/config/trustlist.json](cmd/aasregistryservice/config/trustlist.json)
 - Access rules are imported from the configured access model JSON into the PostgreSQL-backed ABAC policy repository when `abac.policyFileImport` requires it. Runtime authorization uses the active materialized DB policy.
   - Example rules: [cmd/aasregistryservice/config/access_rules/access-rules.json](cmd/aasregistryservice/config/access_rules/access-rules.json)
-- The protected ABAC management API under `/security/abac/**` is available only when `abac.enabled` and `abac.managementApi.enabled` are both true. Digital Twin Registry deliberately never exposes this API. The OpenAPI/Swagger documentation follows the same condition.
+- DB-backed policy rows are isolated by service scope by default. Set `abac.policyScope` only when a deployment must split same-service instances or deliberately share one policy namespace.
+- The protected ABAC management API under `/security/abac/**` is available only when `abac.enabled` and `abac.managementApi.enabled` are both true. Digital Twin Registry keeps this API disabled by default but can expose it through the same explicit opt-in. The OpenAPI/Swagger documentation follows the same condition.
 
 ## OIDC authentication
 
@@ -335,5 +336,6 @@ Example file:
 - Confirm route-to-rights mapping covers all endpoints used by the service.
 - Validate the access rules against the intended claims and objects.
 - Choose `abac.policyFileImport` deliberately. Use `always` only when the file is the source of truth; use `if_missing` when the database-managed policy should survive restarts; use `never` when an active DB policy is mandatory.
-- Enable `abac.managementApi.enabled` only for services where runtime policy administration is required. Do not enable it for Digital Twin Registry; DTR uses the configured access-rule file as source of truth. Protect `/security/abac/**` with admin-only ABAC rules.
+- Use `abac.policyScope` deliberately. Sharing a scope across services with different routes can make one service's policy incomplete or unsafe for another service.
+- Enable `abac.managementApi.enabled` only for services where runtime policy administration is required. For Digital Twin Registry, remember that startup file import defaults to `always`; if multiple DTRs share the default policy scope with different files, later startups can supersede earlier active policies. Protect `/security/abac/**` with admin-only ABAC rules.
 - Restarting is no longer the only update path when the management API is enabled; staged rule edits still require explicit activation before they affect authorization.

--- a/internal/common/configuration.go
+++ b/internal/common/configuration.go
@@ -69,6 +69,7 @@ var DefaultConfig = struct {
 	ABACEnabled                         bool
 	ABACModelPath                       string
 	ABACPolicyFileImport                string
+	ABACPolicyScope                     string
 	ABACManagementAPIEnabled            bool
 	GeneralImplicitCasts                bool
 	GeneralDescriptorDebug              bool
@@ -127,6 +128,7 @@ var DefaultConfig = struct {
 	ABACEnabled:                         false,
 	ABACModelPath:                       "config/access_rules/access-rules.json",
 	ABACPolicyFileImport:                "",
+	ABACPolicyScope:                     "",
 	ABACManagementAPIEnabled:            false,
 	GeneralImplicitCasts:                true,
 	GeneralDescriptorDebug:              false,
@@ -173,6 +175,8 @@ const (
 	ABACPolicyFileImportIfMissing = "if_missing"
 	// ABACPolicyFileImportNever disables startup file import and requires an active DB policy.
 	ABACPolicyFileImportNever = "never"
+
+	maxABACPolicyScopeLength = 255
 )
 
 // PrintSplash displays the BaSyx Go API ASCII art logo to the console.
@@ -387,6 +391,7 @@ type ABACConfig struct {
 	Enabled          bool                    `mapstructure:"enabled" yaml:"enabled" json:"enabled"`                             // Enable/disable ABAC
 	ModelPath        string                  `mapstructure:"modelPath" yaml:"modelPath" json:"modelPath"`                       // Path to access control model
 	PolicyFileImport string                  `mapstructure:"policyFileImport" yaml:"policyFileImport" json:"policyFileImport"`  // always|if_missing|never; empty uses the service default
+	PolicyScope      string                  `mapstructure:"policyScope" yaml:"policyScope" json:"policyScope"`                 // Optional DB policy namespace; empty uses the service default
 	ManagementAPI    ABACManagementAPIConfig `mapstructure:"managementApi" yaml:"managementApi" json:"managementApi,omitempty"` // Runtime ABAC policy management API
 }
 
@@ -571,6 +576,9 @@ func applyABACEnvOverrides(cfg *Config) {
 	if value, ok := lookupFirstTrimmedEnv("ABAC_POLICY_FILE_IMPORT", "BASYX_ABAC_POLICY_FILE_IMPORT"); ok {
 		cfg.ABAC.PolicyFileImport = value
 	}
+	if value, ok := lookupFirstTrimmedEnv("ABAC_POLICY_SCOPE", "BASYX_ABAC_POLICY_SCOPE"); ok {
+		cfg.ABAC.PolicyScope = value
+	}
 	applyFirstBoolEnv(func(value bool) { cfg.ABAC.ManagementAPI.Enabled = value },
 		"ABAC_MANAGEMENT_API_ENABLED",
 		"ABAC_MANAGEMENTAPI_ENABLED",
@@ -582,16 +590,62 @@ func validateABACConfig(cfg *Config) error {
 	if cfg == nil {
 		return fmt.Errorf("CONFIG-ABAC-NIL configuration must not be nil")
 	}
-	if strings.TrimSpace(cfg.ABAC.PolicyFileImport) == "" {
+	if strings.TrimSpace(cfg.ABAC.PolicyFileImport) != "" {
+		switch strings.ToLower(strings.TrimSpace(cfg.ABAC.PolicyFileImport)) {
+		case ABACPolicyFileImportAlways, ABACPolicyFileImportIfMissing, ABACPolicyFileImportNever:
+			cfg.ABAC.PolicyFileImport = strings.ToLower(strings.TrimSpace(cfg.ABAC.PolicyFileImport))
+		default:
+			return fmt.Errorf("CONFIG-ABAC-POLICYFILEIMPORT unsupported abac.policyFileImport %q", cfg.ABAC.PolicyFileImport)
+		}
+	}
+	if strings.TrimSpace(cfg.ABAC.PolicyScope) == "" {
+		cfg.ABAC.PolicyScope = ""
 		return nil
 	}
-	switch strings.ToLower(strings.TrimSpace(cfg.ABAC.PolicyFileImport)) {
-	case ABACPolicyFileImportAlways, ABACPolicyFileImportIfMissing, ABACPolicyFileImportNever:
-		cfg.ABAC.PolicyFileImport = strings.ToLower(strings.TrimSpace(cfg.ABAC.PolicyFileImport))
-		return nil
-	default:
-		return fmt.Errorf("CONFIG-ABAC-POLICYFILEIMPORT unsupported abac.policyFileImport %q", cfg.ABAC.PolicyFileImport)
+	scope, err := normalizeABACPolicyScope(cfg.ABAC.PolicyScope)
+	if err != nil {
+		return err
 	}
+	cfg.ABAC.PolicyScope = scope
+	return nil
+}
+
+// ConfiguredPolicyScope resolves the DB-backed ABAC policy namespace for a service.
+//
+// When abac.policyScope is empty, the service's built-in scope is used so
+// existing deployments keep their current policy isolation behavior.
+func ConfiguredPolicyScope(cfg *Config, defaultServiceScope string) (string, error) {
+	scope := defaultServiceScope
+	if cfg != nil && strings.TrimSpace(cfg.ABAC.PolicyScope) != "" {
+		scope = cfg.ABAC.PolicyScope
+	}
+	return normalizeABACPolicyScope(scope)
+}
+
+func normalizeABACPolicyScope(scope string) (string, error) {
+	trimmed := strings.TrimSpace(scope)
+	if trimmed == "" {
+		return "", fmt.Errorf("CONFIG-ABAC-POLICYSCOPE abac.policyScope must not be empty")
+	}
+	if len(trimmed) > maxABACPolicyScopeLength {
+		return "", fmt.Errorf("CONFIG-ABAC-POLICYSCOPE abac.policyScope must not exceed %d characters", maxABACPolicyScopeLength)
+	}
+	for _, char := range trimmed {
+		if !isABACPolicyScopeChar(char) {
+			return "", fmt.Errorf("CONFIG-ABAC-POLICYSCOPE abac.policyScope contains unsupported character %q", char)
+		}
+	}
+	return trimmed, nil
+}
+
+func isABACPolicyScopeChar(char rune) bool {
+	return char >= 'a' && char <= 'z' ||
+		char >= 'A' && char <= 'Z' ||
+		char >= '0' && char <= '9' ||
+		char == '_' ||
+		char == '-' ||
+		char == '.' ||
+		char == ':'
 }
 
 func applyHistoryEnvOverrides(cfg *Config) {
@@ -962,6 +1016,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("abac.enableDebugErrorResponses", false)
 	v.SetDefault("abac.modelPath", "config/access_rules/access-rules.json")
 	v.SetDefault("abac.policyFileImport", DefaultConfig.ABACPolicyFileImport)
+	v.SetDefault("abac.policyScope", DefaultConfig.ABACPolicyScope)
 	v.SetDefault("abac.managementApi.enabled", DefaultConfig.ABACManagementAPIEnabled)
 
 	// JWS defaults
@@ -1098,6 +1153,7 @@ func PrintConfiguration(cfg *Config) {
 	if cfg.ABAC.Enabled {
 		add("Model Path", cfg.ABAC.ModelPath, DefaultConfig.ABACModelPath)
 		add("Policy File Import", cfg.ABAC.PolicyFileImport, DefaultConfig.ABACPolicyFileImport)
+		add("Policy Scope", cfg.ABAC.PolicyScope, DefaultConfig.ABACPolicyScope)
 		add("Management API Enabled", cfg.ABAC.ManagementAPI.Enabled, DefaultConfig.ABACManagementAPIEnabled)
 
 		lines = append(lines, "🔹 OIDC:")

--- a/internal/common/configuration_test.go
+++ b/internal/common/configuration_test.go
@@ -452,6 +452,8 @@ func TestLoadConfigAppliesHistoryAndEventingDefaults(t *testing.T) {
 	withUnsetEnv(t, "BASYX_HISTORY_INTEGRITY_ANCHOR_PROVIDER")
 	withUnsetEnv(t, "ABAC_POLICY_FILE_IMPORT")
 	withUnsetEnv(t, "BASYX_ABAC_POLICY_FILE_IMPORT")
+	withUnsetEnv(t, "ABAC_POLICY_SCOPE")
+	withUnsetEnv(t, "BASYX_ABAC_POLICY_SCOPE")
 	withUnsetEnv(t, "ABAC_MANAGEMENT_API_ENABLED")
 	withUnsetEnv(t, "ABAC_MANAGEMENTAPI_ENABLED")
 	withUnsetEnv(t, "BASYX_ABAC_MANAGEMENT_API_ENABLED")
@@ -492,6 +494,7 @@ func TestLoadConfigAppliesHistoryAndEventingDefaults(t *testing.T) {
 
 func TestLoadConfigAppliesABACPolicyRepositoryEnvOverrides(t *testing.T) {
 	t.Setenv("ABAC_POLICY_FILE_IMPORT", "if_missing")
+	t.Setenv("ABAC_POLICY_SCOPE", "aasregistry-internal")
 	t.Setenv("ABAC_MANAGEMENT_API_ENABLED", "true")
 	captureLogOutput(t)
 
@@ -503,8 +506,97 @@ func TestLoadConfigAppliesABACPolicyRepositoryEnvOverrides(t *testing.T) {
 	if cfg.ABAC.PolicyFileImport != ABACPolicyFileImportIfMissing {
 		t.Fatalf("expected policy file import override, got %q", cfg.ABAC.PolicyFileImport)
 	}
+	if cfg.ABAC.PolicyScope != "aasregistry-internal" {
+		t.Fatalf("expected policy scope override, got %q", cfg.ABAC.PolicyScope)
+	}
 	if !cfg.ABAC.ManagementAPI.Enabled {
 		t.Fatal("expected ABAC management API env override")
+	}
+}
+
+func TestLoadConfigAppliesABACPolicyScopeFromConfig(t *testing.T) {
+	withUnsetEnv(t, "ABAC_POLICY_SCOPE")
+	withUnsetEnv(t, "BASYX_ABAC_POLICY_SCOPE")
+	path := writeTempConfig(t, `
+abac:
+  policyScope: " dtr:public-01 "
+`)
+	captureLogOutput(t)
+
+	cfg, err := LoadConfig(path, NORMAL)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+
+	if cfg.ABAC.PolicyScope != "dtr:public-01" {
+		t.Fatalf("expected trimmed policy scope, got %q", cfg.ABAC.PolicyScope)
+	}
+}
+
+func TestLoadConfigAppliesABACPolicyScopeBasyxEnvOverride(t *testing.T) {
+	withUnsetEnv(t, "ABAC_POLICY_SCOPE")
+	t.Setenv("BASYX_ABAC_POLICY_SCOPE", "shared.scope")
+	captureLogOutput(t)
+
+	cfg, err := LoadConfig("", NORMAL)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+
+	if cfg.ABAC.PolicyScope != "shared.scope" {
+		t.Fatalf("expected BASYX policy scope override, got %q", cfg.ABAC.PolicyScope)
+	}
+}
+
+func TestConfiguredPolicyScopeUsesDefaultForEmptyConfig(t *testing.T) {
+	cfg := &Config{
+		ABAC: ABACConfig{
+			PolicyScope: " ",
+		},
+	}
+
+	scope, err := ConfiguredPolicyScope(cfg, "aasregistryservice")
+	if err != nil {
+		t.Fatalf("unexpected policy scope error: %v", err)
+	}
+	if scope != "aasregistryservice" {
+		t.Fatalf("expected default service scope, got %q", scope)
+	}
+}
+
+func TestConfiguredPolicyScopeRejectsEmptyDefault(t *testing.T) {
+	_, err := ConfiguredPolicyScope(&Config{}, " ")
+	if err == nil {
+		t.Fatal("expected empty default service scope error")
+	}
+	if !strings.Contains(err.Error(), "CONFIG-ABAC-POLICYSCOPE") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfigRejectsInvalidABACPolicyScope(t *testing.T) {
+	t.Setenv("ABAC_POLICY_SCOPE", "aasregistry/internal")
+	captureLogOutput(t)
+
+	_, err := LoadConfig("", NORMAL)
+	if err == nil {
+		t.Fatal("expected invalid ABAC policy scope error")
+	}
+	if !strings.Contains(err.Error(), "CONFIG-ABAC-POLICYSCOPE") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfigRejectsTooLongABACPolicyScope(t *testing.T) {
+	t.Setenv("ABAC_POLICY_SCOPE", strings.Repeat("a", maxABACPolicyScopeLength+1))
+	captureLogOutput(t)
+
+	_, err := LoadConfig("", NORMAL)
+	if err == nil {
+		t.Fatal("expected too long ABAC policy scope error")
+	}
+	if !strings.Contains(err.Error(), "CONFIG-ABAC-POLICYSCOPE") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/common/security/abacpolicy/repository_test.go
+++ b/internal/common/security/abacpolicy/repository_test.go
@@ -113,6 +113,58 @@ func TestPublishActivePolicyAfterFailClosedClearRestoresCache(t *testing.T) {
 	}
 }
 
+func TestRepositoriesWithDifferentScopesLoadIndependentActivePolicies(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock setup failed: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+	publicRepo, err := NewRepository(db, "dtr-public", chi.NewRouter(), "")
+	if err != nil {
+		t.Fatalf("public repository setup failed: %v", err)
+	}
+	internalRepo, err := NewRepository(db, "aasregistry-internal", chi.NewRouter(), "")
+	if err != nil {
+		t.Fatalf("internal repository setup failed: %v", err)
+	}
+	materialized := testMaterializedPolicy(t)
+	publicActive := testPolicyVersion(10, StatusActive, materialized)
+	publicActive.ServiceScope = "dtr-public"
+	publicActive.PolicyID = strings.Repeat("a", 64)
+	internalActive := testPolicyVersion(20, StatusActive, materialized)
+	internalActive.ServiceScope = "aasregistry-internal"
+	internalActive.PolicyID = strings.Repeat("b", 64)
+
+	mock.ExpectQuery(`FROM "abac_policy_versions".*"service_scope" = 'dtr-public'.*"status" = 'active'`).
+		WillReturnRows(policyVersionRows(publicActive))
+	mock.ExpectQuery(`FROM "abac_policy_rules".*"service_scope" = 'dtr-public'.*"version_id" = 10`).
+		WillReturnRows(policyRuleRows())
+	mock.ExpectQuery(`FROM "abac_policy_versions".*"service_scope" = 'aasregistry-internal'.*"status" = 'active'`).
+		WillReturnRows(policyVersionRows(internalActive))
+	mock.ExpectQuery(`FROM "abac_policy_rules".*"service_scope" = 'aasregistry-internal'.*"version_id" = 20`).
+		WillReturnRows(policyRuleRows())
+
+	if err = publicRepo.RefreshActiveModel(t.Context()); err != nil {
+		t.Fatalf("refresh public policy failed: %v", err)
+	}
+	if err = internalRepo.RefreshActiveModel(t.Context()); err != nil {
+		t.Fatalf("refresh internal policy failed: %v", err)
+	}
+	if publicRepo.ActiveAccessModel().PolicyID() != publicActive.PolicyID {
+		t.Fatalf("expected public policy %q, got %q", publicActive.PolicyID, publicRepo.ActiveAccessModel().PolicyID())
+	}
+	if internalRepo.ActiveAccessModel().PolicyID() != internalActive.PolicyID {
+		t.Fatalf("expected internal policy %q, got %q", internalActive.PolicyID, internalRepo.ActiveAccessModel().PolicyID())
+	}
+	if err = mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
 func TestResolvePolicyFileImportModeAppliesServiceDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -162,17 +214,17 @@ func TestResolvePolicyFileImportModeRejectsUnsupportedValue(t *testing.T) {
 	}
 }
 
-func TestManagementAPIAllowedRejectsDigitalTwinRegistry(t *testing.T) {
+func TestManagementRoutesEnabledRequiresExplicitOptIn(t *testing.T) {
 	t.Parallel()
 
-	if ManagementAPIAllowed("digitaltwinregistryservice") {
-		t.Fatal("expected Digital Twin Registry management API to be rejected")
+	cfg := &common.Config{
+		ABAC: common.ABACConfig{
+			Enabled: true,
+		},
 	}
-	if ManagementAPIAllowed(" DigitalTwinRegistryService ") {
-		t.Fatal("expected Digital Twin Registry management API to be rejected with whitespace and case normalization")
-	}
-	if !ManagementAPIAllowed("submodelrepositoryservice") {
-		t.Fatal("expected non-DTR service scope to allow opt-in management API")
+
+	if ManagementRoutesEnabled(cfg, "digitaltwinregistryservice") {
+		t.Fatal("expected management routes to stay disabled without explicit opt-in")
 	}
 }
 

--- a/internal/common/security/abacpolicy/setup.go
+++ b/internal/common/security/abacpolicy/setup.go
@@ -90,21 +90,25 @@ func SetupSecurityWithABACRepository(
 	cfg *common.Config,
 	r *chi.Mux,
 	db *sql.DB,
-	serviceScope string,
+	serviceType string,
 	claimsMiddleware ...func(http.Handler) http.Handler,
 ) (*Repository, error) {
 	if cfg == nil || !cfg.ABAC.Enabled {
 		return nil, nil
 	}
-	repo, err := NewRepository(db, serviceScope, r, cfg.Server.ContextPath)
+	policyScope, err := common.ConfiguredPolicyScope(cfg, serviceType)
 	if err != nil {
 		return nil, err
 	}
-	mode, err := resolvePolicyFileImportMode(cfg.ABAC.PolicyFileImport, serviceScope)
+	repo, err := NewRepository(db, policyScope, r, cfg.Server.ContextPath)
 	if err != nil {
 		return nil, err
 	}
-	if err = initializeRepository(ctx, repo, cfg.ABAC.ModelPath, serviceScope, mode); err != nil {
+	mode, err := resolvePolicyFileImportMode(cfg.ABAC.PolicyFileImport, serviceType)
+	if err != nil {
+		return nil, err
+	}
+	if err = initializeRepository(ctx, repo, cfg.ABAC.ModelPath, policyScope, mode); err != nil {
 		return nil, err
 	}
 	if err = auth.SetupSecurityWithAccessModelProvider(ctx, cfg, r, repo, claimsMiddleware...); err != nil {
@@ -113,28 +117,18 @@ func SetupSecurityWithABACRepository(
 	return repo, nil
 }
 
-// ManagementAPIAllowed reports whether a service may expose ABAC management.
-//
-// Digital Twin Registry deliberately returns false because its access-rule file
-// remains the operational source of truth and is re-imported on restart.
-func ManagementAPIAllowed(serviceScope string) bool {
-	return !strings.EqualFold(strings.TrimSpace(serviceScope), "digitaltwinregistryservice")
-}
-
 // ManagementRoutesEnabled reports whether management routes should be mounted.
 //
 // The API is available only when ABAC is enabled, the management API is
-// explicitly enabled by configuration, and the service scope is allowed to
-// expose runtime policy management.
-func ManagementRoutesEnabled(cfg *common.Config, serviceScope string) bool {
-	return cfg != nil && cfg.ABAC.Enabled && cfg.ABAC.ManagementAPI.Enabled && ManagementAPIAllowed(serviceScope)
+// explicitly enabled by configuration.
+func ManagementRoutesEnabled(cfg *common.Config, _ string) bool {
+	return cfg != nil && cfg.ABAC.Enabled && cfg.ABAC.ManagementAPI.Enabled
 }
 
 // RegisterManagementRoutesIfEnabled mounts the protected management API.
 //
 // This helper is safe to call for every service. It no-ops when the repository
-// is nil, ABAC is disabled, management is not opted in, or the service scope is
-// not allowed to expose management routes.
+// is nil, ABAC is disabled, or management is not opted in.
 func RegisterManagementRoutesIfEnabled(cfg *common.Config, r chi.Router, repo *Repository, serviceScope string) {
 	if repo == nil || !ManagementRoutesEnabled(cfg, serviceScope) {
 		return

--- a/internal/common/security/abacpolicy/setup_test.go
+++ b/internal/common/security/abacpolicy/setup_test.go
@@ -1,0 +1,104 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package abacpolicy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestSetupSecurityWithABACRepositoryUsesConfiguredPolicyScope(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock setup failed: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	policyScope := "aasregistry-internal"
+	active := testPolicyVersion(7, StatusActive, testMaterializedPolicy(t))
+	active.ServiceScope = policyScope
+	cfg := setupPolicyScopeConfig(t, policyScope)
+	router := chi.NewRouter()
+
+	mock.ExpectQuery(`FROM "abac_policy_versions".*"service_scope" = 'aasregistry-internal'.*"status" = 'active'`).
+		WillReturnRows(policyVersionRows(active))
+	mock.ExpectQuery(`FROM "abac_policy_rules".*"service_scope" = 'aasregistry-internal'.*"version_id" = 7`).
+		WillReturnRows(policyRuleRows())
+
+	repo, err := SetupSecurityWithABACRepository(t.Context(), cfg, router, db, "aasregistryservice")
+	if err != nil {
+		t.Fatalf("setup ABAC repository failed: %v", err)
+	}
+	if repo.serviceScope != policyScope {
+		t.Fatalf("expected repository scope %q, got %q", policyScope, repo.serviceScope)
+	}
+	if err = mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestManagementRoutesEnabledAllowsExplicitDigitalTwinRegistryOptIn(t *testing.T) {
+	t.Parallel()
+
+	cfg := managementAPIEnabledConfig()
+	cfg.ABAC.PolicyScope = "shared-public-policy"
+
+	if !ManagementRoutesEnabled(cfg, "digitaltwinregistryservice") {
+		t.Fatal("expected Digital Twin Registry management routes to be enabled by explicit opt-in")
+	}
+	if !ManagementRoutesEnabled(cfg, "aasregistryservice") {
+		t.Fatal("expected non-DTR management routes to be enabled by explicit opt-in")
+	}
+}
+
+func setupPolicyScopeConfig(t *testing.T, policyScope string) *common.Config {
+	t.Helper()
+	trustlistPath := t.TempDir() + "/trustlist.json"
+	if err := os.WriteFile(trustlistPath, []byte(`[]`), 0o600); err != nil {
+		t.Fatalf("write trustlist: %v", err)
+	}
+	return &common.Config{
+		General: common.GeneralConfig{
+			EnableImplicitCasts: true,
+		},
+		OIDC: common.OIDCConfig{
+			TrustlistPath: trustlistPath,
+		},
+		ABAC: common.ABACConfig{
+			Enabled:          true,
+			PolicyFileImport: common.ABACPolicyFileImportNever,
+			PolicyScope:      policyScope,
+		},
+	}
+}


### PR DESCRIPTION
This pull request introduces a new `abac.policyScope` configuration option to control the database namespace for ABAC (Attribute-Based Access Control) policy storage and isolation. This allows operators to explicitly separate or share policy state between different deployments or services using the same database. The change is accompanied by documentation updates, configuration validation, new environment variable support, and comprehensive tests to ensure correct behavior and error handling.

**Key changes:**

**ABAC Policy Scope Configuration and Validation**
- Added `policyScope` to the ABAC configuration struct, environment variables, and config file parsing. This value determines the namespace used for storing and retrieving ABAC policies in the database, allowing for explicit isolation or sharing of policies between deployments. Validation ensures the scope is non-empty, within length limits, and contains only allowed characters. [[1]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R72) [[2]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R131) [[3]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R394) [[4]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R579-R581) [[5]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21L585-R649) [[6]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R1019) [[7]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R1156)
- Introduced the `ConfiguredPolicyScope` function to resolve the effective policy scope, defaulting to the service's built-in scope if not set.

**Documentation and Usage Guidance**
- Updated ABAC policy repository documentation to explain the new `policyScope` option, its effects, and best practices for using it to isolate or share policy state across deployments. Clarified the behavior for Digital Twin Registry and other services, and added usage caveats for multi-instance deployments. [[1]](diffhunk://#diff-aa4d917c96007b90bc2672c85c7cb417dcdf2f8191a5e57feb2f797b04acb965R19) [[2]](diffhunk://#diff-aa4d917c96007b90bc2672c85c7cb417dcdf2f8191a5e57feb2f797b04acb965R29-R47) [[3]](diffhunk://#diff-aa4d917c96007b90bc2672c85c7cb417dcdf2f8191a5e57feb2f797b04acb965L55-R68) [[4]](diffhunk://#diff-aa4d917c96007b90bc2672c85c7cb417dcdf2f8191a5e57feb2f797b04acb965L542-R559) [[5]](diffhunk://#diff-2e93ae240019246f83f247177aedb273801a830aa3ad2430661f9b349e471548L131-R132) [[6]](diffhunk://#diff-2e93ae240019246f83f247177aedb273801a830aa3ad2430661f9b349e471548L338-R340)

**Testing and Validation**
- Added and extended tests to verify correct parsing, validation, and application of `policyScope` from config files and environment variables, including error cases for invalid or too-long values. [[1]](diffhunk://#diff-160e618ebbfc84b3000fb7dcfffc15c6f9dfadaafe3d1915e5a47f3393dcc46cR455-R456) [[2]](diffhunk://#diff-160e618ebbfc84b3000fb7dcfffc15c6f9dfadaafe3d1915e5a47f3393dcc46cR497) [[3]](diffhunk://#diff-160e618ebbfc84b3000fb7dcfffc15c6f9dfadaafe3d1915e5a47f3393dcc46cR509-R602)
- Added integration test to ensure repositories with different policy scopes load and cache independent active policies from the database.

**Other Notable Adjustments**
- Updated configuration printing and defaults to include the new `policyScope` field. [[1]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R1156) [[2]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R1019)
- Removed Digital Twin Registry-specific logic that forcibly disables the ABAC management API, making it possible to enable the management API explicitly if desired.

These changes collectively provide more flexible and robust control over ABAC policy management in multi-service and multi-instance deployments, with clear documentation and safeguards.

**References:**  
[[1]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R72) [[2]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R131) [[3]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R394) [[4]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R579-R581) [[5]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21L585-R649) [[6]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R1019) [[7]](diffhunk://#diff-7b43e39694dad3fe671ce46b4026cd48dc259e8c69cab5f14532769e34885e21R1156) [[8]](diffhunk://#diff-aa4d917c96007b90bc2672c85c7cb417dcdf2f8191a5e57feb2f797b04acb965R19) [[9]](diffhunk://#diff-aa4d917c96007b90bc2672c85c7cb417dcdf2f8191a5e57feb2f797b04acb965R29-R47) [[10]](diffhunk://#diff-aa4d917c96007b90bc2672c85c7cb417dcdf2f8191a5e57feb2f797b04acb965L55-R68) [[11]](diffhunk://#diff-aa4d917c96007b90bc2672c85c7cb417dcdf2f8191a5e57feb2f797b04acb965L542-R559) [[12]](diffhunk://#diff-2e93ae240019246f83f247177aedb273801a830aa3ad2430661f9b349e471548L131-R132) [[13]](diffhunk://#diff-2e93ae240019246f83f247177aedb273801a830aa3ad2430661f9b349e471548L338-R340) [[14]](diffhunk://#diff-160e618ebbfc84b3000fb7dcfffc15c6f9dfadaafe3d1915e5a47f3393dcc46cR455-R456) [[15]](diffhunk://#diff-160e618ebbfc84b3000fb7dcfffc15c6f9dfadaafe3d1915e5a47f3393dcc46cR497) [[16]](diffhunk://#diff-160e618ebbfc84b3000fb7dcfffc15c6f9dfadaafe3d1915e5a47f3393dcc46cR509-R602) [[17]](diffhunk://#diff-913e52947516289ffcb34c80b6b70fde10f71b0d8d03aa5bbcb5f1b4ac755ceaR116-R167) [[18]](diffhunk://#diff-ee38c16347b18545d4fb956226c6b9501a83ca5636f4b25bf4d85ecba90535adL66-L68)

Closes #408 