### PR TITLE
Improves Catena-X Marker Example

### DIFF
--- a/examples/BaSyxMarkerAccessExample/BaSyx-Marker-Access.postman_collection.json
+++ b/examples/BaSyxMarkerAccessExample/BaSyx-Marker-Access.postman_collection.json
@@ -872,7 +872,7 @@
     },
     {
       "key": "keycloakTokenUrl",
-      "value": "http://localhost:8080/realms/basyx/protocol/openid-connect/token"
+      "value": "http://keycloak.localhost:8080/realms/basyx/protocol/openid-connect/token"
     },
     {
       "key": "keycloakClientId",

--- a/examples/BaSyxMarkerAccessExample/README.md
+++ b/examples/BaSyxMarkerAccessExample/README.md
@@ -4,7 +4,8 @@ This example builds the current repository code and runs:
 
 - a Digital Twin Registry on `http://localhost:5004/api/v3`;
 - a Submodel Repository on `http://localhost:5005`;
-- Keycloak on `http://localhost:8080`;
+- the BaSyx UI on `http://localhost:3000`;
+- Keycloak on `http://keycloak.localhost:8080`;
 - separate databases and configuration-service runs for DTR and Submodel Repository.
 
 The services use marker values to control visibility:
@@ -29,6 +30,9 @@ Run from this directory:
 ```bash
 docker compose up -d --build
 ```
+
+The BaSyx UI uses the `basyx-ui` OAuth2 auth-code client from the imported
+Keycloak realm and is configured through `basyx-infra.yml`.
 
 ## Postman Collection
 

--- a/examples/BaSyxMarkerAccessExample/basyx-infra.yml
+++ b/examples/BaSyxMarkerAccessExample/basyx-infra.yml
@@ -1,0 +1,18 @@
+infrastructures:
+  default: markerAccess
+
+  markerAccess:
+    name: Catena-X Example
+    template: catena-x
+    components:
+      digitalTwinRegistry:
+        baseUrl: "http://localhost:5004/api/v3"
+        hasDiscoveryIntegration: true
+      submodelService:
+        baseUrl: "http://localhost:5005"
+    security:
+      type: oauth2
+      config:
+        flow: auth_code
+        issuer: "http://keycloak.localhost:8080/realms/basyx"
+        clientId: "basyx-ui"

--- a/examples/BaSyxMarkerAccessExample/docker-compose.yml
+++ b/examples/BaSyxMarkerAccessExample/docker-compose.yml
@@ -71,6 +71,10 @@ services:
       SERVER_PORT: 5004
       SERVER_CONTEXTPATH: /api/v3
       SERVER_STRICTVERIFICATION: "off"
+      CORS_ALLOWEDORIGINS: "*"
+      CORS_ALLOWEDHEADERS: "*"
+      CORS_ALLOWEDCREDENTIALS: "true"
+      CORS_ALLOWEDMETHODS: GET,POST,PUT,PATCH,DELETE,OPTIONS
       POSTGRES_HOST: dtr-db
       POSTGRES_PORT: 5432
       POSTGRES_USER: admin
@@ -78,13 +82,14 @@ services:
       POSTGRES_DBNAME: dtr
       ABAC_ENABLED: "true"
       ABAC_MODELPATH: /security/access-rules.json
+      ABAC_POLICY_FILE_IMPORT: always
       OIDC_TRUSTLISTPATH: /security/trustlist.json
       GENERAL_ENABLECUSTOMMIDDLEWAREHEADERINJECTION: "true"
       GENERAL_SUPPORTSSINGULARSUPPLEMENTALSEMANTICID: "true"
     volumes:
       - ./security/dtr:/security:ro
     extra_hosts:
-      - "localhost:host-gateway"
+      - "keycloak.localhost:host-gateway"
     ports:
       - "5004:5004"
     depends_on:
@@ -100,6 +105,10 @@ services:
     environment:
       SERVER_PORT: 5004
       SERVER_STRICTVERIFICATION: "off"
+      CORS_ALLOWEDORIGINS: "*"
+      CORS_ALLOWEDHEADERS: "*"
+      CORS_ALLOWEDCREDENTIALS: "true"
+      CORS_ALLOWEDMETHODS: GET,POST,PUT,PATCH,DELETE,OPTIONS
       POSTGRES_HOST: smrepo-db
       POSTGRES_PORT: 5432
       POSTGRES_USER: admin
@@ -107,17 +116,38 @@ services:
       POSTGRES_DBNAME: smrepo
       ABAC_ENABLED: "true"
       ABAC_MODELPATH: /security/access-rules.json
+      ABAC_POLICY_FILE_IMPORT: always
       OIDC_TRUSTLISTPATH: /security/trustlist.json
       GENERAL_ENABLECUSTOMMIDDLEWAREHEADERINJECTION: "true"
     volumes:
       - ./security/smrepo:/security:ro
     extra_hosts:
-      - "localhost:host-gateway"
+      - "keycloak.localhost:host-gateway"
     ports:
       - "5005:5004"
     depends_on:
       smrepo-configuration:
         condition: service_completed_successfully
+      keycloak-healthcheck:
+        condition: service_completed_successfully
+
+  aas-ui:
+    container_name: marker-access-aas-web-ui
+    image: eclipsebasyx/aas-gui:SNAPSHOT
+    pull_policy: always
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./basyx-infra.yml:/basyx-infra.yml:ro
+    environment:
+      START_PAGE_ROUTE_NAME: "CatenaXplorer"
+    extra_hosts:
+      - "keycloak.localhost:host-gateway"
+    depends_on:
+      digital-twin-registry:
+        condition: service_started
+      submodel-repository:
+        condition: service_started
       keycloak-healthcheck:
         condition: service_completed_successfully
 
@@ -128,21 +158,21 @@ services:
       KC_DB_URL: jdbc:postgresql://keycloak-db:5432/keycloak
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
-      KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: http://localhost:8080
+      KC_HOSTNAME: keycloak.localhost
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
+      KC_HTTPS_ENABLED: "false"
       KC_HEALTH_ENABLED: "true"
       KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
       KC_IMPORT: /opt/keycloak/data/import/
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
       - "8080:8080"
     volumes:
-      - ../BaSyxDigitalTwinRegistryExample/keycloak/realm:/opt/keycloak/data/import:ro
+      - ./keycloak/realm:/opt/keycloak/data/import:ro
     depends_on:
       keycloak-db:
         condition: service_healthy

--- a/examples/BaSyxMarkerAccessExample/keycloak/realm/basyx-realm.json
+++ b/examples/BaSyxMarkerAccessExample/keycloak/realm/basyx-realm.json
@@ -1,0 +1,2562 @@
+{
+  "id" : "f97245ab-82c3-45ac-9b5b-dc160b1a1311",
+  "realm" : "basyx",
+  "displayName" : "",
+  "displayNameHtml" : "",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxTemporaryLockouts" : 0,
+  "bruteForceStrategy" : "MULTIPLE",
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "a83a65a8-0a55-4a8b-86b2-cf6e6484d70d",
+      "name" : "admin",
+      "description" : "",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f97245ab-82c3-45ac-9b5b-dc160b1a1311",
+      "attributes" : { }
+    }, {
+      "id" : "ee306a9f-d72f-456b-84dd-04ae55262e23",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f97245ab-82c3-45ac-9b5b-dc160b1a1311",
+      "attributes" : { }
+    }, {
+      "id" : "6981ff7a-5223-40dd-bc78-322ae5a357fa",
+      "name" : "default-roles-basyx",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "view-profile", "manage-account" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "f97245ab-82c3-45ac-9b5b-dc160b1a1311",
+      "attributes" : { }
+    }, {
+      "id" : "f58b8d72-388b-4d3e-8431-1bb4a540e2ef",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f97245ab-82c3-45ac-9b5b-dc160b1a1311",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "7c4855d3-c93e-440c-b511-608bf4148d1a",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "578c8556-266a-4978-b779-e4f6d43c23ea",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "41cfe82c-e73a-4270-9938-c9e311795d06",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "dfbbee59-23f9-4e3e-81d2-d7f34772c55e",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "f86cb5a6-0cfa-4ab8-bdc5-772127027818",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "8a65a532-867f-41e2-8357-22ddcc2eaeca",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "017bfacd-59a5-4897-a49a-d5f8651f54f6",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "8cbe1350-1398-4293-899e-64ff21bfc9b0",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "3c5eef9f-c1f3-42f0-9ab6-6950da0d0250",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "66445e2e-d718-4b70-b5b1-a328c6a234d1",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "dead45ca-5b7b-4466-8b88-738dc7217197",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "a24a4aa7-d557-4a39-8845-92af98b5c538",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-users", "query-realms", "view-authorization", "query-clients", "view-clients", "manage-users", "manage-clients", "impersonation", "create-client", "view-identity-providers", "view-events", "manage-realm", "manage-events", "query-groups", "manage-identity-providers", "manage-authorization", "view-realm", "view-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "a2f95f4a-d337-438f-953a-77b69b11251b",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "427c8af1-075a-4141-9c11-cd5efdfac68a",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "bd2628b9-6518-4e77-92ac-010c2a9e5815",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "b020d5aa-a1ed-4bb1-9326-7345a8e85720",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "77e9ecaf-5fd4-40df-9031-78d71ad4c4cf",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "f886dc7a-5644-41bb-83ed-61c49ea25444",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      }, {
+        "id" : "a458476f-82e7-49e8-9cd9-d30c384e8c08",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-users", "query-groups" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "d66f233e-c934-40d3-912e-cccb235a254e",
+        "attributes" : { }
+      } ],
+      "basyx-ui" : [ ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "97476aed-c5f7-491e-8775-27638fc10cf5",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "20974092-14b8-4258-a260-12cccbb34ce1",
+        "attributes" : { }
+      } ],
+      "aas-env" : [ {
+        "id" : "60882525-791b-48d2-b036-759aa6a81337",
+        "name" : "admin",
+        "description" : "",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "a943241a-12bf-44b4-a0bc-8bed1edf744a",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "02c9a901-d899-4d04-ace8-b2265745c33b",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5056cdec-06ed-4c3b-b478-90a524521a69",
+        "attributes" : { }
+      }, {
+        "id" : "e804a2b0-01dd-44a3-8580-f23255236470",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "5056cdec-06ed-4c3b-b478-90a524521a69",
+        "attributes" : { }
+      }, {
+        "id" : "2e9ed72e-e808-408c-b67a-fbd023ddc12b",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5056cdec-06ed-4c3b-b478-90a524521a69",
+        "attributes" : { }
+      }, {
+        "id" : "9cd59e5e-1622-419b-ae1c-82887566598f",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5056cdec-06ed-4c3b-b478-90a524521a69",
+        "attributes" : { }
+      }, {
+        "id" : "a4665872-9e8a-407a-be8b-3bac927dbd62",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5056cdec-06ed-4c3b-b478-90a524521a69",
+        "attributes" : { }
+      }, {
+        "id" : "8a1152f2-6d11-4b60-bff9-355a621ba440",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5056cdec-06ed-4c3b-b478-90a524521a69",
+        "attributes" : { }
+      }, {
+        "id" : "3651b578-e3c6-4912-989f-cd3a19e4fa89",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "5056cdec-06ed-4c3b-b478-90a524521a69",
+        "attributes" : { }
+      }, {
+        "id" : "0fb29d7e-4a49-47ec-adf6-5528ee19a301",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "5056cdec-06ed-4c3b-b478-90a524521a69",
+        "attributes" : { }
+      } ],
+      "discovery-service" : [ {
+        "id" : "ca583d4f-0319-423c-aa5a-5a8632409979",
+        "name" : "uma_protection",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "988bf103-59ae-4ea9-9301-34d973e69c4d",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRole" : {
+    "id" : "6981ff7a-5223-40dd-bc78-322ae5a357fa",
+    "name" : "default-roles-basyx",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "f97245ab-82c3-45ac-9b5b-dc160b1a1311"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
+  "localizationTexts" : { },
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyExtraOrigins" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
+  "users" : [ {
+    "id" : "32103f0d-1d0e-4d94-b720-bcd22e1c7709",
+    "username" : "admin",
+    "firstName" : "Max",
+    "lastName" : "Mustermann",
+    "email" : "admin@mail.com",
+    "emailVerified" : false,
+    "attributes" : {
+      "clear" : [ "20" ],
+      "role" : [ "view_digital_twin, add_digital_twin, update_digital_twin, delete_digital_twin" ]
+    },
+    "createdTimestamp" : 1763553349664,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "d0e2fd16-b38a-42d3-84e5-7dc631bd83ae",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1763553379929,
+      "secretData" : "{\"value\":\"Bz6V9b1teEAVbvhx6kFeR8qJX6TdDGL+yDWpJbOuByA=\",\"salt\":\"4BGpZ3Uxlllp8SCXYXYOjQ==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-basyx" ],
+    "clientRoles" : {
+      "aas-env" : [ "admin" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "78b8ff04-d473-4143-9e5e-42716e41f7cb",
+    "username" : "service-account-aas-env",
+    "firstName" : "Martin",
+    "lastName" : "Stemmer",
+    "email" : "martin-stemmer@t-online.de",
+    "emailVerified" : false,
+    "attributes" : {
+      "clear" : [ "20" ],
+      "role" : [ "admin" ]
+    },
+    "createdTimestamp" : 1764768925034,
+    "enabled" : true,
+    "totp" : false,
+    "serviceAccountClientId" : "aas-env",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-basyx" ],
+    "clientRoles" : {
+      "aas-env" : [ "admin" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "6a2d8f76-af47-40e9-b8b2-1ca14918c448",
+    "username" : "service-account-discovery-service",
+    "emailVerified" : false,
+    "createdTimestamp" : 1761290465613,
+    "enabled" : true,
+    "totp" : false,
+    "serviceAccountClientId" : "discovery-service",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-basyx" ],
+    "clientRoles" : {
+      "discovery-service" : [ "uma_protection" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "c4d04982-cd08-4dc7-ba30-75c49c62dc3a",
+    "username" : "usera",
+    "firstName" : "Max",
+    "lastName" : "Mustermann",
+    "email" : "usera@mail.com",
+    "emailVerified" : false,
+    "attributes" : {
+      "role" : [ "viewer" ]
+    },
+    "createdTimestamp" : 1763553182453,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "733effaa-4527-4582-917e-9d6453a70e91",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1763553389508,
+      "secretData" : "{\"value\":\"/DfHWYWN5tIuRUt7vdh5F6fpt/xcDN4bdWkhY+jCnVs=\",\"salt\":\"1V1zPwre8fO/hEFYf+PEtg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-basyx" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "0983a0fd-5e10-4121-81a1-bbae51750e42",
+    "username" : "userb",
+    "firstName" : "Max",
+    "lastName" : "Mustermann",
+    "email" : "userb@mail.com",
+    "emailVerified" : false,
+    "attributes" : {
+      "clear" : [ "2" ],
+      "role" : [ "martin" ]
+    },
+    "createdTimestamp" : 1763553224432,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "9b71dd25-e29f-441f-95c3-0d2f3a6637e7",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1763553400313,
+      "secretData" : "{\"value\":\"ZuApULLLH22Nc4iB/pfgac/qJZhYUW23qCee0DDnTtI=\",\"salt\":\"yKgnRwIkF9ZubcS033Xxbg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-basyx" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "803f798c-3e11-440e-ad66-26016efca76c",
+    "username" : "userx",
+    "firstName" : "Max",
+    "lastName" : "Mustermann",
+    "email" : "userx@mail.com",
+    "emailVerified" : false,
+    "attributes" : {
+      "role" : [ "editor" ]
+    },
+    "createdTimestamp" : 1763553277239,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "c1bb153c-951e-471e-9ddf-a3dec64f7452",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1763553410862,
+      "secretData" : "{\"value\":\"rILNeJ1Atdyg3V1eF7KDkw3kZgbXSmHP8z4g4MQVidU=\",\"salt\":\"qFkvnew602rmkafCjUueCg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-basyx" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "5d4e91f5-f48d-42e3-8f6f-c2d6e111f9de",
+    "username" : "usery",
+    "firstName" : "Max",
+    "lastName" : "Mustermann",
+    "email" : "usery@mail.com",
+    "emailVerified" : false,
+    "attributes" : {
+      "clear" : [ "2" ],
+      "role" : [ "editor" ]
+    },
+    "createdTimestamp" : 1763553312697,
+    "enabled" : true,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "711a05f1-f9bb-414c-ba74-aee52dddea2d",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1763553423175,
+      "secretData" : "{\"value\":\"xno1fB+MsKoetwJJM9d+monjFXQj1UuVfFLv9pSS42o=\",\"salt\":\"Vw62MhV+JlPIrJdCfdSIug==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-basyx" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "a943241a-12bf-44b4-a0bc-8bed1edf744a",
+    "clientId" : "aas-env",
+    "name" : "aas-env",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "gqj6bXy7uBx0F97mXzy4vOsnD1frqYcB",
+    "redirectUris" : [ "/*" ],
+    "webOrigins" : [ "/*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : true,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : true,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "client.secret.creation.time" : "1764768782",
+      "backchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+",
+      "display.on.consent.screen" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "9df7044a-e35f-4606-84aa-e3dc5ff43060",
+      "name" : "Role Mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "aggregate.attrs" : "false",
+        "introspection.token.claim" : "true",
+        "multivalued" : "false",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "role",
+        "id.token.claim" : "true",
+        "lightweight.claim" : "false",
+        "access.token.claim" : "true",
+        "claim.name" : "role",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "024ae3b1-f483-46d1-b18d-7cfcf54a804d",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e41fd604-43b1-431b-8782-18f3df11e795",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ee66a355-5ea6-4c1c-b075-7a08433fb389",
+      "name" : "aas-env-aud-mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "discovery-service",
+        "id.token.claim" : "false",
+        "lightweight.claim" : "false",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "false"
+      }
+    }, {
+      "id" : "0d366b07-a8e3-40f6-92d8-d8699501876a",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "client_id",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "client_id",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "852d8141-eaa5-4f80-affb-0cf04d93d4ce",
+      "name" : "Clearance Mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "aggregate.attrs" : "false",
+        "introspection.token.claim" : "true",
+        "multivalued" : "false",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "clear",
+        "id.token.claim" : "true",
+        "lightweight.claim" : "false",
+        "access.token.claim" : "true",
+        "claim.name" : "clear",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "role", "profile", "roles", "clear", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "5056cdec-06ed-4c3b-b478-90a524521a69",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/basyx/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/basyx/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "ad273746-da54-45f6-8b9a-759fcca085e9",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/basyx/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/basyx/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "c06bb2ad-8f94-4ac0-86ca-ff03cc3b0896",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "2be1fdd4-9929-4cfd-a761-6bb66726c41c",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "a931544a-636e-4030-a0af-427f00873ff5",
+    "clientId" : "basyx-ui",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "http://localhost:3000/*", "/*" ],
+    "webOrigins" : [ "/*", "http://localhost:3000" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : true,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+##http://localhost:3000/*",
+      "display.on.consent.screen" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "900ab17f-a3f5-49a0-a6cd-91d7be0df0eb",
+      "name" : "Role Mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "aggregate.attrs" : "false",
+        "introspection.token.claim" : "true",
+        "multivalued" : "false",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "role",
+        "id.token.claim" : "true",
+        "lightweight.claim" : "false",
+        "access.token.claim" : "true",
+        "claim.name" : "role",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "87d7e16b-8156-4410-95d0-59dcee3240fc",
+      "name" : "discovery-service-aud-mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "discovery-service",
+        "id.token.claim" : "false",
+        "lightweight.claim" : "false",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "false"
+      }
+    }, {
+      "id" : "a0f45fb3-5d14-4535-8475-12971aefdfc2",
+      "name" : "Clearance Mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "aggregate.attrs" : "false",
+        "introspection.token.claim" : "true",
+        "multivalued" : "false",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "clear",
+        "id.token.claim" : "true",
+        "lightweight.claim" : "false",
+        "access.token.claim" : "true",
+        "claim.name" : "clear",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "20974092-14b8-4258-a260-12cccbb34ce1",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "988bf103-59ae-4ea9-9301-34d973e69c4d",
+    "clientId" : "discovery-service",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "**********",
+    "redirectUris" : [ "http://localhost:5004/auth/callback" ],
+    "webOrigins" : [ "http://localhost:5004" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : true,
+    "authorizationServicesEnabled" : true,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "client.secret.creation.time" : "1761290465",
+      "backchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+",
+      "display.on.consent.screen" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "f96009e8-5aad-4ff6-ae77-1eefdabf02dd",
+      "name" : "discovery-service-aud-mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "discovery-service",
+        "id.token.claim" : "false",
+        "lightweight.claim" : "false",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "false"
+      }
+    }, {
+      "id" : "b0882d11-06e0-4a0f-b0ea-f8dabdb3c448",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "client_id",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "client_id",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e7e7053a-bc36-4284-979e-466817df4514",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b5d5f8f4-2565-4aef-9f28-9097b60333ee",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ],
+    "authorizationSettings" : {
+      "allowRemoteResourceManagement" : true,
+      "policyEnforcementMode" : "ENFORCING",
+      "resources" : [ {
+        "name" : "Default Resource",
+        "type" : "urn:discovery-service:resources:default",
+        "ownerManagedAccess" : false,
+        "attributes" : { },
+        "uris" : [ "/*" ]
+      } ],
+      "policies" : [ ],
+      "scopes" : [ ],
+      "decisionStrategy" : "UNANIMOUS"
+    }
+  }, {
+    "id" : "d66f233e-c934-40d3-912e-cccb235a254e",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  }, {
+    "id" : "a5e5ed2c-da66-4140-a531-93cd3c8a72e8",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/basyx/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/basyx/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "15c7c7b6-e884-4187-97c4-77340ba73cd2",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "basic", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "organization", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "b8b3b5b9-3459-454b-b82d-a6bac51af5b3",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "4bcecc4f-5950-41e3-8717-160268400a55",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "d8e45bd1-c127-44a8-b7b4-cbfe16bff068",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0492aae7-91d2-431d-83f0-599d28803fdd",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "f186e47a-9cc2-4445-a74d-7b595e941863",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "d1b9d43c-6dff-493d-8fa7-8201bfea77ff",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "bd23bff3-039b-4175-86fd-d283527fdd97",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "c4a31b61-afc9-40cc-9471-ad6d809b86f0",
+    "name" : "role",
+    "description" : "",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "gui.order" : "",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "20e9e916-6202-471a-bdf2-5235c9fb7b96",
+      "name" : "Role Mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "role",
+        "id.token.claim" : "true",
+        "lightweight.claim" : "false",
+        "access.token.claim" : "true",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "46e2fd9d-c240-424d-9b43-bd5ddae9f35c",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "${rolesScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "634a4e5d-29a7-42a0-b3b1-26b092b4943c",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "93ee8212-db42-46da-8726-3b9613d7521f",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "59fbac50-9683-4475-9f22-cdc5169be292",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "0a0d5f60-0400-4c77-be35-70ae05f4a28e",
+    "name" : "basic",
+    "description" : "OpenID Connect scope for add all basic claims to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "40f7f9b9-106e-4366-aabd-a8e5460edfb1",
+      "name" : "sub",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-sub-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "0d61dc04-8d7c-432e-98cc-1365e47d2a3b",
+      "name" : "auth_time",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "AUTH_TIME",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "auth_time",
+        "jsonType.label" : "long"
+      }
+    } ]
+  }, {
+    "id" : "58a65e6c-3220-4afa-9a6a-9061169ce4ba",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "a58baf7d-880b-4f6d-950a-1e90ede92147",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "6ecb691c-3ae6-4f38-9e8a-0085e0a34e52",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "f2089154-114e-4aec-88d3-338d8aa1b928",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "7933c532-b209-4380-8fed-1f41ac1c6033",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "ed51bc06-4f76-4c9a-b85c-144c25cab0bc",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "d783a21c-02b5-477f-9171-bc9d4f72d4ad",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6b40a39c-8f05-4fa6-afe3-c8b417068bb3",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "65dd6f99-b8f3-4bd2-ad8b-9e812121a3aa",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "facd5278-166b-407d-aa0c-3956b9579d95",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "36a6da28-e6c5-403b-8d82-a526c1028359",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ef96dc72-0487-4784-943a-bfa5d0b24a00",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "3974137e-614e-4b09-bf9d-98cee313470f",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ce63a167-6f55-4f33-98f7-a1185414464f",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "225b832f-d568-4168-8880-f7bae2a95b8f",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "13c8306b-84e2-4aee-9e89-d7d0d8ec8ed9",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0dd8bc3e-28da-4be5-9604-dd80cfbcdfac",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cc414e8f-71af-43e1-9108-547da19dc44e",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e6d5473d-baf5-401a-9c1f-ce000173f264",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "58952da3-e089-4f2d-b22a-400fe51369b1",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "0fc957e8-55a0-444d-91fb-0b66b73b6c31",
+    "name" : "saml_organization",
+    "description" : "Organization Membership",
+    "protocol" : "saml",
+    "attributes" : {
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "4acafcd1-ef09-4539-9121-45dc4f0ab452",
+      "name" : "organization",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "3da35a14-4743-464b-9a80-4d669245ce39",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "8a266f60-51d7-4743-89b8-6c11eed62814",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "introspection.token.claim" : "true",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "a59b7b48-d77a-4dac-9e78-e85e2fac6753",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "consent.screen.text" : "",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "51196a78-0f5a-47bc-a315-dc6424452962",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "access.token.claim" : "true",
+        "introspection.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "f5b839fa-3262-4592-aadf-c929b7d67551",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "fda282ce-db26-4f08-808a-0055581450ed",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "d8db6f87-6b98-4729-971d-a25737b3f1c4",
+    "name" : "organization",
+    "description" : "Additional claims about the organization a subject belongs to",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "${organizationScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "7500d7d2-2a78-4521-9c85-2fde78a896e1",
+      "name" : "organization",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-organization-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "organization",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "80d225df-e562-4a72-92f8-3ba5a7007ca5",
+    "name" : "clear",
+    "description" : "",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "gui.order" : "",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "4c1bfa53-934e-4e5f-b45a-86b9f1420abc",
+      "name" : "Clearance Mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "clear",
+        "id.token.claim" : "true",
+        "lightweight.claim" : "false",
+        "access.token.claim" : "true",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "saml_organization", "profile", "email", "roles", "web-origins", "acr", "basic" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt", "organization" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "3d66e2fb-c54c-4ec7-ab75-440d89325eae",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "741033cb-8d97-4407-b21b-1e1df2aa177a",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "9ec57834-3be7-46d2-96d5-b91a0c928cef",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper" ]
+      }
+    }, {
+      "id" : "7e49e253-e765-426d-83f1-9d71cc880e90",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "oidc-address-mapper" ]
+      }
+    }, {
+      "id" : "1d763900-c324-45c7-a08d-ec64849605dd",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "b0a4c28b-1e91-405c-9e04-d340ef422c1f",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "d0c193a1-3739-4057-9d7f-bacb6c6f1fd8",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "678c9871-17be-4f3d-a5be-51914a665105",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    } ],
+    "org.keycloak.userprofile.UserProfileProvider" : [ {
+      "id" : "a986d230-d3cc-4ec0-9b61-61340207a68d",
+      "providerId" : "declarative-user-profile",
+      "subComponents" : { },
+      "config" : {
+        "kc.user.profile.config" : [ "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"role\",\"displayName\":\"Role\",\"validations\":{},\"annotations\":{},\"permissions\":{\"view\":[],\"edit\":[\"admin\"]},\"multivalued\":false},{\"name\":\"clear\",\"displayName\":\"Clearance\",\"validations\":{},\"annotations\":{},\"permissions\":{\"view\":[],\"edit\":[\"admin\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}]}" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "f39d4e1f-20e2-4cca-a010-9cdd316fc7c8",
+      "name" : "hmac-generated-hs512",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "6dcdd780-a14e-4d5a-9a1a-e1ef894e3a3a" ],
+        "secret" : [ "6o21jWCZ38XFgKrXRQ8u0IprO1k8QaYQiQ6H0_Jl8nlbUdaKQ4dN3UfW3UeTMPiNjMzkdZDq_bb1NULm_yWl8E42NW-EHOwKnlwzuNkjDv5ABRoqLJwxu0ZxfJUmKiohIwPb1NSZVxz6IrT-IohVv7c3iBIM-tVm4sfcP6V6ebA" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS512" ]
+      }
+    }, {
+      "id" : "38766ab2-ebbe-40d3-af33-76dcd3f55a0d",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAqL9dPI1YX4A/RzmFv83ygWUZmnl1wia37GhO++QIFTuTLWmvIZhZtNGcEMg1L4kif6R/1PBYjobNBvMNGccuroSh/kcoCYeO5waC9K08lRnBUQ40G+hLI3B/bwuddScq5sYTsdzLM+sWnDo8YndtYLaLDpjtjv0Vo3GJkMbKRqIxVdq5pdGIEDLouE3KjESjFTKbS12b8DAUetx8vWUxHchfkixYzsr54io/b7dzkWSxvJfpWMk5iCc4Nl71MgkpmcJ46//dj3qq7G3nTysEYzhr5g2vl2xW3dFqufOUgOQX/IidSncoSoN1Tkep5o1gUb3PB87Oh9BxtMMDUDKCcQIDAQABAoIBAAuZBWczPrrnlVHHnA/r72ohwPH7PZLvts3eeGk7Cawt6UZigFkif63cByonHHKtLewQagHAWBHJpX9ABqs6I5T2hCy2BsQq5zEtIyR+YI7N05nGzGGLpFhl87g11+dUnw/31qQvjN6/XlEz9nD9DM0sFqAU9iTQ86MFW2NSKlZS1CK7p/rnGnlwaKxpeQzPOhL+KxKZVCM4izib4DqKmdy2HDLM0eUtdvfw0VCgpgOmm2l2inVx0NHGX2sywy07W4aIYPSoFWnWSaweaycLRJCUGFSu6UAl/EZiYw5T3i5i/2K2PnLfOvTfVWCa6BXa4MjwXJTGaE525JNyYqagJ50CgYEA6m3oW9YB9p+W6FBeMeDXox86e0SMoO7vIlU2vSIQ4+rJ6i/vBf8kZJ8c6yeisnz7KDSYAxbTTQrVgdbDFq/K0VveaHpwtIpZW50WhWPJa/QZaMZUbq8HGieYVTju6VYnIxHgZFUQzBSjmcYWvkXH3JdOozC+M5WjYDlRPjLrIVUCgYEAuEZKcuw1n2s+vikYpdM8wNx6pLi+m/k+a4Yw1V15TogBvvKkfygt9MsHO7tb8kvVelotzF67aUB6+lvKZVnCve0a5YuSw+oqIggix8GOF1sXg95HQpS/wGgJdaDoONtbijX4epi/jwBGzOLep6NjVoa4WG8K+VQBrByLx97JDK0CgYEAlNzV//sVpBYTLdJa/jFYvSzHZh9RbaBMGfEioVdQgmpFbYCit5wc8AhZxLmWhuD2W8GKBewooXOPwLMvjuhyUh+US6P0jbCMrbBC7NFAxlxrBi1q0B401FbwVK2iiGk80Pg5FX0u/WjdungfWRPWpi0uslHxdbA/3oqHHIgY50ECgYAu3dG5gNHyhbgjbRhTtHHTK0AV/NadnLp/ZlWtLmTX0EeBZPzpSjLF+40PaAtuiFL3F1BmlgFcN4YPfqDvPfEFlPQuRV1Cbp/gn+kYnOWikwxcAYBmMqbCLLObMx1cuI2DjU5w/8BYgl1/ZoPyZt+w9fqUo0lLOE5kk64JW2QO0QKBgCHAJ5CECWjRi5JV6Y4tjcv1gvncGwWp2echFfXMHv65VycUs4tZQxkYDmzOpnUYJvB81aJL6jXEcc7lrFqV0KJZe2T/ZDtHGDi0JaE0tvDpTFEeMdnT3c3zzL1MvtvRt470fbtj7dcCPyyVor89lxaI3faRpKNprOCOlazAIVnZ" ],
+        "certificate" : [ "MIICmTCCAYECBgGaFVZtlDANBgkqhkiG9w0BAQsFADAQMQ4wDAYDVQQDDAViYXN5eDAeFw0yNTEwMjQwODI3NTdaFw0zNTEwMjQwODI5MzdaMBAxDjAMBgNVBAMMBWJhc3l4MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqL9dPI1YX4A/RzmFv83ygWUZmnl1wia37GhO++QIFTuTLWmvIZhZtNGcEMg1L4kif6R/1PBYjobNBvMNGccuroSh/kcoCYeO5waC9K08lRnBUQ40G+hLI3B/bwuddScq5sYTsdzLM+sWnDo8YndtYLaLDpjtjv0Vo3GJkMbKRqIxVdq5pdGIEDLouE3KjESjFTKbS12b8DAUetx8vWUxHchfkixYzsr54io/b7dzkWSxvJfpWMk5iCc4Nl71MgkpmcJ46//dj3qq7G3nTysEYzhr5g2vl2xW3dFqufOUgOQX/IidSncoSoN1Tkep5o1gUb3PB87Oh9BxtMMDUDKCcQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAIYip9w0sGe1QIDOEsWCvAKBR5ssgaQxdL3GjRDql84bW7eODUD4+zj032k30MlTYMh6Cm9h1P9p+PiQP8FyZWSf1kAqXwmXs5qsA8UwbALpA2pa9xE13y9qJ90V9Ts/Ya429hjJM//HXfa54tA0Bxm+DZqOgIm72bB406iky3NlxnsB+Azuy2RX0RW1RaBBVJESA2cba/KUyGhoWNo7oIQio+M79pf/K3qh4d9dBQirwHmztUW728l5FIOliwBeNKUZNNS34Edva4InSwduept2WGy0AiftB+avgpOb15jMcjBvXrWfstUjktjvOdOBdDr0RsNS4RHWP2Cwd42Yg9" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "79669e2a-829d-4b52-ae56-ba97f595db3e",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "549385c7-3644-4378-8db3-62d01eb8e6e7" ],
+        "secret" : [ "goX6rQlS1kWubykYKn857w" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "84db8e8f-afe5-4768-a5fa-8638d3716c6a",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAqQmpZE4rdSvoxRSnkHXcaAcpMXb8WhIycO9F/AXl7sjQrg/PGz1PJzcdhYSK/jpDoNEP7NaqSrEmzgR6akedPi64ZBuozv9sZ4HOI7bFnlOlfGOKycHqjoHO6VUQlfAOdGyq2DL+8qD5kxLJhB2j2J2h9i6XGWaVOp4w/lE/hbqOONEuH9RVdXsgSExh+cfzl5zxy3/ccFVHE8/e0MVjpKM5CzyDYvFpjdxy/h+T3xmIGNUZEun7mu8FNdEIsphNgBm0G8AWzATkuQCsdFuL6HQGRDltDUxeQCRv1aYFfHHaUlCP/V8wZLbleXRTVJpP0WIreU6ESv2kYKsxjguQxQIDAQABAoIBAACZfDksgTR0iaorSTxDfFrlGmhAKD1HvvFa5xtkyCly5/4tQa2MNKvqfHqrZ+4zaQDlkbu9qvoO8bJXRNNI+j3AEiwOug6z5ex73IfDzFfw3k+LSQp8QaRfdJgSX54i7Ull7XkAI03bTgKCyLKxttG1np9K9oLvs9wZNz2SFOc/RIVV41FrJUjKuldUFA+J39hTqfZMR89d71+2NnfaEZBJILHJlkcd+xMbIfHLAagKcAo+rCjA9PoaiaE3LgwdScZ/t/vvDZXmEVdGTHfOerKeA1O1iV6r4TNdXdeUVSrRjgKweX6+6mulcGHcyOXsycYtY2iBmaz+UxirFiE1DJkCgYEA09PxF7d5ll4TAC6o52fQqS99gyLktBhzhi4hZ5/9xNMrLLEa6doBslr3bM3MbpYqE1C9LddqmvBfZlwHM1AP16iy3rsLV60T4qGxmMQXlVqDXAIy1fHenUkUkRGKT3an0cLBCpvFgTBAIu7ff8MEygsXy4rXGDBLnNFyCn5PK10CgYEAzElxZtnwk6iL05toIUpJd3L1+uXKx9Dr5UyPC5OG5rqua30eR21zAEkT/p3ZZXB6oMxf8LXHz2Q55tFoaIbIPM7DTq8+Y6eqbO1ADVmmeINbDuS6ycI5FjZ6hlXI10fmFbpc7s85W1Os99ff7JzjOJxRG9JDdc1+OVi6LGjpDIkCgYEAnHoHstlZ+/XqW0wcgTRzM0ddlC2GfHNDg284RfAt6eOEFTOPCgh9EF+aPsmXpmlPE42k8eQbX/EIx/hbaVBPI6P+3gGV02KLOfLv2kWgljeSqbkGDHzrUYzWoIMwhJrGRXF0YH3JXDFkb2m9uAc71nRzU2xwj/G9KU6ey5maqhECgYAjNGzkip5Y8+zU1K1HP2QVv6wARuWBNdHRPDZSimPvEzDHuVIkgQoWfIGDmXRDdPTNDStjchAy/1SzIFdb3A5Z3E/wGWcpCVXnW6N0KYT0s75XfLdr2Zq45z6KM/JelzdhezJUvUVnJa5jL8KZJhhKQzX/E2cov/cGrvG2gYXX8QKBgD7G1B44vf062QgXgLezGYmnQ8zED/dSXvpFJW8DtawsAPjIHp5N1cw2NvCT7XTiIlP6KbJT3DJLjLxxy2Sqn7/SbYsV1rXkQxenwrclFshKdY6uXadCN1a37yEHyONnUZuYakpIJa8jHpQI9gOnMIsCe0bIUxm+Bm6e7AmPeYLG" ],
+        "certificate" : [ "MIICmTCCAYECBgGaFVZt9DANBgkqhkiG9w0BAQsFADAQMQ4wDAYDVQQDDAViYXN5eDAeFw0yNTEwMjQwODI3NTdaFw0zNTEwMjQwODI5MzdaMBAxDjAMBgNVBAMMBWJhc3l4MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqQmpZE4rdSvoxRSnkHXcaAcpMXb8WhIycO9F/AXl7sjQrg/PGz1PJzcdhYSK/jpDoNEP7NaqSrEmzgR6akedPi64ZBuozv9sZ4HOI7bFnlOlfGOKycHqjoHO6VUQlfAOdGyq2DL+8qD5kxLJhB2j2J2h9i6XGWaVOp4w/lE/hbqOONEuH9RVdXsgSExh+cfzl5zxy3/ccFVHE8/e0MVjpKM5CzyDYvFpjdxy/h+T3xmIGNUZEun7mu8FNdEIsphNgBm0G8AWzATkuQCsdFuL6HQGRDltDUxeQCRv1aYFfHHaUlCP/V8wZLbleXRTVJpP0WIreU6ESv2kYKsxjguQxQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBOqFKRkJeWGJnnqrlr3XFilMYI5ko1GASnSGvfVrWg7Pk6yDGwBe2v+nd7OG/yNJtbS97xPePeoVIXCEwzA8rhZDzfsYlrDvakn/5p8GpwJKAUtk1yRcI26hzANXAqKMWqAEtxtfEWtIn3j/asAe17Ara47MZMonsm5VxeqyFB1oDu94ht+Cq4vomjnucmC1DRUnliXTnKSBmLdWK/LrqR0Pgq7KrplKyiHlWBZEYFCKXmiRmtDJqF3QYFtHqxr/HjiPdlrJhUEhxyeKoi0q+dTYRhrpRa7MWwFlX/HTAWGWmW5VtaxlqqGctz9AWTNUzB86NdCguNYQq4uFllJal7" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "af0ffca2-f529-4e0c-8eb4-01c038b8836e",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a747c2ad-0d8a-44c1-a75c-a176f8035bf4",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "922860b5-49e7-4b5a-b5a8-4efcef3008b5",
+    "alias" : "Browser - Conditional Organization",
+    "description" : "Flow to determine if the organization identity-first login is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "organization",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3c27bad3-36ed-47f0-a03f-58a919ddcc5d",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "52fe5237-4826-45e4-998b-f76d182b3a46",
+    "alias" : "First Broker Login - Conditional Organization",
+    "description" : "Flow to determine if the authenticator that adds organization members is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "idp-add-organization-member",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "86aab927-3928-42f0-ab71-2823232f740b",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0ba72201-1926-4f68-8ef9-04a0b8fedbda",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "56cb4036-7ebc-4cca-ae8d-ebc3bf61eeae",
+    "alias" : "Organization",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ba9fadf4-e884-4ab9-bf10-513970afc696",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "4da5a8e6-b854-407d-80fd-ec018cdfe4aa",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b56dbe8a-b7e5-424d-bb12-062eef357d98",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "8ab99073-7164-4de3-ae15-031f7ead63dc",
+    "alias" : "browser",
+    "description" : "Browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 26,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Organization",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "d98a4fe6-7392-4e6b-a779-e9d567f36a92",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "13744817-8b7d-42cc-b370-d94057f0c57a",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0598b349-373f-452e-864e-7c9b0d5be266",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "580c4af6-6480-41ad-9123-f672c253eb42",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 50,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First Broker Login - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "05ecbd6b-1170-4460-a6e2-420e8d32ab07",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "5f743ce3-87da-441f-8d99-46b1a1535740",
+    "alias" : "registration",
+    "description" : "Registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "9815c239-18a5-4d42-bce5-649516ee6194",
+    "alias" : "registration form",
+    "description" : "Registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-terms-and-conditions",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 70,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "2323a309-e3f9-4fa5-98c7-fbac4a3370ca",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "eb2d3a0a-5e7f-4216-b2a9-f9e764879c78",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "83f1e02a-3909-4009-a586-6e79515dfd4a",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "3a97fec7-4b67-45ff-9e8b-50dd7ad8c010",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_PROFILE",
+    "name" : "Verify Profile",
+    "providerId" : "VERIFY_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 90,
+    "config" : { }
+  }, {
+    "alias" : "delete_credential",
+    "name" : "Delete Credential",
+    "providerId" : "delete_credential",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 100,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "firstBrokerLoginFlow" : "first broker login",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "clientOfflineSessionMaxLifespan" : "0",
+    "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false",
+    "cibaExpiresIn" : "120",
+    "oauth2DeviceCodeLifespan" : "600",
+    "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "frontendUrl" : "",
+    "organizationsEnabled" : "false",
+    "acr.loa.map" : "{}"
+  },
+  "keycloakVersion" : "26.0.6",
+  "userManagedAccessAllowed" : false,
+  "organizationsEnabled" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/examples/BaSyxMarkerAccessExample/post_marker_variants.py
+++ b/examples/BaSyxMarkerAccessExample/post_marker_variants.py
@@ -20,7 +20,7 @@ def parse_args():
     parser.add_argument("--start-index", type=int, default=1)
     parser.add_argument("--dtr-base-url", default="http://localhost:5004/api/v3")
     parser.add_argument("--smrepo-base-url", default="http://localhost:5005")
-    parser.add_argument("--token-url", default="http://localhost:8080/realms/basyx/protocol/openid-connect/token")
+    parser.add_argument("--token-url", default="http://keycloak.localhost:8080/realms/basyx/protocol/openid-connect/token")
     parser.add_argument("--client-id", default="basyx-ui")
     parser.add_argument("--username", default="admin")
     parser.add_argument("--password", default="pwd")

--- a/examples/BaSyxMarkerAccessExample/security/dtr/access-rules.json
+++ b/examples/BaSyxMarkerAccessExample/security/dtr/access-rules.json
@@ -20,6 +20,14 @@
         ]
       },
       {
+        "name": "description",
+        "objects": [
+          {
+            "ROUTE": "/description"
+          }
+        ]
+      },
+      {
         "name": "all_shell_descriptors",
         "objects": [
           {
@@ -64,6 +72,12 @@
       }
     ],
     "DEFFORMULAS": [
+      {
+        "name": "always_true",
+        "formula": {
+          "$boolean": true
+        }
+      },
       {
         "name": "data_provider_read",
         "formula": {
@@ -287,6 +301,13 @@
       }
     ],
     "rules": [
+      {
+        "USEACL": "read",
+        "USEOBJECTS": [
+          "description"
+        ],
+        "USEFORMULA": "always_true"
+      },
       {
         "USEACL": "read",
         "USEOBJECTS": [

--- a/examples/BaSyxMarkerAccessExample/security/dtr/trustlist.json
+++ b/examples/BaSyxMarkerAccessExample/security/dtr/trustlist.json
@@ -1,6 +1,6 @@
 [
   {
-    "issuer": "http://localhost:8080/realms/basyx",
+    "issuer": "http://keycloak.localhost:8080/realms/basyx",
     "audience": "discovery-service",
     "scopes": ["email", "profile"]
   }

--- a/examples/BaSyxMarkerAccessExample/security/smrepo/access-rules.json
+++ b/examples/BaSyxMarkerAccessExample/security/smrepo/access-rules.json
@@ -20,6 +20,14 @@
         ]
       },
       {
+        "name": "description",
+        "objects": [
+          {
+            "ROUTE": "/description"
+          }
+        ]
+      },
+      {
         "name": "submodel_routes",
         "objects": [
           {
@@ -65,6 +73,12 @@
       }
     ],
     "DEFFORMULAS": [
+      {
+        "name": "always_true",
+        "formula": {
+          "$boolean": true
+        }
+      },
       {
         "name": "data_provider_read",
         "formula": {
@@ -199,6 +213,13 @@
       }
     ],
     "rules": [
+      {
+        "USEACL": "read",
+        "USEOBJECTS": [
+          "description"
+        ],
+        "USEFORMULA": "always_true"
+      },
       {
         "USEACL": "read",
         "USEOBJECTS": [

--- a/examples/BaSyxMarkerAccessExample/security/smrepo/trustlist.json
+++ b/examples/BaSyxMarkerAccessExample/security/smrepo/trustlist.json
@@ -1,6 +1,6 @@
 [
   {
-    "issuer": "http://localhost:8080/realms/basyx",
+    "issuer": "http://keycloak.localhost:8080/realms/basyx",
     "audience": "discovery-service",
     "scopes": ["email", "profile"]
   }


### PR DESCRIPTION
This pull request updates the BaSyx Marker Access Example to introduce the BaSyx UI, improve OAuth2/Keycloak configuration, and enhance CORS and access control settings. It also standardizes the use of `keycloak.localhost` for Keycloak-related URLs and updates security rules to allow universal read access to the `/description` route. Below are the most significant changes:

**UI Integration and Configuration:**
- Added the BaSyx UI (`aas-ui` service) to the `docker-compose.yml`, exposing it on port 3000 and configuring it via the new `basyx-infra.yml` file, which specifies OAuth2 settings and service endpoints. (`[[1]](diffhunk://#diff-bc44a5fafcbdf951be61e8831d796a77bebbef522bdab531a5e826aa805a5e32R134-R175)`, `[[2]](diffhunk://#diff-ca8a9b6da00b28093ccd595e486ec0d8fd9ca495faf6f991d9974878ae09dd47R1-R18)`, `[[3]](diffhunk://#diff-203cc66a9b12cc3a3149b5f79c489ef9e503ae2ba614710d48091b547aedd16dL7-R8)`, `[[4]](diffhunk://#diff-203cc66a9b12cc3a3149b5f79c489ef9e503ae2ba614710d48091b547aedd16dR34-R36)`)

**Keycloak and OAuth2 Standardization:**
- Changed all Keycloak URLs from `localhost` to `keycloak.localhost` across environment variables, config files, and documentation to ensure consistent service discovery and networking. (`[[1]](diffhunk://#diff-e0d9d5e01d3c47cbebddfd4efa7520639b85275f1eccf5567b2b511f54e5ba80L875-R875)`, `[[2]](diffhunk://#diff-0818a5f1ae372a3e6c2f5ce4ab995bb34cfa996f75d7f09e1a183ddf9c0c0b55L23-R23)`, `[[3]](diffhunk://#diff-cf0790aae70d4bf78a2dd64e1cf7646977b11ea1504807f0b03d8009edad922fL3-R3)`, `[[4]](diffhunk://#diff-bc44a5fafcbdf951be61e8831d796a77bebbef522bdab531a5e826aa805a5e32R134-R175)`)
- Updated Keycloak container configuration in `docker-compose.yml` to use the new hostname and improved its environment variables for development and compatibility. (`[examples/BaSyxMarkerAccessExample/docker-compose.ymlR134-R175](diffhunk://#diff-bc44a5fafcbdf951be61e8831d796a77bebbef522bdab531a5e826aa805a5e32R134-R175)`)

**CORS and Service Configuration:**
- Enabled permissive CORS settings (`*` origins/headers, credentials, common HTTP methods) for both the Digital Twin Registry and Submodel Repository services in `docker-compose.yml` to facilitate cross-origin requests from the UI. (`[[1]](diffhunk://#diff-bc44a5fafcbdf951be61e8831d796a77bebbef522bdab531a5e826aa805a5e32R74-R92)`, `[[2]](diffhunk://#diff-bc44a5fafcbdf951be61e8831d796a77bebbef522bdab531a5e826aa805a5e32R108-R125)`)

**Access Control Enhancements:**
- Modified `access-rules.json` for both DTR and Submodel Repository to add a `description` object and a universal `always_true` formula, then granted all users read access to the `/description` route. (`[[1]](diffhunk://#diff-c5cd44573c24f6ef1a827c4218f42bd843b7d71faf33dbf998bf2cf1fc163645R22-R29)`, `[[2]](diffhunk://#diff-c5cd44573c24f6ef1a827c4218f42bd843b7d71faf33dbf998bf2cf1fc163645R75-R80)`, `[[3]](diffhunk://#diff-c5cd44573c24f6ef1a827c4218f42bd843b7d71faf33dbf998bf2cf1fc163645R304-R310)`, `[[4]](diffhunk://#diff-70fff623299294a556287d987240af52d0a1f577ea0180bf2efb16989639b52eR22-R29)`, `[[5]](diffhunk://#diff-70fff623299294a556287d987240af52d0a1f577ea0180bf2efb16989639b52eR76-R81)`, `[[6]](diffhunk://#diff-70fff623299294a556287d987240af52d0a1f577ea0180bf2efb16989639b52eR216-R222)`)

**Documentation Updates:**
- Updated the `README.md` to reflect the addition of the BaSyx UI, new service URLs, and configuration details for the UI and Keycloak. (`[[1]](diffhunk://#diff-203cc66a9b12cc3a3149b5f79c489ef9e503ae2ba614710d48091b547aedd16dL7-R8)`, `[[2]](diffhunk://#diff-203cc66a9b12cc3a3149b5f79c489ef9e503ae2ba614710d48091b547aedd16dR34-R36)`)

These changes collectively improve the developer experience, security, and usability of the example setup.