### PR TITLE
Fix panic in TokenizeField on malformed array segments

### DIFF
--- a/internal/common/builder/field_tokenizer.go
+++ b/internal/common/builder/field_tokenizer.go
@@ -39,14 +39,18 @@ import (
 // TokenizeField performs the following steps:
 //  1. Removes everything up to and including the first '#'.
 //  2. Splits the remaining expression on '.'.
-//  3. Converts each segment into either a SimpleToken (no brackets)
-//     or an ArrayToken (contains "[index]").
+//  3. Converts each segment into either a SimpleToken (no well-formed
+//     array selector) or an ArrayToken (contains "[index]").
 //     An empty index ("[]") is interpreted as a wildcard and stored as -1.
+//
+// Segments without a well-formed array selector (for example a ']'
+// appearing before the first '[') are kept as SimpleTokens instead of
+// causing a panic.
 //
 // Example:
 //
 //	input:  "$aasdesc#submodels[2].id"
-//	output: [ SimpleToken{"submodels"}, ArrayToken{"submodels", 2}, SimpleToken{"id"} ]
+//	output: [ ArrayToken{"submodels", 2}, SimpleToken{"id"} ]
 func TokenizeField(field string) []Token {
 	str := field
 
@@ -58,21 +62,15 @@ func TokenizeField(field string) []Token {
 
 	var tokens []Token
 	for _, t := range rawToken {
-		if strings.Contains(t, "[") && strings.Contains(t, "]") {
-			// nolint:gocritic // safe: guarded by Contains() above
-			name := t[:strings.Index(t, "[")]
-			indexStr := t[strings.Index(t, "[")+1 : strings.Index(t, "]")]
+		openIndex := strings.Index(t, "[")
+		closeIndex := strings.Index(t, "]")
+		if openIndex >= 0 && closeIndex > openIndex {
+			name := t[:openIndex]
+			indexStr := t[openIndex+1 : closeIndex]
 
-			var index int
-			if indexStr == "" {
-				index = -1 // wildcard index
-			} else {
-				i, err := strconv.Atoi(indexStr)
-				if err != nil {
-					index = -1 // malformed index → treat as wildcard
-				} else {
-					index = i
-				}
+			index := -1 // wildcard ("[]") or malformed index
+			if parsedIndex, err := strconv.Atoi(indexStr); err == nil {
+				index = parsedIndex
 			}
 
 			tokens = append(tokens, ArrayToken{Name: name, Index: index})

--- a/internal/common/builder/field_tokenizer_test.go
+++ b/internal/common/builder/field_tokenizer_test.go
@@ -113,6 +113,28 @@ var tokenizeCases = []struct {
 			{Name: "href", IsArray: false},
 		},
 	},
+	{
+		name:  "$aasdesc#specificAssetIds]0[.value",
+		field: "$aasdesc#specificAssetIds]0[.value",
+		tokens: []expectedToken{
+			{Name: "specificAssetIds]0[", IsArray: false},
+			{Name: "value", IsArray: false},
+		},
+	},
+	{
+		name:  "$aasdesc#]keys[2]",
+		field: "$aasdesc#]keys[2]",
+		tokens: []expectedToken{
+			{Name: "]keys[2]", IsArray: false},
+		},
+	},
+	{
+		name:  "$aasdesc#keys[2",
+		field: "$aasdesc#keys[2",
+		tokens: []expectedToken{
+			{Name: "keys[2", IsArray: false},
+		},
+	},
 }
 
 func TestTokenizeFieldPaths(t *testing.T) {


### PR DESCRIPTION
Sketch 

`TokenizeField` in `internal/common/builder/field_tokenizer.go` slices `t[open+1 : close]` whenever a segment contains both `[` and `]`. When `]` appears before `[` in a segment (e.g. `a]b[1`), the slice bounds are inverted and the function panics with `slice bounds out of range`.

This PR guards the array-selector parse on `closeIndex > openIndex` and keeps segments without a well-formed selector as `SimpleToken`s. Behavior for all well-formed inputs is unchanged (all existing `TestTokenizeFieldPaths` cases still pass unchanged). The GoDoc example output was also corrected: `submodels[2]` produces a single `ArrayToken`, not a `SimpleToken` plus an `ArrayToken`.

`$field`/fragment strings from the public query API are regex-validated during unmarshaling, so this is primarily defense-in-depth for the other callers of this exported function (e.g. programmatically constructed field paths in the ABAC engine helpers) and for future call sites.
