### PR TITLE
Speed up Docker multi-platform builds

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -161,13 +161,12 @@ jobs:
           pull: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
           cache-from: |
-            type=gha,scope=${{ github.workflow }}-${{ matrix.service.name }}
+            type=gha,scope=basyx-docker-snapshot-${{ matrix.service.name }}
+            type=gha,scope=basyx-docker-release-${{ matrix.service.name }}
             type=registry,ref=${{ matrix.service.image }}:buildcache
           cache-to: |
-            type=gha,scope=${{ github.workflow }}-${{ matrix.service.name }},mode=max
+            type=gha,scope=basyx-docker-release-${{ matrix.service.name }},mode=max
             type=registry,ref=${{ matrix.service.image }}:buildcache,mode=max
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           provenance: mode=max

--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -162,13 +162,12 @@ jobs:
             ${{ matrix.service.image }}:SNAPSHOT
             ${{ matrix.service.image }}:${{ steps.meta.outputs.version }}
             ${{ matrix.service.image }}:${{ steps.meta.outputs.short_sha }}
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
           cache-from: |
-            type=gha,scope=${{ github.workflow }}-${{ matrix.service.name }}
+            type=gha,scope=basyx-docker-snapshot-${{ matrix.service.name }}
+            type=gha,scope=basyx-docker-release-${{ matrix.service.name }}
             type=registry,ref=${{ matrix.service.image }}:buildcache
           cache-to: |
-            type=gha,scope=${{ github.workflow }}-${{ matrix.service.name }},mode=max
+            type=gha,scope=basyx-docker-snapshot-${{ matrix.service.name }},mode=max
             type=registry,ref=${{ matrix.service.image }}:buildcache,mode=max
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           provenance: mode=max

--- a/cmd/aasenvironmentservice/Dockerfile
+++ b/cmd/aasenvironmentservice/Dockerfile
@@ -1,21 +1,31 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-COPY . .
+COPY cmd/aasenvironmentservice ./cmd/aasenvironmentservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o aasenvironmentservice ./cmd/aasenvironmentservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 FROM gcr.io/distroless/static:nonroot

--- a/cmd/aasregistryservice/Dockerfile
+++ b/cmd/aasregistryservice/Dockerfile
@@ -1,8 +1,11 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Install git and SSL certificates for package downloads
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
@@ -14,17 +17,22 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the entire project
-COPY . .
+COPY cmd/aasregistryservice ./cmd/aasregistryservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-# Build the application with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build the application
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o aasregistryservice ./cmd/aasregistryservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/aasrepositoryservice/Dockerfile
+++ b/cmd/aasrepositoryservice/Dockerfile
@@ -1,8 +1,11 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Install git and SSL certificates for package downloads
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
@@ -14,17 +17,22 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the entire project
-COPY . .
+COPY cmd/aasrepositoryservice ./cmd/aasrepositoryservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-# Build the application with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build the application
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o aasrepositoryservice ./cmd/aasrepositoryservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/aasxfileserverservice/Dockerfile
+++ b/cmd/aasxfileserverservice/Dockerfile
@@ -1,8 +1,11 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Install git and SSL certificates for package downloads
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
@@ -14,17 +17,22 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the entire project
-COPY . .
+COPY cmd/aasxfileserverservice ./cmd/aasxfileserverservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-# Build the application with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build the application
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o aasxfileserver ./cmd/aasxfileserverservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/basyxconfigurationservice/Dockerfile
+++ b/cmd/basyxconfigurationservice/Dockerfile
@@ -1,8 +1,11 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Install git and SSL certificates for package downloads
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
@@ -14,17 +17,23 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the entire project
-COPY . .
+COPY cmd/basyxconfigurationservice ./cmd/basyxconfigurationservice
+COPY internal ./internal
+COPY pkg ./pkg
+COPY database ./database
 
-# Build the application with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build the application
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o basyxconfigurationservice ./cmd/basyxconfigurationservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/companylookupservice/Dockerfile
+++ b/cmd/companylookupservice/Dockerfile
@@ -1,8 +1,11 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Install git and SSL certificates for package downloads
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
@@ -14,17 +17,22 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the entire project
-COPY . .
+COPY cmd/companylookupservice ./cmd/companylookupservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-# Build the application with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build the application
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o companylookupservice ./cmd/companylookupservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/conceptdescriptionrepositoryservice/Dockerfile
+++ b/cmd/conceptdescriptionrepositoryservice/Dockerfile
@@ -1,8 +1,11 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Install git and SSL certificates for package downloads
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
@@ -14,17 +17,22 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the entire project
-COPY . .
+COPY cmd/conceptdescriptionrepositoryservice ./cmd/conceptdescriptionrepositoryservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-# Build the application with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build the application
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o conceptdescriptionrepositoryservice ./cmd/conceptdescriptionrepositoryservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/digitaltwinregistryservice/Dockerfile
+++ b/cmd/digitaltwinregistryservice/Dockerfile
@@ -1,8 +1,11 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Install git and SSL certificates for package downloads
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
@@ -14,17 +17,22 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the entire project
-COPY . .
+COPY cmd/digitaltwinregistryservice ./cmd/digitaltwinregistryservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-# Build the application with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build the application
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o digitaltwinregistryservice ./cmd/digitaltwinregistryservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/discoveryservice/Dockerfile
+++ b/cmd/discoveryservice/Dockerfile
@@ -1,25 +1,33 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
 WORKDIR /app
 
 # Dependencies first (better layer caching)
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy full source
-COPY . .
+COPY cmd/discoveryservice ./cmd/discoveryservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-# Build discoveryservice binary with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build discoveryservice binary
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o discoveryservice ./cmd/discoveryservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/dppapiservice/Dockerfile
+++ b/cmd/dppapiservice/Dockerfile
@@ -1,22 +1,32 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
 
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-COPY . .
+COPY cmd/dppapiservice ./cmd/dppapiservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o dppapiservice ./cmd/dppapiservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/submodelregistryservice/Dockerfile
+++ b/cmd/submodelregistryservice/Dockerfile
@@ -1,8 +1,11 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Install git and SSL certificates for package downloads
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
@@ -14,17 +17,22 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the entire project
-COPY . .
+COPY cmd/submodelregistryservice ./cmd/submodelregistryservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-# Build the application with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build the application
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o submodelregistryservice ./cmd/submodelregistryservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image

--- a/cmd/submodelrepositoryservice/Dockerfile
+++ b/cmd/submodelrepositoryservice/Dockerfile
@@ -1,8 +1,11 @@
-# Stage 1: Build the application
-FROM golang:1.26.4-alpine AS builder
+# syntax=docker/dockerfile:1
 
-# Version argument for build-time injection
-ARG VERSION=dev
+# Stage 1: Build the application
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 # Install git and SSL certificates for package downloads
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
@@ -14,17 +17,22 @@ WORKDIR /app
 COPY go.mod go.sum ./
 
 # Download dependencies
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
-# Copy the entire project
-COPY . .
+COPY cmd/submodelrepositoryservice ./cmd/submodelrepositoryservice
+COPY internal ./internal
+COPY pkg ./pkg
 
-# Build the application with version information
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+# Build the application
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o submodelrepositoryservice ./cmd/submodelrepositoryservice
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image


### PR DESCRIPTION
## Summary

- Build all service Dockerfiles on the native BuildKit build platform and cross-compile Go binaries for the requested target platform.
- Keep published platforms unchanged: `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.
- Narrow Docker build context copies to each service-specific `cmd/<service>` directory plus shared `internal` and `pkg` sources, with `database` copied only for `basyxconfigurationservice`.
- Remove the unused `VERSION` build arg and inert `main.Version` / `main.BuildTime` ldflags.
- Update snapshot and release BuildKit cache scopes so both workflows can read warm caches while writing to workflow-specific scopes.

## Why

The slow path was compile-heavy ARM builds running under QEMU, especially for `linux/arm/v7`. Docker recommends native cross-compilation or native build nodes for this case. The Go services cross-compile cleanly, so the Dockerfiles can avoid emulated builder stages while preserving the runtime image contracts.

## Impact

Runtime image names, tags, commands, binary paths, ports, healthchecks, SBOM/provenance settings, signing, and attestations are preserved. Version information remains represented by tags and image metadata/provenance rather than unused binary ldflags.

## Validation

- `git diff --check`
- ARMv7 cross-compile for all 12 services plus `./internal/healthprobe`
- `docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -f cmd/aasenvironmentservice/Dockerfile .`
- `docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -f cmd/basyxconfigurationservice/Dockerfile .`
- `go clean -testcache && go test -v ./internal/submodelrepository/integration_tests`
