### PR TITLE
Adds Postgres missing large object cleanup

### DIFF
--- a/.github/workflows/docker-snapshot.yml
+++ b/.github/workflows/docker-snapshot.yml
@@ -59,7 +59,7 @@ jobs:
       contents: read
       id-token: write
     strategy:
-      max-parallel: 3
+      max-parallel: 12
       matrix:
         service:
           - name: aasenvironmentservice

--- a/internal/aasrepository/integration_tests/aasrepository_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_integration_test.go
@@ -1376,6 +1376,97 @@ func TestThumbnailAttachmentOperations(t *testing.T) {
 	})
 }
 
+func TestDeleteAssetAdministrationShellUnlinksThumbnailLargeObject(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	aasID := fmt.Sprintf("https://example.com/ids/aas/thumbnail_delete_cleanup_%d", time.Now().UnixNano())
+	encodedAASID := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+	aasEndpoint := fmt.Sprintf("%s/shells/%s", baseURL, encodedAASID)
+	thumbnailEndpoint := fmt.Sprintf("%s/asset-information/thumbnail", aasEndpoint)
+	baselineCount := countPostgresLargeObjects(t, integrationTestDSN)
+
+	createAASForLargeObjectCleanupTest(t, baseURL, aasID)
+	defer deleteAASForLargeObjectCleanupTest(t, aasEndpoint)
+
+	uploadStatus, uploadErr := uploadThumbnail(thumbnailEndpoint, "testFiles/marcus.gif", "marcus.gif")
+	require.NoError(t, uploadErr)
+	require.Equal(t, http.StatusNoContent, uploadStatus)
+	require.Greater(t, countPostgresLargeObjects(t, integrationTestDSN), baselineCount)
+
+	deleteStatus, deleteErr := deleteResponseStatus(aasEndpoint)
+	require.NoError(t, deleteErr)
+	require.Equal(t, http.StatusNoContent, deleteStatus)
+	require.Equal(t, baselineCount, countPostgresLargeObjects(t, integrationTestDSN))
+}
+
+func TestPutAssetAdministrationShellUnlinksReplacedThumbnailLargeObject(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	aasID := fmt.Sprintf("https://example.com/ids/aas/thumbnail_put_cleanup_%d", time.Now().UnixNano())
+	encodedAASID := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+	aasEndpoint := fmt.Sprintf("%s/shells/%s", baseURL, encodedAASID)
+	thumbnailEndpoint := fmt.Sprintf("%s/asset-information/thumbnail", aasEndpoint)
+	baselineCount := countPostgresLargeObjects(t, integrationTestDSN)
+
+	createAASForLargeObjectCleanupTest(t, baseURL, aasID)
+	defer deleteAASForLargeObjectCleanupTest(t, aasEndpoint)
+
+	uploadStatus, uploadErr := uploadThumbnail(thumbnailEndpoint, "testFiles/marcus.gif", "marcus.gif")
+	require.NoError(t, uploadErr)
+	require.Equal(t, http.StatusNoContent, uploadStatus)
+	require.Greater(t, countPostgresLargeObjects(t, integrationTestDSN), baselineCount)
+
+	_, putStatus, _, putErr := putJSONResponse(aasEndpoint, aasLargeObjectCleanupPayload(aasID))
+	require.NoError(t, putErr)
+	require.Equal(t, http.StatusNoContent, putStatus)
+	require.Equal(t, baselineCount, countPostgresLargeObjects(t, integrationTestDSN))
+}
+
+func createAASForLargeObjectCleanupTest(t *testing.T, baseURL string, aasID string) {
+	t.Helper()
+
+	statusCode, err := postResponseStatus(baseURL+"/shells", aasLargeObjectCleanupPayload(aasID))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, statusCode)
+}
+
+func aasLargeObjectCleanupPayload(aasID string) string {
+	return fmt.Sprintf(
+		`{"id":"%s","modelType":"AssetAdministrationShell","assetInformation":{"assetKind":"Instance","globalAssetId":"%s-global-asset"}}`,
+		aasID,
+		aasID,
+	)
+}
+
+func deleteAASForLargeObjectCleanupTest(t *testing.T, aasEndpoint string) {
+	t.Helper()
+
+	statusCode, err := deleteResponseStatus(aasEndpoint)
+	if err != nil {
+		t.Logf("cleanup delete AAS failed: %v", err)
+		return
+	}
+	if statusCode != http.StatusNoContent && statusCode != http.StatusNotFound {
+		t.Logf("cleanup delete AAS returned status=%d", statusCode)
+	}
+}
+
+func countPostgresLargeObjects(t *testing.T, dsn string) int64 {
+	t.Helper()
+
+	db, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	query, args, err := goqu.Dialect("postgres").
+		From(goqu.T("pg_largeobject_metadata")).
+		Select(goqu.COUNT("*")).
+		ToSQL()
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.QueryRow(query, args...).Scan(&count))
+	return count
+}
+
 func TestContractThumbnailGetReturnsDetectedContentType(t *testing.T) {
 	baseURL := "http://localhost:6004"
 	aasID := fmt.Sprintf("https://example.com/ids/aas/thumbnail_contract_%d", time.Now().UnixNano())

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -899,14 +899,9 @@ func (s *AssetAdministrationShellDatabase) PutAssetAdministrationShellByIDInTran
 
 func (s *AssetAdministrationShellDatabase) putAssetAdministrationShellByIDInTransactionValidated(ctx context.Context, tx *sql.Tx, aasIdentifier string, aas types.IAssetAdministrationShell) (bool, error) {
 	dialect := goqu.Dialect("postgres")
-	selectSQL, selectArgs, buildErr := buildGetAssetAdministrationShellDBIDByIdentifierQuery(&dialect, aasIdentifier)
-	if buildErr != nil {
-		return false, common.NewInternalServerError("AASREPO-PUTAAS-BUILDSELECT " + buildErr.Error())
-	}
-
-	var existingID int64
 	isUpdate := true
-	if scanErr := tx.QueryRow(selectSQL, selectArgs...).Scan(&existingID); scanErr != nil {
+	existingID, scanErr := persistenceutils.GetAssetAdministrationShellDatabaseIDForUpdate(tx, aasIdentifier)
+	if scanErr != nil {
 		if scanErr != sql.ErrNoRows {
 			return false, common.NewInternalServerError("AASREPO-PUTAAS-EXECSELECT " + scanErr.Error())
 		}
@@ -935,6 +930,10 @@ func (s *AssetAdministrationShellDatabase) putAssetAdministrationShellByIDInTran
 	}
 
 	if isUpdate {
+		if cleanupErr := cleanupThumbnailLargeObjectsByAASDBID(tx, &dialect, existingID, "AASREPO-PUTAAS"); cleanupErr != nil {
+			return false, cleanupErr
+		}
+
 		deleteSQL, deleteArgs, deleteBuildErr := buildDeleteAssetAdministrationShellByDBIDQuery(&dialect, existingID)
 		if deleteBuildErr != nil {
 			return false, common.NewInternalServerError("AASREPO-PUTAAS-BUILDDELETE " + deleteBuildErr.Error())
@@ -1008,7 +1007,16 @@ func (s *AssetAdministrationShellDatabase) DeleteAssetAdministrationShellByIDInT
 	}
 
 	dialect := goqu.Dialect("postgres")
-	sqlQuery, args, buildErr := buildDeleteAssetAdministrationShellByIdentifierQuery(&dialect, aasIdentifier)
+	aasDBID, err := getAssetAdministrationShellDBIDForDelete(tx, aasIdentifier)
+	if err != nil {
+		return err
+	}
+
+	if err = cleanupThumbnailLargeObjectsByAASDBID(tx, &dialect, aasDBID, "AASREPO-DELAAS"); err != nil {
+		return err
+	}
+
+	sqlQuery, args, buildErr := buildDeleteAssetAdministrationShellByDBIDQuery(&dialect, aasDBID)
 	if buildErr != nil {
 		return common.NewInternalServerError("AASREPO-DELAAS-BUILDSQL " + buildErr.Error())
 	}
@@ -1028,6 +1036,30 @@ func (s *AssetAdministrationShellDatabase) DeleteAssetAdministrationShellByIDInT
 	}
 
 	return history.AppendVersionTx(ctx, tx, history.TableAAS, aasIdentifier, history.ChangeDeleted, map[string]any{"id": aasIdentifier}, true)
+}
+
+func getAssetAdministrationShellDBIDForDelete(tx *sql.Tx, aasIdentifier string) (int64, error) {
+	aasDBID, scanErr := persistenceutils.GetAssetAdministrationShellDatabaseIDForUpdate(tx, aasIdentifier)
+	if scanErr != nil {
+		if scanErr == sql.ErrNoRows {
+			return 0, common.NewErrNotFound("AASREPO-DELAAS-AASNOTFOUND Asset Administration Shell with ID '" + aasIdentifier + "' not found")
+		}
+		return 0, common.NewInternalServerError("AASREPO-DELAAS-EXECSELECT " + scanErr.Error())
+	}
+	return aasDBID, nil
+}
+
+func cleanupThumbnailLargeObjectsByAASDBID(tx *sql.Tx, dialect *goqu.DialectWrapper, aasDBID int64, errorPrefix string) error {
+	query, args, buildErr := buildCleanupThumbnailLargeObjectsByAASDBIDQuery(dialect, aasDBID)
+	if buildErr != nil {
+		return common.NewInternalServerError(errorPrefix + "-BUILDUNLINKLO " + buildErr.Error())
+	}
+
+	var unlinkedCount int64
+	if scanErr := tx.QueryRow(query, args...).Scan(&unlinkedCount); scanErr != nil {
+		return common.NewInternalServerError(errorPrefix + "-UNLINKLO " + scanErr.Error())
+	}
+	return nil
 }
 
 // GetAssetAdministrationShellReferences returns paginated model references while preserving ABAC filters from ctx.

--- a/internal/aasrepository/persistence/aas_database_query_utils.go
+++ b/internal/aasrepository/persistence/aas_database_query_utils.go
@@ -229,11 +229,6 @@ func buildGetAssetAdministrationShellCursorByDBIDQuery(dialect *goqu.DialectWrap
 	return dialect.From("aas").Select("aas_id").Where(goqu.I("id").Eq(aasDBID)).ToSQL()
 }
 
-func buildGetAssetAdministrationShellDBIDByIdentifierQuery(dialect *goqu.DialectWrapper, aasIdentifier string) (string, []any, error) {
-	ds := buildGetAssetAdministrationShellDBIDByIdentifierDataset(dialect, aasIdentifier)
-	return ds.ToSQL()
-}
-
 func buildGetAssetAdministrationShellDBIDByIdentifierDataset(dialect *goqu.DialectWrapper, aasIdentifier string) *goqu.SelectDataset {
 	return dialect.From(goqu.T("aas").As("aas")).
 		Select(goqu.I("aas.id")).
@@ -245,8 +240,19 @@ func buildDeleteAssetAdministrationShellByDBIDQuery(dialect *goqu.DialectWrapper
 	return dialect.Delete("aas").Where(goqu.I("id").Eq(aasDBID)).ToSQL()
 }
 
-func buildDeleteAssetAdministrationShellByIdentifierQuery(dialect *goqu.DialectWrapper, aasIdentifier string) (string, []any, error) {
-	return dialect.Delete("aas").Where(goqu.I("aas_id").Eq(aasIdentifier)).ToSQL()
+func buildCleanupThumbnailLargeObjectsByAASDBIDQuery(dialect *goqu.DialectWrapper, aasDBID int64) (string, []any, error) {
+	unlinkSubquery := dialect.From(goqu.T("thumbnail_file_data").As("tfd")).
+		Prepared(true).
+		Select(goqu.Func("lo_unlink", goqu.I("tfd.file_oid")).As("unlink_result")).
+		Where(
+			goqu.I("tfd.id").Eq(aasDBID),
+			goqu.I("tfd.file_oid").IsNotNull(),
+		)
+
+	return dialect.From(unlinkSubquery.As("unlink_results")).
+		Prepared(true).
+		Select(goqu.COUNT("*")).
+		ToSQL()
 }
 
 func buildGetAssetInformationCurrentStateQuery(dialect *goqu.DialectWrapper, aasDBID int64) (string, []any, error) {

--- a/internal/aasrepository/persistence/aas_large_object_cleanup_test.go
+++ b/internal/aasrepository/persistence/aas_large_object_cleanup_test.go
@@ -1,0 +1,97 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package persistence
+
+import (
+	"context"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteAssetAdministrationShellCleansThumbnailLargeObjectBeforeDelete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tx := beginMockTransaction(t, db, mock)
+	repository := &AssetAdministrationShellDatabase{}
+	aasID := "https://example.com/ids/aas/delete-cleanup"
+
+	mock.ExpectQuery(`SELECT .*FROM "aas".*FOR UPDATE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
+	mock.ExpectQuery(`SELECT COUNT\(\*\).*lo_unlink.*thumbnail_file_data`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+	mock.ExpectExec(`DELETE FROM "aas"`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectRollback()
+
+	err = repository.DeleteAssetAdministrationShellByIDInTransaction(contextWithConfig(), tx, aasID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPutAssetAdministrationShellReplacementCleansThumbnailLargeObjectBeforeDelete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tx := beginMockTransaction(t, db, mock)
+	repository := &AssetAdministrationShellDatabase{}
+	aasID := "https://example.com/ids/aas/put-cleanup"
+	assetInformation := types.NewAssetInformation(types.AssetKindInstance)
+	globalAssetID := "https://example.com/global-assets/put-cleanup"
+	assetInformation.SetGlobalAssetID(&globalAssetID)
+	aas := types.NewAssetAdministrationShell(aasID, assetInformation)
+
+	mock.ExpectQuery(`SELECT .*FROM "aas".*FOR UPDATE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
+	mock.ExpectQuery(`SELECT COUNT\(\*\).*lo_unlink.*thumbnail_file_data`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+	mock.ExpectExec(`DELETE FROM "aas"`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`INSERT INTO "aas".*RETURNING "id"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(43)))
+	mock.ExpectExec(`INSERT INTO "aas_payload"`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`INSERT INTO "asset_information"`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectRollback()
+
+	isUpdate, err := repository.PutAssetAdministrationShellByIDInTransaction(contextWithConfig(), tx, aasID, aas)
+	require.NoError(t, err)
+	require.True(t, isUpdate)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func contextWithConfig() context.Context {
+	return common.ContextWithConfig(context.Background(), &common.Config{})
+}

--- a/internal/aasrepository/persistence/thumbnail_file_handler.go
+++ b/internal/aasrepository/persistence/thumbnail_file_handler.go
@@ -182,7 +182,7 @@ func (h *PostgreSQLThumbnailFileHandler) UploadThumbnailByAASIDReader(aasIdentif
 
 // nolint:revive // cyclomatic complexity of 33
 func (h *PostgreSQLThumbnailFileHandler) uploadThumbnailByAASIDReaderInTransaction(tx *sql.Tx, aasIdentifier string, fileName string, file io.Reader) error {
-	aasDBID, err := persistenceutils.GetAssetAdministrationShellDatabaseID(tx, aasIdentifier)
+	aasDBID, err := persistenceutils.GetAssetAdministrationShellDatabaseIDForUpdate(tx, aasIdentifier)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return common.NewErrNotFound("AASREPO-PUTTHUMBNAIL-AASNOTFOUND Asset Administration Shell with ID '" + aasIdentifier + "' not found")
@@ -366,7 +366,7 @@ func (h *PostgreSQLThumbnailFileHandler) DeleteThumbnailByAASID(aasIdentifier st
 }
 
 func (h *PostgreSQLThumbnailFileHandler) deleteThumbnailByAASIDInTransaction(tx *sql.Tx, aasIdentifier string) error {
-	aasDBID, err := persistenceutils.GetAssetAdministrationShellDatabaseID(tx, aasIdentifier)
+	aasDBID, err := persistenceutils.GetAssetAdministrationShellDatabaseIDForUpdate(tx, aasIdentifier)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return common.NewErrNotFound("AASREPO-DELTHUMBNAIL-AASNOTFOUND Asset Administration Shell with ID '" + aasIdentifier + "' not found")

--- a/internal/aasrepository/persistence/utils/aas_utils.go
+++ b/internal/aasrepository/persistence/utils/aas_utils.go
@@ -44,9 +44,8 @@ func GetAssetAdministrationShellDatabaseIDForUpdate(tx *sql.Tx, aasId string) (i
 
 func getAssetAdministrationShellDatabaseID(tx *sql.Tx, aasId string, forUpdate bool) (int64, error) {
 	var databaseID int64
-	query := goqu.Dialect("postgres").
+	query := goqu.Select("id").
 		From("aas").
-		Select("id").
 		Where(goqu.I("aas_id").Eq(aasId))
 	if forUpdate {
 		query = query.ForUpdate(goqu.Wait)

--- a/internal/aasrepository/persistence/utils/aas_utils.go
+++ b/internal/aasrepository/persistence/utils/aas_utils.go
@@ -34,8 +34,25 @@ import (
 
 // GetAssetAdministrationShellDatabaseID returns the internal database ID for a given AAS identifier.
 func GetAssetAdministrationShellDatabaseID(tx *sql.Tx, aasId string) (int64, error) {
+	return getAssetAdministrationShellDatabaseID(tx, aasId, false)
+}
+
+// GetAssetAdministrationShellDatabaseIDForUpdate returns and locks the internal database ID for a given AAS identifier.
+func GetAssetAdministrationShellDatabaseIDForUpdate(tx *sql.Tx, aasId string) (int64, error) {
+	return getAssetAdministrationShellDatabaseID(tx, aasId, true)
+}
+
+func getAssetAdministrationShellDatabaseID(tx *sql.Tx, aasId string, forUpdate bool) (int64, error) {
 	var databaseID int64
-	sqlQuery, args, err := goqu.Select("id").From("aas").Where(goqu.I("aas_id").Eq(aasId)).ToSQL()
+	query := goqu.Dialect("postgres").
+		From("aas").
+		Select("id").
+		Where(goqu.I("aas_id").Eq(aasId))
+	if forUpdate {
+		query = query.ForUpdate(goqu.Wait)
+	}
+
+	sqlQuery, args, err := query.ToSQL()
 	if err != nil {
 		return 0, err
 	}

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -2034,6 +2034,130 @@ func TestFileAttachmentOperations(t *testing.T) {
 	})
 }
 
+func TestDeleteSubmodelElementByPathUnlinksFileAttachmentLargeObject(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	submodelID := fmt.Sprintf("urn:basyx:integration:lo-delete-file-%d", time.Now().UnixNano())
+	encodedSubmodelID := common.EncodeString(submodelID)
+	filePath := "DeleteFile"
+	baselineCount := countPostgresLargeObjects(t, submodelRepositoryIntegrationTestDSN)
+
+	createSubmodelForLargeObjectCleanupTest(t, baseURL, submodelID, "LargeObjectDeleteFile", []any{
+		fileElementForLargeObjectCleanupTest(filePath),
+	})
+	defer deleteSubmodelForLargeObjectCleanupTest(t, baseURL, encodedSubmodelID)
+
+	attachmentEndpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/%s/attachment", baseURL, encodedSubmodelID, url.PathEscape(filePath))
+	statusCode, err := uploadFileAttachment(attachmentEndpoint, "testFiles/marcus.gif", "marcus.gif")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, statusCode)
+	require.Greater(t, countPostgresLargeObjects(t, submodelRepositoryIntegrationTestDSN), baselineCount)
+
+	deleteEndpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/%s", baseURL, encodedSubmodelID, url.PathEscape(filePath))
+	statusCode, body, err := requestJSON(http.MethodDelete, deleteEndpoint, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, statusCode, "response=%s", string(body))
+	require.Equal(t, baselineCount, countPostgresLargeObjects(t, submodelRepositoryIntegrationTestDSN))
+}
+
+func TestPutParentSubmodelElementUnlinksNestedFileAttachmentLargeObject(t *testing.T) {
+	baseURL := "http://localhost:6004"
+	submodelID := fmt.Sprintf("urn:basyx:integration:lo-replace-parent-%d", time.Now().UnixNano())
+	encodedSubmodelID := common.EncodeString(submodelID)
+	parentPath := "Container"
+	nestedFilePath := parentPath + ".NestedFile"
+	baselineCount := countPostgresLargeObjects(t, submodelRepositoryIntegrationTestDSN)
+
+	createSubmodelForLargeObjectCleanupTest(t, baseURL, submodelID, "LargeObjectReplaceParent", []any{
+		map[string]any{
+			"idShort":   parentPath,
+			"modelType": "SubmodelElementCollection",
+			"value": []any{
+				fileElementForLargeObjectCleanupTest("NestedFile"),
+			},
+		},
+	})
+	defer deleteSubmodelForLargeObjectCleanupTest(t, baseURL, encodedSubmodelID)
+
+	attachmentEndpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/%s/attachment", baseURL, encodedSubmodelID, url.PathEscape(nestedFilePath))
+	statusCode, err := uploadFileAttachment(attachmentEndpoint, "testFiles/marcus.gif", "marcus.gif")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, statusCode)
+	require.Greater(t, countPostgresLargeObjects(t, submodelRepositoryIntegrationTestDSN), baselineCount)
+
+	replacement := map[string]any{
+		"idShort":   parentPath,
+		"modelType": "SubmodelElementCollection",
+		"value": []any{
+			map[string]any{
+				"idShort":   "ReplacementProperty",
+				"modelType": "Property",
+				"value":     "replacement",
+				"valueType": "xs:string",
+			},
+		},
+	}
+	replaceEndpoint := fmt.Sprintf("%s/submodels/%s/submodel-elements/%s", baseURL, encodedSubmodelID, url.PathEscape(parentPath))
+	statusCode, body, err := requestJSON(http.MethodPut, replaceEndpoint, replacement)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, statusCode, "response=%s", string(body))
+	require.Equal(t, baselineCount, countPostgresLargeObjects(t, submodelRepositoryIntegrationTestDSN))
+}
+
+func createSubmodelForLargeObjectCleanupTest(t *testing.T, baseURL string, submodelID string, idShort string, elements []any) {
+	t.Helper()
+
+	payload := map[string]any{
+		"id":               submodelID,
+		"idShort":          idShort,
+		"kind":             "Instance",
+		"modelType":        "Submodel",
+		"submodelElements": elements,
+	}
+	statusCode, body, err := requestJSON(http.MethodPost, baseURL+"/submodels", payload)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
+}
+
+func fileElementForLargeObjectCleanupTest(idShort string) map[string]any {
+	return map[string]any{
+		"idShort":     idShort,
+		"modelType":   "File",
+		"contentType": "image/gif",
+		"value":       "file:///" + idShort,
+	}
+}
+
+func deleteSubmodelForLargeObjectCleanupTest(t *testing.T, baseURL string, encodedSubmodelID string) {
+	t.Helper()
+
+	statusCode, body, err := requestJSON(http.MethodDelete, baseURL+"/submodels/"+encodedSubmodelID, nil)
+	if err != nil {
+		t.Logf("cleanup delete submodel failed: %v", err)
+		return
+	}
+	if statusCode != http.StatusNoContent && statusCode != http.StatusNotFound {
+		t.Logf("cleanup delete submodel returned status=%d response=%s", statusCode, string(body))
+	}
+}
+
+func countPostgresLargeObjects(t *testing.T, dsn string) int64 {
+	t.Helper()
+
+	db, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	query, args, err := goqu.Dialect("postgres").
+		From(goqu.T("pg_largeobject_metadata")).
+		Select(goqu.COUNT("*")).
+		ToSQL()
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.QueryRow(query, args...).Scan(&count))
+	return count
+}
+
 func TestUploadAttachmentToNonFileSubmodelElementReturnsMethodNotAllowed(t *testing.T) {
 	baseURL := "http://localhost:6004"
 	submodelID := fmt.Sprintf("urn:basyx:integration:non-file-attachment-%d", time.Now().UnixNano())

--- a/internal/submodelrepository/persistence/submodelElements/FileHandler.go
+++ b/internal/submodelrepository/persistence/submodelElements/FileHandler.go
@@ -453,7 +453,7 @@ func reopenUploadedFile(file *os.File) (*os.File, error) {
 }
 
 func readFileElementUploadMetadata(tx *sql.Tx, dialect goqu.DialectWrapper, submodelID string, idShortPath string) (fileElementUploadMetadata, error) {
-	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseID(tx, submodelID)
+	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseIDForUpdate(tx, submodelID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return fileElementUploadMetadata{}, common.NewErrNotFound("submodel not found")
@@ -761,7 +761,7 @@ func (p PostgreSQLFileHandler) DeleteFileAttachment(submodelID string, idShortPa
 func (p PostgreSQLFileHandler) DeleteFileAttachmentTx(tx *sql.Tx, submodelID string, idShortPath string) error {
 	dialect := goqu.Dialect("postgres")
 
-	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseID(tx, submodelID)
+	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseIDForUpdate(tx, submodelID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return common.NewErrNotFound("submodel not found")

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
@@ -42,6 +42,7 @@ import (
 	"github.com/FriedJannik/aas-go-sdk/types"
 	"github.com/doug-martin/goqu/v9"
 	_ "github.com/doug-martin/goqu/v9/dialect/postgres" // Postgres Driver for Goqu
+	"github.com/doug-martin/goqu/v9/exp"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	persistenceutils "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence/utils"
@@ -290,12 +291,17 @@ func getModelTypeByIdShortPathAndSubmodelID(queryer queryRower, submodelID strin
 //	// Delete a nested collection and all its children
 //	err := DeleteSubmodelElementByPath(tx, "submodel123", "properties.metadata")
 func DeleteSubmodelElementByPath(tx *sql.Tx, submodelID string, idShortOrPath string) error {
-	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseID(tx, submodelID)
+	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseIDForUpdate(tx, submodelID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return common.NewErrNotFound("SMREPO-DELSMEBPATH-SMNOTFOUND Submodel with ID '" + submodelID + "' not found")
 		}
 		return common.NewInternalServerError("SMREPO-DELSMEBPATH-GETSMDATABASEID Failed to resolve Submodel database ID: " + err.Error())
+	}
+
+	err = cleanupSubmodelElementTreeLargeObjects(tx, submodelDatabaseID, idShortOrPath, true, "SMREPO-DELSMEBPATH")
+	if err != nil {
+		return err
 	}
 
 	affectedRows, err := deleteSubmodelElementTree(tx, submodelDatabaseID, idShortOrPath)
@@ -318,16 +324,8 @@ func DeleteSubmodelElementByPath(tx *sql.Tx, submodelID string, idShortOrPath st
 }
 
 func deleteSubmodelElementTree(tx *sql.Tx, submodelDatabaseID int, idShortOrPath string) (int64, error) {
-	escapedPath := escapeSQLLikePattern(idShortOrPath)
 	del := goqu.Delete("submodel_element").Where(
-		goqu.And(
-			goqu.I("submodel_id").Eq(submodelDatabaseID),
-			goqu.Or(
-				goqu.I("idshort_path").Eq(idShortOrPath),
-				idShortPathLikeEscaped(goqu.I("idshort_path"), escapedPath+".%"),
-				idShortPathLikeEscaped(goqu.I("idshort_path"), escapedPath+"[%"),
-			),
-		),
+		submodelElementTreeWhere(submodelDatabaseID, idShortOrPath, true, ""),
 	)
 	sqlQuery, args, err := del.ToSQL()
 	if err != nil {
@@ -342,6 +340,63 @@ func deleteSubmodelElementTree(tx *sql.Tx, submodelDatabaseID int, idShortOrPath
 		return 0, common.NewInternalServerError("SMREPO-DELSMEBPATH-ROWSAFFECTED Failed to get affected rows: " + err.Error())
 	}
 	return affectedRows, nil
+}
+
+func cleanupSubmodelElementTreeLargeObjects(tx *sql.Tx, submodelDatabaseID int, idShortOrPath string, includeRoot bool, errorPrefix string) error {
+	query, args, err := buildCleanupSubmodelElementTreeLargeObjectsSQL(submodelDatabaseID, idShortOrPath, includeRoot)
+	if err != nil {
+		return common.NewInternalServerError(errorPrefix + "-BUILDUNLINKLO Failed to build large object cleanup query: " + err.Error())
+	}
+
+	var unlinkedCount int64
+	if err = tx.QueryRow(query, args...).Scan(&unlinkedCount); err != nil {
+		return common.NewInternalServerError(errorPrefix + "-UNLINKLO Failed to unlink large objects: " + err.Error())
+	}
+	return nil
+}
+
+func buildCleanupSubmodelElementTreeLargeObjectsSQL(submodelDatabaseID int, idShortOrPath string, includeRoot bool) (string, []any, error) {
+	dialect := goqu.Dialect("postgres")
+	unlinkSubquery := dialect.From(goqu.T("submodel_element").As("sme")).
+		Prepared(true).
+		Join(goqu.T("file_data").As("fd"), goqu.On(goqu.I("fd.id").Eq(goqu.I("sme.id")))).
+		Select(goqu.Func("lo_unlink", goqu.I("fd.file_oid")).As("unlink_result")).
+		Where(
+			submodelElementTreeWhere(submodelDatabaseID, idShortOrPath, includeRoot, "sme"),
+			goqu.I("fd.file_oid").IsNotNull(),
+		)
+
+	return dialect.From(unlinkSubquery.As("unlink_results")).
+		Prepared(true).
+		Select(goqu.COUNT("*")).
+		ToSQL()
+}
+
+func submodelElementTreeWhere(submodelDatabaseID int, idShortOrPath string, includeRoot bool, tableAlias string) goqu.Expression {
+	return goqu.And(
+		qualifiedSubmodelElementColumn(tableAlias, "submodel_id").Eq(submodelDatabaseID),
+		goqu.Or(submodelElementTreePathConditions(qualifiedSubmodelElementColumn(tableAlias, "idshort_path"), idShortOrPath, includeRoot)...),
+	)
+}
+
+func submodelElementTreePathConditions(idShortPath exp.IdentifierExpression, idShortOrPath string, includeRoot bool) []goqu.Expression {
+	escapedPath := escapeSQLLikePattern(idShortOrPath)
+	conditions := make([]goqu.Expression, 0, 3)
+	if includeRoot {
+		conditions = append(conditions, idShortPath.Eq(idShortOrPath))
+	}
+	return append(
+		conditions,
+		idShortPathLikeEscaped(idShortPath, escapedPath+".%"),
+		idShortPathLikeEscaped(idShortPath, escapedPath+"[%"),
+	)
+}
+
+func qualifiedSubmodelElementColumn(tableAlias string, column string) exp.IdentifierExpression {
+	if tableAlias == "" {
+		return goqu.I(column)
+	}
+	return goqu.I(tableAlias + "." + column)
 }
 
 func isListElementPath(idShortPath string) bool {
@@ -533,7 +588,7 @@ func DeleteAllChildren(db *sql.DB, submodelId string, idShortPath string, tx *sq
 		defer cu(&err)
 	}
 
-	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseID(localTx, submodelId)
+	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseIDForUpdate(localTx, submodelId)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return common.NewErrNotFound("SMREPO-DELALLCHILDREN-SMNOTFOUND Submodel with ID '" + submodelId + "' not found")
@@ -541,16 +596,13 @@ func DeleteAllChildren(db *sql.DB, submodelId string, idShortPath string, tx *sq
 		return common.NewInternalServerError("SMREPO-DELALLCHILDREN-GETSMDATABASEID Failed to resolve Submodel database ID: " + err.Error())
 	}
 
-	escapedPath := escapeSQLLikePattern(idShortPath)
+	err = cleanupSubmodelElementTreeLargeObjects(localTx, submodelDatabaseID, idShortPath, false, "SMREPO-DELALLCHILDREN")
+	if err != nil {
+		return err
+	}
 
 	del := goqu.Delete("submodel_element").Where(
-		goqu.And(
-			goqu.I("submodel_id").Eq(submodelDatabaseID),
-			goqu.Or(
-				idShortPathLikeEscaped(goqu.I("idshort_path"), escapedPath+".%"),
-				idShortPathLikeEscaped(goqu.I("idshort_path"), escapedPath+"[%"),
-			),
-		),
+		submodelElementTreeWhere(submodelDatabaseID, idShortPath, false, ""),
 	)
 	sqlQuery, args, err := del.ToSQL()
 	if err != nil {

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_large_object_cleanup_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_large_object_cleanup_test.go
@@ -1,0 +1,79 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package submodelelements
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteSubmodelElementByPathCleansLargeObjectsBeforeDeletingTree(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	mock.ExpectQuery(`SELECT .*FROM "submodel".*FOR UPDATE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+	mock.ExpectQuery(`SELECT COUNT\(\*\).*lo_unlink.*file_data`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+	mock.ExpectExec(`DELETE FROM "submodel_element"`).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectRollback()
+
+	err = DeleteSubmodelElementByPath(tx, "sm-1", "Parent.File")
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeleteAllChildrenCleansLargeObjectsBeforeDeletingChildren(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	mock.ExpectQuery(`SELECT .*FROM "submodel".*FOR UPDATE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(43))
+	mock.ExpectQuery(`SELECT COUNT\(\*\).*lo_unlink.*file_data`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
+	mock.ExpectExec(`DELETE FROM "submodel_element"`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectRollback()
+
+	err = DeleteAllChildren(db, "sm-1", "Parent", tx)
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/submodelrepository/persistence/submodel_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_write_database.go
@@ -482,7 +482,7 @@ func (s *SubmodelDatabase) deleteSubmodelInTransaction(ctx context.Context, tx *
 		}
 	}
 
-	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseID(tx, submodelID)
+	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseIDForUpdate(tx, submodelID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return common.NewErrNotFound("SMREPO-DELSM-NOTFOUND Submodel with ID '" + submodelID + "' not found")
@@ -508,7 +508,7 @@ func (s *SubmodelDatabase) deleteSubmodelInTransaction(ctx context.Context, tx *
 }
 
 func (s *SubmodelDatabase) replaceSubmodelInTransaction(tx *sql.Tx, submodelID string, submodel types.ISubmodel, requireExisting bool) (bool, error) {
-	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseID(tx, submodelID)
+	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseIDForUpdate(tx, submodelID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			if requireExisting {

--- a/internal/submodelrepository/persistence/utils/submodel_utils.go
+++ b/internal/submodelrepository/persistence/utils/submodel_utils.go
@@ -54,8 +54,25 @@ import (
 //		return err
 //	}
 func GetSubmodelDatabaseID(tx *sql.Tx, submodelID string) (int, error) {
+	return getSubmodelDatabaseID(tx, submodelID, false)
+}
+
+// GetSubmodelDatabaseIDForUpdate resolves and locks the internal database ID of a Submodel by its identifier.
+func GetSubmodelDatabaseIDForUpdate(tx *sql.Tx, submodelID string) (int, error) {
+	return getSubmodelDatabaseID(tx, submodelID, true)
+}
+
+func getSubmodelDatabaseID(tx *sql.Tx, submodelID string, forUpdate bool) (int, error) {
 	var databaseID int
-	sqlQuery, args, err := goqu.Select("id").From("submodel").Where(goqu.I("submodel_identifier").Eq(submodelID)).ToSQL()
+	query := goqu.Dialect("postgres").
+		From("submodel").
+		Select("id").
+		Where(goqu.I("submodel_identifier").Eq(submodelID))
+	if forUpdate {
+		query = query.ForUpdate(goqu.Wait)
+	}
+
+	sqlQuery, args, err := query.ToSQL()
 	if err != nil {
 		return 0, err
 	}

--- a/internal/submodelrepository/persistence/utils/submodel_utils.go
+++ b/internal/submodelrepository/persistence/utils/submodel_utils.go
@@ -64,9 +64,8 @@ func GetSubmodelDatabaseIDForUpdate(tx *sql.Tx, submodelID string) (int, error) 
 
 func getSubmodelDatabaseID(tx *sql.Tx, submodelID string, forUpdate bool) (int, error) {
 	var databaseID int
-	query := goqu.Dialect("postgres").
+	query := goqu.Select("id").
 		From("submodel").
-		Select("id").
 		Where(goqu.I("submodel_identifier").Eq(submodelID))
 	if forUpdate {
 		query = query.ForUpdate(goqu.Wait)


### PR DESCRIPTION
## Description of Changes

This PR fixes PostgreSQL large object cleanup for File attachments and AAS thumbnails.

Changes include:
- Unlink `file_data.file_oid` before deleting submodel element trees or replacing child elements.
- Unlink `thumbnail_file_data.file_oid` before deleting or replacing AAS rows.
- Keep cleanup inside the existing transactions so failed `lo_unlink` calls roll back the delete/replace.
- Add row-level `FOR UPDATE` locking on owning AAS/Submodel rows to prevent concurrent upload/delete races.
- Add SQL-mock and integration coverage for SME delete/replacement and AAS delete/replacement cleanup paths.

No public API or schema changes are included.

## Related Issue

Closes #445.

## BaSyx Configuration for Testing

No special configuration is required beyond the existing PostgreSQL-backed integration test setup.

Tested with the repository’s Docker Compose based integration tests.

## AAS Files Used for Testing

No AAS files were used for this change.

The existing `testFiles/marcus.gif` fixture was used to upload File attachments and AAS thumbnails in integration tests.

## Additional Information

Existing orphaned PostgreSQL large objects are not removed automatically by this change. This PR prevents new orphaned large objects on the affected delete/replace paths; existing database cleanup remains an admin task such as `vacuumlo`.