### PR TITLE
Harden HTTP server lifecycle across production services

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ If a setup uses mutable tags and pulls images on every start or restart, include
 Configuration is managed via YAML files in `cmd/<service>/config.yaml` and environment variables. Key variables include database connection settings (see [docu/errors.md](docu/errors.md) for troubleshooting):
 
 ```yaml
+server:
+    readHeaderTimeoutSeconds: 15
+    readTimeoutSeconds: 300
+    writeTimeoutSeconds: 300
+    idleTimeoutSeconds: 60
+    shutdownTimeoutSeconds: 10
+
 postgres:
     # Either set dsn or the individual connection fields below. Do not mix them.
     # dsn: postgres://user:password@db:5432/basyx?sslmode=require
@@ -123,6 +130,12 @@ postgres:
 Or via `.env`:
 
 ```env
+SERVER_READ_HEADER_TIMEOUT_SECONDS=15
+SERVER_READ_TIMEOUT_SECONDS=300
+SERVER_WRITE_TIMEOUT_SECONDS=300
+SERVER_IDLE_TIMEOUT_SECONDS=60
+SERVER_SHUTDOWN_TIMEOUT_SECONDS=10
+
 # Either set POSTGRES_DSN or the individual connection variables below. Do not mix them.
 # POSTGRES_DSN=postgres://user:password@db:5432/basyx?sslmode=require
 POSTGRES_HOST=localhost
@@ -144,6 +157,8 @@ POSTGRES_MAXOPENCONNECTIONS=500
 POSTGRES_MAXIDLECONNECTIONS=500
 POSTGRES_CONNMAXLIFETIMEMINUTES=5
 ```
+
+All HTTP timeout values are in seconds and must be greater than zero. The legacy Viper-derived names such as `SERVER_READTIMEOUTSECONDS` still work; readable aliases with underscores and `BASYX_` prefixes, such as `BASYX_SERVER_READ_TIMEOUT_SECONDS`, are also supported.
 
 For `aasenvironmentservice`, `aasrepositoryservice`, and `submodelrepositoryservice`, uploads are additionally bounded by:
 

--- a/cmd/aasenvironmentservice/config.yaml
+++ b/cmd/aasenvironmentservice/config.yaml
@@ -4,6 +4,11 @@ server:
   host: 0.0.0.0
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/aasenvironmentservice/config.yaml
+++ b/cmd/aasenvironmentservice/config.yaml
@@ -5,8 +5,8 @@ server:
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/aasenvironmentservice/main.go
+++ b/cmd/aasenvironmentservice/main.go
@@ -286,7 +286,10 @@ func runServer(ctx context.Context, configPath string) error {
 
 	addr := common.ServerAddress(cfg.Server)
 	log.Printf("AAS Environment Service listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
-	server := common.StartHTTPServer("AASENV", cfg.Server, r)
+	server, err := common.StartHTTPServer(ctx, "AASENV", cfg.Server, r)
+	if err != nil {
+		return err
+	}
 
 	preconfigurationCtx := aasenvironment.ContextWithAASPreconfigurationAudit(common.ContextWithConfig(ctx, cfg))
 	preconfigurationSummary := aasenvironment.RunAASPreconfiguration(preconfigurationCtx, uploadService, cfg.General.AASPreconfigPaths)

--- a/cmd/aasenvironmentservice/main.go
+++ b/cmd/aasenvironmentservice/main.go
@@ -286,7 +286,7 @@ func runServer(ctx context.Context, configPath string) error {
 
 	addr := common.ServerAddress(cfg.Server)
 	log.Printf("AAS Environment Service listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
-	server, err := common.StartHTTPServer(ctx, "AASENV", cfg.Server, r)
+	runner, err := common.StartHTTPServer(ctx, "AASENV", cfg.Server, r)
 	if err != nil {
 		return err
 	}
@@ -304,7 +304,7 @@ func runServer(ctx context.Context, configPath string) error {
 		preconfigurationSummary.SkippedFileCount,
 	)
 
-	return server.Wait(ctx)
+	return runner.Wait(ctx)
 }
 
 func openSharedDatabase(ctx context.Context, cfg *common.Config, dsn string) (*sql.DB, error) {

--- a/cmd/aasenvironmentservice/main.go
+++ b/cmd/aasenvironmentservice/main.go
@@ -32,7 +32,6 @@ import (
 	"database/sql"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"sync/atomic"
@@ -285,21 +284,9 @@ func runServer(ctx context.Context, configPath string) error {
 	aasenvironment.RegisterUploadAPI(apiRouter, uploadService, cfg.General.UploadMaxSizeBytes)
 	aasenvironment.RegisterSerializationAPI(apiRouter, serializationService)
 
-	addr := fmt.Sprintf("0.0.0.0:%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("AAS Environment Service listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
-	server := &http.Server{
-		Addr:              addr,
-		Handler:           r,
-		ReadHeaderTimeout: 15 * time.Second,
-		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      30 * time.Second,
-		IdleTimeout:       60 * time.Second,
-	}
-	go func() {
-		if serveErr := server.ListenAndServe(); serveErr != nil && serveErr != http.ErrServerClosed {
-			log.Printf("Server error: %v", serveErr)
-		}
-	}()
+	server := common.StartHTTPServer("AASENV", cfg.Server, r)
 
 	preconfigurationCtx := aasenvironment.ContextWithAASPreconfigurationAudit(common.ContextWithConfig(ctx, cfg))
 	preconfigurationSummary := aasenvironment.RunAASPreconfiguration(preconfigurationCtx, uploadService, cfg.General.AASPreconfigPaths)
@@ -314,14 +301,7 @@ func runServer(ctx context.Context, configPath string) error {
 		preconfigurationSummary.SkippedFileCount,
 	)
 
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-	defer cancel()
-	if err := server.Shutdown(shutdownCtx); err != nil {
-		return fmt.Errorf("AASENV-SRV-SHUTDOWN %w", err)
-	}
-	return nil
+	return server.Wait(ctx)
 }
 
 func openSharedDatabase(ctx context.Context, cfg *common.Config, dsn string) (*sql.DB, error) {
@@ -349,13 +329,15 @@ func configurePostgresPool(db *sql.DB, cfg common.PostgresConfig) {
 }
 
 func main() {
-	ctx := context.TODO()
+	ctx, stop := common.SignalContext()
 	configPath := ""
 
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/cmd/aasregistryservice/config.yaml
+++ b/cmd/aasregistryservice/config.yaml
@@ -4,6 +4,11 @@ server:
   host: 0.0.0.0
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/aasregistryservice/config.yaml
+++ b/cmd/aasregistryservice/config.yaml
@@ -5,8 +5,8 @@ server:
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/aasregistryservice/main.go
+++ b/cmd/aasregistryservice/main.go
@@ -31,7 +31,6 @@ import (
 	"context"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -168,30 +167,22 @@ func runServer(ctx context.Context, configPath string) error {
 	// Mount protected API under base path
 	r.Mount(base, apiRouter)
 
-	addr := "0.0.0.0:" + fmt.Sprintf("%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("▶️ AAS Registry listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
 
-	// Start server in a goroutine
-	go func() {
-		//nolint:gosec // implementing this fix would cause errors.
-		if err := http.ListenAndServe(addr, r); err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
-
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	return nil
+	return common.RunHTTPServer(ctx, "AASR", cfg.Server, r)
 }
 
 func main() {
-	ctx := context.Background()
+	ctx, stop := common.SignalContext()
 
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/cmd/aasrepositoryservice/config.yaml
+++ b/cmd/aasrepositoryservice/config.yaml
@@ -4,6 +4,11 @@ server:
   host: 0.0.0.0
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/aasrepositoryservice/config.yaml
+++ b/cmd/aasrepositoryservice/config.yaml
@@ -5,8 +5,8 @@ server:
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/aasrepositoryservice/main.go
+++ b/cmd/aasrepositoryservice/main.go
@@ -31,9 +31,7 @@ import (
 	"crypto/rsa"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -209,29 +207,22 @@ func runServer(ctx context.Context, configPath string) error {
 
 	r.Mount(base, apiRouter)
 
-	addr := "0.0.0.0:" + fmt.Sprintf("%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("▶️  Asset Administration Shell Repository listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
 
-	go func() {
-		//nolint:gosec // implementing this fix would cause errors.
-		if err := http.ListenAndServe(addr, r); err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
-
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	return nil
+	return common.RunHTTPServer(ctx, "AASREPO", cfg.Server, r)
 }
 
 func main() {
-	ctx := context.Background()
+	ctx, stop := common.SignalContext()
 	// load config path from flag
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/cmd/aasxfileserverservice/config.yaml
+++ b/cmd/aasxfileserverservice/config.yaml
@@ -3,8 +3,8 @@ server:
   contextPath: ""
   host: 0.0.0.0
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/aasxfileserverservice/config.yaml
+++ b/cmd/aasxfileserverservice/config.yaml
@@ -2,6 +2,11 @@ server:
   port: 5004
   contextPath: ""
   host: 0.0.0.0
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/aasxfileserverservice/main.go
+++ b/cmd/aasxfileserverservice/main.go
@@ -32,7 +32,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -138,29 +137,22 @@ func runServer(ctx context.Context, configPath string) error {
 
 	r.Mount(base, apiRouter)
 
-	addr := "0.0.0.0:" + fmt.Sprintf("%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("▶️  AASX File Server listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
 
-	go func() {
-		//nolint:gosec // implementing this fix would cause errors.
-		if err := http.ListenAndServe(addr, r); err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
-
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	return nil
+	return common.RunHTTPServer(ctx, "AASX", cfg.Server, r)
 }
 
 func main() {
-	ctx := context.Background()
+	ctx, stop := common.SignalContext()
 	// load config path from flag
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/cmd/companylookupservice/config.yaml
+++ b/cmd/companylookupservice/config.yaml
@@ -4,6 +4,11 @@ server:
   host: 0.0.0.0
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/companylookupservice/config.yaml
+++ b/cmd/companylookupservice/config.yaml
@@ -5,8 +5,8 @@ server:
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/companylookupservice/main.go
+++ b/cmd/companylookupservice/main.go
@@ -30,9 +30,7 @@ import (
 	"context"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
-	"net/http"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	commonmodel "github.com/eclipse-basyx/basyx-go-components/internal/common/model"
@@ -122,30 +120,22 @@ func runServer(ctx context.Context, configPath string) error {
 	// Mount protected API under base path
 	r.Mount(base, apiRouter)
 
-	// === Start Server ===
-	addr := fmt.Sprintf("0.0.0.0:%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("▶️ Company Lookup listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
 
-	go func() {
-		//nolint:gosec // implementing this fix would cause errors.
-		if err := http.ListenAndServe(addr, r); err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
-
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	return nil
+	return common.RunHTTPServer(ctx, "COMPANYLOOKUP", cfg.Server, r)
 }
 
 func main() {
-	ctx := context.Background()
+	ctx, stop := common.SignalContext()
 	// load config path from flag
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/cmd/conceptdescriptionrepositoryservice/config.yaml
+++ b/cmd/conceptdescriptionrepositoryservice/config.yaml
@@ -4,6 +4,11 @@ server:
   host: 0.0.0.0
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/conceptdescriptionrepositoryservice/config.yaml
+++ b/cmd/conceptdescriptionrepositoryservice/config.yaml
@@ -5,8 +5,8 @@ server:
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/conceptdescriptionrepositoryservice/main.go
+++ b/cmd/conceptdescriptionrepositoryservice/main.go
@@ -30,9 +30,7 @@ import (
 	"context"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -156,30 +154,22 @@ func runServer(ctx context.Context, configPath string) error {
 	// Mount protected API under base path
 	r.Mount(base, apiRouter)
 
-	// Start the server
-	addr := "0.0.0.0:" + fmt.Sprintf("%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("▶️  Concept Description Repository listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
-	// Start server in a goroutine
-	go func() {
-		//nolint:gosec // implementing this fix would cause errors.
-		if err := http.ListenAndServe(addr, r); err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
 
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	return nil
+	return common.RunHTTPServer(ctx, "CDREPO", cfg.Server, r)
 }
 
 func main() {
-	ctx := context.Background()
+	ctx, stop := common.SignalContext()
 	// load config path from flag
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/cmd/digitaltwinregistryservice/config.yaml
+++ b/cmd/digitaltwinregistryservice/config.yaml
@@ -4,6 +4,11 @@ server:
   host: 0.0.0.0
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/digitaltwinregistryservice/config.yaml
+++ b/cmd/digitaltwinregistryservice/config.yaml
@@ -5,8 +5,8 @@ server:
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/digitaltwinregistryservice/main.go
+++ b/cmd/digitaltwinregistryservice/main.go
@@ -31,7 +31,6 @@ import (
 	"context"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -200,28 +199,21 @@ func runServer(ctx context.Context, configPath string) error {
 
 	r.Mount(base, apiRouter)
 
-	addr := fmt.Sprintf("0.0.0.0:%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("▶️ Digital Twin Registry listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
 
-	go func() {
-		//nolint:gosec // implementing this fix would cause errors.
-		if err := http.ListenAndServe(addr, r); err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
-
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	return nil
+	return common.RunHTTPServer(ctx, "DTR", cfg.Server, r)
 }
 
 func main() {
-	ctx := context.Background()
+	ctx, stop := common.SignalContext()
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/cmd/discoveryservice/config.yaml
+++ b/cmd/discoveryservice/config.yaml
@@ -4,6 +4,11 @@ server:
   host: 0.0.0.0
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/discoveryservice/config.yaml
+++ b/cmd/discoveryservice/config.yaml
@@ -5,8 +5,8 @@ server:
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/discoveryservice/main.go
+++ b/cmd/discoveryservice/main.go
@@ -31,9 +31,7 @@ import (
 	"context"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
@@ -143,30 +141,21 @@ func runServer(ctx context.Context, configPath string) error {
 	// Mount protected API under base path
 	r.Mount(base, apiRouter)
 
-	// === Start Server ===
-	addr := fmt.Sprintf("0.0.0.0:%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("▶️ AAS Discovery listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
 
-	// Start server in a goroutine
-	go func() {
-		//nolint:gosec // implementing this fix would cause errors.
-		if err := http.ListenAndServe(addr, r); err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
-
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	return nil
+	return common.RunHTTPServer(ctx, "DISCOVERY", cfg.Server, r)
 }
 
 func main() {
-	ctx := context.Background()
+	ctx, stop := common.SignalContext()
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/cmd/dppapiservice/config.yaml
+++ b/cmd/dppapiservice/config.yaml
@@ -3,8 +3,8 @@ server:
   contextPath: ""
   host: 0.0.0.0
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/dppapiservice/config.yaml
+++ b/cmd/dppapiservice/config.yaml
@@ -2,6 +2,11 @@ server:
   port: 8080
   contextPath: ""
   host: 0.0.0.0
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/dppapiservice/main.go
+++ b/cmd/dppapiservice/main.go
@@ -32,12 +32,7 @@ import (
 	"database/sql"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	aasrepositorydb "github.com/eclipse-basyx/basyx-go-components/internal/aasrepository/persistence"
@@ -61,7 +56,7 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 
-	addr := fmt.Sprintf("0.0.0.0:%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 
 	dsn := common.BuildPostgresDSN(cfg.Postgres)
 	sharedDB, err := openSharedDatabase(ctx, cfg, dsn)
@@ -84,30 +79,8 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 
-	server := &http.Server{
-		Addr:              addr,
-		Handler:           router,
-		ReadHeaderTimeout: 15 * time.Second,
-		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      30 * time.Second,
-		IdleTimeout:       60 * time.Second,
-	}
-
 	log.Printf("Server started on %s", addr)
-	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
-
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-	defer cancel()
-	if err := server.Shutdown(shutdownCtx); err != nil {
-		return fmt.Errorf("DPP-SRV-SHUTDOWN %w", err)
-	}
-	return nil
+	return common.RunHTTPServer(ctx, "DPP", cfg.Server, router)
 }
 
 func openSharedDatabase(ctx context.Context, cfg *common.Config, dsn string) (*sql.DB, error) {
@@ -138,7 +111,7 @@ func configurePostgresPool(db *sql.DB, cfg common.PostgresConfig) {
 }
 
 func main() {
-	ctx, stop := signal.NotifyContext(context.TODO(), os.Interrupt, syscall.SIGTERM)
+	ctx, stop := common.SignalContext()
 
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")

--- a/cmd/submodelregistryservice/config.yaml
+++ b/cmd/submodelregistryservice/config.yaml
@@ -4,6 +4,11 @@ server:
   host: 0.0.0.0
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/submodelregistryservice/config.yaml
+++ b/cmd/submodelregistryservice/config.yaml
@@ -5,8 +5,8 @@ server:
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/submodelregistryservice/main.go
+++ b/cmd/submodelregistryservice/main.go
@@ -31,7 +31,6 @@ import (
 	"context"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -167,30 +166,22 @@ func runServer(ctx context.Context, configPath string) error {
 	// Mount protected API under base path
 	r.Mount(base, apiRouter)
 
-	addr := "0.0.0.0:" + fmt.Sprintf("%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("▶️ Submodel Registry listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
 
-	// Start server in a goroutine
-	go func() {
-		//nolint:gosec // implementing this fix would cause errors.
-		if err := http.ListenAndServe(addr, r); err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
-
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	return nil
+	return common.RunHTTPServer(ctx, "SMR", cfg.Server, r)
 }
 
 func main() {
-	ctx := context.Background()
+	ctx, stop := common.SignalContext()
 
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/cmd/submodelrepositoryservice/config.yaml
+++ b/cmd/submodelrepositoryservice/config.yaml
@@ -4,6 +4,11 @@ server:
   host: 0.0.0.0
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
+  readHeaderTimeoutSeconds: 15
+  readTimeoutSeconds: 30
+  writeTimeoutSeconds: 30
+  idleTimeoutSeconds: 60
+  shutdownTimeoutSeconds: 10
 
 postgres:
   # Choose exactly one connection variant:

--- a/cmd/submodelrepositoryservice/config.yaml
+++ b/cmd/submodelrepositoryservice/config.yaml
@@ -5,8 +5,8 @@ server:
   strictVerification: permissive  # Values: off|permissive|strict (default: permissive)
   verificationEndpointAvailable: true
   readHeaderTimeoutSeconds: 15
-  readTimeoutSeconds: 30
-  writeTimeoutSeconds: 30
+  readTimeoutSeconds: 300
+  writeTimeoutSeconds: 300
   idleTimeoutSeconds: 60
   shutdownTimeoutSeconds: 10
 

--- a/cmd/submodelrepositoryservice/main.go
+++ b/cmd/submodelrepositoryservice/main.go
@@ -31,7 +31,6 @@ import (
 	"crypto/rsa"
 	"embed"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -227,32 +226,24 @@ func runServer(ctx context.Context, configPath string) error {
 	// Mount protected API under base path
 	r.Mount(base, apiRouter)
 
-	// Start the server
-	addr := "0.0.0.0:" + fmt.Sprintf("%d", cfg.Server.Port)
+	addr := common.ServerAddress(cfg.Server)
 	log.Printf("▶️  Submodel Repository listening on %s (contextPath=%q)\n", addr, cfg.Server.ContextPath)
-	// Start server in a goroutine
-	go func() {
-		//nolint:gosec // implementing this fix would cause errors.
-		if err := http.ListenAndServe(addr, r); err != http.ErrServerClosed {
-			log.Printf("Server error: %v", err)
-		}
-	}()
 
 	// submodelrepository.TestNewSubmodelHandler(smDatabase)
 
-	<-ctx.Done()
-	log.Println("Shutting down server...")
-	return nil
+	return common.RunHTTPServer(ctx, "SMREPO", cfg.Server, r)
 }
 
 func main() {
-	ctx := context.Background()
+	ctx, stop := common.SignalContext()
 	// load config path from flag
 	configPath := ""
 	flag.StringVar(&configPath, "config", "", "Path to config file")
 	flag.Parse()
 
 	if err := runServer(ctx, configPath); err != nil {
+		stop()
 		log.Fatalf("Server error: %v", err)
 	}
+	stop()
 }

--- a/docu/developer/review-prompt.md
+++ b/docu/developer/review-prompt.md
@@ -1,0 +1,112 @@
+# Senior Engineering PR Review Prompt
+
+Review this Pull Request as a Senior Software Engineer for the BaSyx Go components repository.
+
+Follow the repository instructions in `AGENTS.md` and review the actual diff, not just the PR description. Focus only on actionable issues that should be addressed before merging.
+
+## Review Priorities
+
+### Correctness
+
+Check for:
+
+- Functional bugs and behavioral regressions
+- Edge cases, nil handling, empty inputs, cancellation paths, and shutdown paths
+- Race conditions, goroutine leaks, resource leaks, and unbounded waits
+- Broken context propagation, especially use of `context.Background()` in live code
+- Error handling that drops root causes or returns uncoded errors
+- Breaking changes to public APIs, config keys, OpenAPI behavior, routes, response shapes, or database behavior
+
+### Security
+
+Check for:
+
+- Missing authentication or authorization checks
+- ABAC/OIDC/security middleware accidentally bypassed
+- Insecure HTTP/client/server defaults, missing timeouts, unbounded request bodies, unsafe redirects, SSRF risks
+- Sensitive data exposure in logs, responses, config printing, errors, or tests
+- SQL injection or unsafe query construction
+- Use of plain SQL where GOQU should be used
+- Unsafe file/path handling, archive extraction, upload/download behavior, or trust boundary mistakes
+
+### Database And Persistence
+
+Check for:
+
+- Schema changes not reflected in `basyxschema.sql`
+- Queryable columns added to `*_payload` tables
+- Missing transactions, incorrect rollback/commit behavior, lock ordering issues
+- Inefficient queries, N+1 patterns, missing pagination, unbounded scans
+- Incorrect history/audit/recent-changes behavior
+
+### Clean Code And Architecture
+
+Check for:
+
+- Duplicated logic that should live in `internal/common` or existing local helpers
+- Large or complex functions, deep nesting, unclear names, dead code
+- Unnecessary abstractions or coupling across components
+- Code that violates established package boundaries or local patterns
+- Comments used to explain unclear code instead of simplifying the code
+- Missing or weak GoDoc on exported functions, types, constants, or variables
+
+### Configuration And Compatibility
+
+Check for:
+
+- New config fields missing defaults, validation, env support, docs/templates, or printed config behavior
+- Changed defaults that may break deployments
+- Service-specific config drift across equivalent components
+- Mismatches between command services that should follow the same lifecycle/security pattern
+
+### Testing
+
+Check for:
+
+- Missing regression tests for the changed behavior
+- Missing integration tests where service behavior, DB behavior, or HTTP behavior changes
+- Tests that use caches, narrow flags, brittle sleeps, leaked containers, or non-deterministic ports
+- Insufficient negative tests for invalid config, malformed input, unauthorized access, cancellation, or failure paths
+
+## Repo-Specific Rules To Enforce
+
+- Go code must use GOQU for SQL query construction. Do not accept new plain-text SQL query construction unless there is an established exception.
+- Errors should include coded prefixes in the project style, for example `SMREPO-UPDPROP-EXECDBQUERY`.
+- Live code must not use `context.Background()`; pass a caller/request/signal-aware context. Unit tests may create their own context.
+- Own `.go` files must include the project license header. Generated files may follow their generator's established header pattern.
+- Public Go symbols must have useful GoDoc. For exported functions, check that docs explain parameters, return values, and include a short example snippet when it materially improves correct usage.
+- Database schema changes must update `basyxschema.sql`.
+- Queryable columns must not be added to `*_payload` tables.
+- Service changes should stay aligned across equivalent production services.
+- Prefer existing helpers and patterns over new one-off implementations.
+- Pay special attention to security, scalability, and performance.
+
+## Suggested Multi-Pass Review
+
+If subagents or parallel review passes are available, split the review into:
+
+1. Security and lifecycle pass
+   - Auth, ABAC/OIDC, context propagation, HTTP timeouts, graceful shutdown, logging, sensitive data, request limits.
+2. Data and API pass
+   - DB/schema/query behavior, GOQU usage, transactions, API compatibility, config compatibility, OpenAPI/routes.
+3. Maintainability and test pass
+   - DRY, package boundaries, complexity, naming, missing tests, flaky tests, integration test coverage.
+
+The final reviewer should merge duplicate findings and report only issues with concrete evidence.
+
+## Output Format
+
+Only report actionable findings. Do not praise code. Do not summarize what is already good.
+
+For each finding, provide:
+
+- **Severity:** Critical / High / Medium / Low
+- **Location:** file and line
+- **Explanation:** why this is a real issue
+- **Suggested fix:** concrete remediation
+
+Order findings by severity. If there are no actionable findings, say:
+
+> No actionable findings found.
+
+Then list any residual test gaps or review limitations briefly.

--- a/internal/common/configuration.go
+++ b/internal/common/configuration.go
@@ -121,8 +121,8 @@ var DefaultConfig = struct {
 	ServerStrictVerification:            defaultServerStrictVerification,
 	ServerVerificationEndpointAvailable: true,
 	ServerReadHeaderTimeoutSeconds:      15,
-	ServerReadTimeoutSeconds:            30,
-	ServerWriteTimeoutSeconds:           30,
+	ServerReadTimeoutSeconds:            300,
+	ServerWriteTimeoutSeconds:           300,
 	ServerIdleTimeoutSeconds:            60,
 	ServerShutdownTimeoutSeconds:        10,
 	PgPort:                              5432,
@@ -486,6 +486,7 @@ func LoadConfig(configPath string, configMode ConfigMode) (*Config, error) {
 	}
 	cfg.Server.StrictVerification = string(verificationMode)
 	applyAASPreconfigPathOverrides(cfg)
+	applyServerEnvOverrides(cfg)
 	applyGeneralEnvOverrides(cfg)
 	if err = validatePostgresConfig(v, cfg.Postgres); err != nil {
 		return nil, err
@@ -522,6 +523,32 @@ func applyGeneralEnvOverrides(cfg *Config) {
 			cfg.General.BulkBatchLimit = parsed
 		}
 	}
+}
+
+func applyServerEnvOverrides(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	applyFirstIntEnv(func(value int) { cfg.Server.ReadHeaderTimeoutSeconds = value },
+		"SERVER_READ_HEADER_TIMEOUT_SECONDS",
+		"BASYX_SERVER_READ_HEADER_TIMEOUT_SECONDS",
+	)
+	applyFirstIntEnv(func(value int) { cfg.Server.ReadTimeoutSeconds = value },
+		"SERVER_READ_TIMEOUT_SECONDS",
+		"BASYX_SERVER_READ_TIMEOUT_SECONDS",
+	)
+	applyFirstIntEnv(func(value int) { cfg.Server.WriteTimeoutSeconds = value },
+		"SERVER_WRITE_TIMEOUT_SECONDS",
+		"BASYX_SERVER_WRITE_TIMEOUT_SECONDS",
+	)
+	applyFirstIntEnv(func(value int) { cfg.Server.IdleTimeoutSeconds = value },
+		"SERVER_IDLE_TIMEOUT_SECONDS",
+		"BASYX_SERVER_IDLE_TIMEOUT_SECONDS",
+	)
+	applyFirstIntEnv(func(value int) { cfg.Server.ShutdownTimeoutSeconds = value },
+		"SERVER_SHUTDOWN_TIMEOUT_SECONDS",
+		"BASYX_SERVER_SHUTDOWN_TIMEOUT_SECONDS",
+	)
 }
 
 func validateGeneralConfig(cfg *Config) error {
@@ -944,6 +971,17 @@ func applyIntEnv(key string, assign func(int)) {
 	}
 }
 
+func applyFirstIntEnv(assign func(int), keys ...string) {
+	value, ok := lookupFirstTrimmedEnv(keys...)
+	if !ok {
+		return
+	}
+	var parsed int
+	if _, err := fmt.Sscanf(value, "%d", &parsed); err == nil {
+		assign(parsed)
+	}
+}
+
 func parseCommaSeparated(rawValue string) []string {
 	parts := strings.Split(rawValue, ",")
 	values := make([]string, 0, len(parts))
@@ -1005,7 +1043,7 @@ func normalizeAASPreconfigPaths(rawPaths []string) []string {
 //   - v: Viper instance to configure with default values
 //
 // Default values include:
-//   - Server: Port 5004, no context path, caching disabled
+//   - Server: Port 5004, no context path, caching disabled, bounded HTTP timeouts
 //   - Database: Local PostgreSQL on port 5432 with test credentials
 //   - CORS: Permissive policy allowing all origins and common methods
 //   - OIDC: Local Keycloak realm configuration

--- a/internal/common/configuration.go
+++ b/internal/common/configuration.go
@@ -49,11 +49,17 @@ const defaultServerStrictVerification = string(commonmodel.VerificationModePermi
 // DefaultConfig holds all default values for configuration options.
 // These values are also used to mark default values in the printed configuration.
 var DefaultConfig = struct {
+	ServerHost                          string
 	ServerPort                          int
 	ServerContextPath                   string
 	ServerCacheEnabled                  bool
 	ServerStrictVerification            string
 	ServerVerificationEndpointAvailable bool
+	ServerReadHeaderTimeoutSeconds      int
+	ServerReadTimeoutSeconds            int
+	ServerWriteTimeoutSeconds           int
+	ServerIdleTimeoutSeconds            int
+	ServerShutdownTimeoutSeconds        int
 	PgPort                              int
 	PgDBName                            string
 	PgSSLMode                           string
@@ -108,11 +114,17 @@ var DefaultConfig = struct {
 	EventingTopicPrefix                 string
 	SwaggerEnabled                      bool
 }{
+	ServerHost:                          "0.0.0.0",
 	ServerPort:                          5004,
 	ServerContextPath:                   "",
 	ServerCacheEnabled:                  false,
 	ServerStrictVerification:            defaultServerStrictVerification,
 	ServerVerificationEndpointAvailable: true,
+	ServerReadHeaderTimeoutSeconds:      15,
+	ServerReadTimeoutSeconds:            30,
+	ServerWriteTimeoutSeconds:           30,
+	ServerIdleTimeoutSeconds:            60,
+	ServerShutdownTimeoutSeconds:        10,
 	PgPort:                              5432,
 	PgDBName:                            "basyxTestDB",
 	PgSSLMode:                           "disable",
@@ -307,12 +319,17 @@ type SwaggerConfig struct {
 
 // ServerConfig contains HTTP server configuration parameters.
 type ServerConfig struct {
-	Host                          string `mapstructure:"host" yaml:"host"`                                                   // HTTP server host (default: 0.0.0.0)
-	Port                          int    `mapstructure:"port" yaml:"port"`                                                   // HTTP server port (default: 5004)
-	ContextPath                   string `mapstructure:"contextPath" yaml:"contextPath"`                                     // Base path for all endpoints
-	CacheEnabled                  bool   `mapstructure:"cacheEnabled" yaml:"cacheEnabled"`                                   // Enable/disable response caching
-	StrictVerification            string `mapstructure:"strictVerification" yaml:"strictVerification"`                       // Verification mode: off|permissive|strict (default: permissive)
-	VerificationEndpointAvailable bool   `mapstructure:"verificationEndpointAvailable" yaml:"verificationEndpointAvailable"` // Enable/disable verification endpoint
+	Host                          string `mapstructure:"host" yaml:"host"`                                                                         // HTTP server host (default: 0.0.0.0)
+	Port                          int    `mapstructure:"port" yaml:"port"`                                                                         // HTTP server port (default: 5004)
+	ContextPath                   string `mapstructure:"contextPath" yaml:"contextPath"`                                                           // Base path for all endpoints
+	CacheEnabled                  bool   `mapstructure:"cacheEnabled" yaml:"cacheEnabled"`                                                         // Enable/disable response caching
+	StrictVerification            string `mapstructure:"strictVerification" yaml:"strictVerification"`                                             // Verification mode: off|permissive|strict (default: permissive)
+	VerificationEndpointAvailable bool   `mapstructure:"verificationEndpointAvailable" yaml:"verificationEndpointAvailable"`                       // Enable/disable verification endpoint
+	ReadHeaderTimeoutSeconds      int    `mapstructure:"readHeaderTimeoutSeconds" yaml:"readHeaderTimeoutSeconds" json:"readHeaderTimeoutSeconds"` // Maximum time to read request headers
+	ReadTimeoutSeconds            int    `mapstructure:"readTimeoutSeconds" yaml:"readTimeoutSeconds" json:"readTimeoutSeconds"`                   // Maximum time to read an entire request
+	WriteTimeoutSeconds           int    `mapstructure:"writeTimeoutSeconds" yaml:"writeTimeoutSeconds" json:"writeTimeoutSeconds"`                // Maximum time before timing out response writes
+	IdleTimeoutSeconds            int    `mapstructure:"idleTimeoutSeconds" yaml:"idleTimeoutSeconds" json:"idleTimeoutSeconds"`                   // Maximum idle keep-alive connection time
+	ShutdownTimeoutSeconds        int    `mapstructure:"shutdownTimeoutSeconds" yaml:"shutdownTimeoutSeconds" json:"shutdownTimeoutSeconds"`       // Maximum graceful shutdown wait time
 }
 
 // PostgresConfig contains PostgreSQL database connection parameters.
@@ -473,6 +490,9 @@ func LoadConfig(configPath string, configMode ConfigMode) (*Config, error) {
 	if err = validatePostgresConfig(v, cfg.Postgres); err != nil {
 		return nil, err
 	}
+	if err = validateServerConfig(cfg.Server); err != nil {
+		return nil, err
+	}
 	applyABACEnvOverrides(cfg)
 	if err = validateGeneralConfig(cfg); err != nil {
 		return nil, err
@@ -510,6 +530,22 @@ func validateGeneralConfig(cfg *Config) error {
 	}
 	if cfg.General.BulkBatchLimit <= 0 {
 		return fmt.Errorf("CONFIG-GENERAL-BULKBATCHLIMIT general.bulkBatchLimit must be greater than 0")
+	}
+	return nil
+}
+
+func validateServerConfig(cfg ServerConfig) error {
+	timeouts := map[string]int{
+		"server.readHeaderTimeoutSeconds": cfg.ReadHeaderTimeoutSeconds,
+		"server.readTimeoutSeconds":       cfg.ReadTimeoutSeconds,
+		"server.writeTimeoutSeconds":      cfg.WriteTimeoutSeconds,
+		"server.idleTimeoutSeconds":       cfg.IdleTimeoutSeconds,
+		"server.shutdownTimeoutSeconds":   cfg.ShutdownTimeoutSeconds,
+	}
+	for key, value := range timeouts {
+		if value <= 0 {
+			return fmt.Errorf("CONFIG-SERVER-TIMEOUT %s must be greater than 0", key)
+		}
 	}
 	return nil
 }
@@ -976,12 +1012,17 @@ func normalizeAASPreconfigPaths(rawPaths []string) []string {
 //   - ABAC: Disabled by default
 func setDefaults(v *viper.Viper) {
 	// Server defaults
-	v.SetDefault("server.host", "0.0.0.0")
-	v.SetDefault("server.port", 5004)
+	v.SetDefault("server.host", DefaultConfig.ServerHost)
+	v.SetDefault("server.port", DefaultConfig.ServerPort)
 	v.SetDefault("server.contextPath", "")
 	v.SetDefault("server.cacheEnabled", false)
 	v.SetDefault("server.strictVerification", DefaultConfig.ServerStrictVerification)
-	v.SetDefault("server.verificationEndpointAvailable", true)
+	v.SetDefault("server.verificationEndpointAvailable", DefaultConfig.ServerVerificationEndpointAvailable)
+	v.SetDefault("server.readHeaderTimeoutSeconds", DefaultConfig.ServerReadHeaderTimeoutSeconds)
+	v.SetDefault("server.readTimeoutSeconds", DefaultConfig.ServerReadTimeoutSeconds)
+	v.SetDefault("server.writeTimeoutSeconds", DefaultConfig.ServerWriteTimeoutSeconds)
+	v.SetDefault("server.idleTimeoutSeconds", DefaultConfig.ServerIdleTimeoutSeconds)
+	v.SetDefault("server.shutdownTimeoutSeconds", DefaultConfig.ServerShutdownTimeoutSeconds)
 
 	// PostgreSQL defaults
 	v.SetDefault("postgres.host", "db")
@@ -1119,11 +1160,17 @@ func PrintConfiguration(cfg *Config) {
 
 	// Server
 	lines = append(lines, "🔹 Server:")
+	add("Host", cfg.Server.Host, DefaultConfig.ServerHost)
 	add("Port", cfg.Server.Port, DefaultConfig.ServerPort)
 	add("Context Path", cfg.Server.ContextPath, DefaultConfig.ServerContextPath)
 	add("Cache Enabled", cfg.Server.CacheEnabled, DefaultConfig.ServerCacheEnabled)
 	add("Verification Mode", cfg.Server.StrictVerification, DefaultConfig.ServerStrictVerification)
 	add("Verification Endpoint Available", cfg.Server.VerificationEndpointAvailable, DefaultConfig.ServerVerificationEndpointAvailable)
+	add("Read Header Timeout (s)", cfg.Server.ReadHeaderTimeoutSeconds, DefaultConfig.ServerReadHeaderTimeoutSeconds)
+	add("Read Timeout (s)", cfg.Server.ReadTimeoutSeconds, DefaultConfig.ServerReadTimeoutSeconds)
+	add("Write Timeout (s)", cfg.Server.WriteTimeoutSeconds, DefaultConfig.ServerWriteTimeoutSeconds)
+	add("Idle Timeout (s)", cfg.Server.IdleTimeoutSeconds, DefaultConfig.ServerIdleTimeoutSeconds)
+	add("Shutdown Timeout (s)", cfg.Server.ShutdownTimeoutSeconds, DefaultConfig.ServerShutdownTimeoutSeconds)
 
 	lines = append(lines, divider)
 

--- a/internal/common/http_server.go
+++ b/internal/common/http_server.go
@@ -48,12 +48,17 @@ type HTTPServerRunner struct {
 	serveErr        chan error
 }
 
-// SignalContext returns a context that is canceled on process interrupt or SIGTERM.
+// SignalContext returns a context that is canceled when the process receives
+// os.Interrupt or SIGTERM, plus the cancel function returned by
+// signal.NotifyContext. Callers should defer the cancel function in main so the
+// signal handler is released when the service exits.
 func SignalContext() (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(context.TODO(), os.Interrupt, syscall.SIGTERM)
 }
 
-// ServerAddress returns the configured HTTP listen address.
+// ServerAddress returns the HTTP listen address from cfg.Host and cfg.Port.
+// Blank hosts are treated as the BaSyx default host, and the returned value is
+// formatted with net.JoinHostPort so IPv6 hosts are bracketed correctly.
 func ServerAddress(cfg ServerConfig) string {
 	host := strings.TrimSpace(cfg.Host)
 	if host == "" {
@@ -63,7 +68,15 @@ func ServerAddress(cfg ServerConfig) string {
 }
 
 // NewConfiguredHTTPServer creates an HTTP server with BaSyx timeout defaults.
-func NewConfiguredHTTPServer(cfg ServerConfig, handler http.Handler) *http.Server {
+// The ctx parameter becomes the base context for accepted connections, allowing
+// request handlers to observe service shutdown through r.Context(). The cfg
+// parameter supplies the listen address and timeout values; unset timeout values
+// use secure BaSyx defaults. The returned server is not started.
+func NewConfiguredHTTPServer(ctx context.Context, cfg ServerConfig, handler http.Handler) *http.Server {
+	baseCtx := ctx
+	if baseCtx == nil {
+		baseCtx = context.TODO()
+	}
 	return &http.Server{
 		Addr:              ServerAddress(cfg),
 		Handler:           handler,
@@ -71,27 +84,63 @@ func NewConfiguredHTTPServer(cfg ServerConfig, handler http.Handler) *http.Serve
 		ReadTimeout:       serverTimeout(cfg.ReadTimeoutSeconds, DefaultConfig.ServerReadTimeoutSeconds),
 		WriteTimeout:      serverTimeout(cfg.WriteTimeoutSeconds, DefaultConfig.ServerWriteTimeoutSeconds),
 		IdleTimeout:       serverTimeout(cfg.IdleTimeoutSeconds, DefaultConfig.ServerIdleTimeoutSeconds),
+		BaseContext: func(net.Listener) context.Context {
+			return baseCtx
+		},
 	}
 }
 
-// StartHTTPServer starts a configured HTTP server in a managed goroutine.
-func StartHTTPServer(serviceCode string, cfg ServerConfig, handler http.Handler) *HTTPServerRunner {
+// StartHTTPServer binds and starts a configured HTTP server in a managed
+// goroutine. The serviceCode parameter is normalized and used as the prefix for
+// coded RUNSERVER errors. The ctx parameter is propagated to request contexts
+// and is later passed to Wait to trigger graceful shutdown. The returned runner
+// has already bound its listener; startup failures are returned immediately.
+func StartHTTPServer(ctx context.Context, serviceCode string, cfg ServerConfig, handler http.Handler) (*HTTPServerRunner, error) {
+	normalizedServiceCode := normalizeServiceCode(serviceCode)
+	if ctx == nil {
+		return nil, fmt.Errorf("%s-RUNSERVER-CONTEXT context must not be nil", normalizedServiceCode)
+	}
+	server := NewConfiguredHTTPServer(ctx, cfg, handler)
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		return nil, fmt.Errorf("%s-RUNSERVER-LISTEN %w", normalizedServiceCode, err)
+	}
+	server.Addr = listener.Addr().String()
 	runner := &HTTPServerRunner{
-		server:          NewConfiguredHTTPServer(cfg, handler),
-		serviceCode:     normalizeServiceCode(serviceCode),
+		server:          server,
+		serviceCode:     normalizedServiceCode,
 		shutdownTimeout: serverTimeout(cfg.ShutdownTimeoutSeconds, DefaultConfig.ServerShutdownTimeoutSeconds),
 		serveErr:        make(chan error, 1),
 	}
-	go runner.listenAndServe()
-	return runner
+	go runner.serve(listener)
+	return runner, nil
 }
 
-// RunHTTPServer starts a configured HTTP server and blocks until it stops.
+// RunHTTPServer starts a configured HTTP server and blocks until it stops. The
+// ctx parameter is used both as the server base context and as the cancellation
+// signal for graceful shutdown. The serviceCode parameter prefixes coded listen,
+// shutdown, and context errors. The cfg parameter controls address and timeout
+// values; the handler parameter serves all HTTP requests.
+//
+// Example:
+//
+//	ctx, stop := common.SignalContext()
+//	defer stop()
+//	if err := common.RunHTTPServer(ctx, "AASR", cfg.Server, router); err != nil {
+//		log.Fatal(err)
+//	}
 func RunHTTPServer(ctx context.Context, serviceCode string, cfg ServerConfig, handler http.Handler) error {
-	return StartHTTPServer(serviceCode, cfg, handler).Wait(ctx)
+	runner, err := StartHTTPServer(ctx, serviceCode, cfg, handler)
+	if err != nil {
+		return err
+	}
+	return runner.Wait(ctx)
 }
 
-// Wait blocks until the server fails to start, stops externally, or ctx is canceled.
+// Wait blocks until the server stops externally or ctx is canceled. A canceled
+// ctx starts graceful shutdown with the runner's configured shutdown timeout.
+// The returned error is nil on clean shutdown or includes the normalized service
+// code when listen, shutdown, or context handling fails.
 func (runner *HTTPServerRunner) Wait(ctx context.Context) error {
 	if runner == nil || runner.server == nil {
 		return fmt.Errorf("HTTP-RUNSERVER-CONTEXT server runner must not be nil")
@@ -109,8 +158,8 @@ func (runner *HTTPServerRunner) Wait(ctx context.Context) error {
 	}
 }
 
-func (runner *HTTPServerRunner) listenAndServe() {
-	err := runner.server.ListenAndServe()
+func (runner *HTTPServerRunner) serve(listener net.Listener) {
+	err := runner.server.Serve(listener)
 	if errors.Is(err, http.ErrServerClosed) {
 		runner.serveErr <- nil
 		return

--- a/internal/common/http_server.go
+++ b/internal/common/http_server.go
@@ -149,6 +149,10 @@ func (runner *HTTPServerRunner) Wait(ctx context.Context) error {
 		return fmt.Errorf("%s-RUNSERVER-CONTEXT context must not be nil", runner.serviceCode)
 	}
 
+	if ok, err := runner.pollServeError(); ok {
+		return runner.listenError(err)
+	}
+
 	select {
 	case err := <-runner.serveErr:
 		return runner.listenError(err)
@@ -172,6 +176,12 @@ func (runner *HTTPServerRunner) shutdown(ctx context.Context) error {
 	defer cancel()
 
 	if err := runner.server.Shutdown(shutdownCtx); err != nil {
+		if ok, serveErr := runner.pollServeError(); ok {
+			return runner.listenError(serveErr)
+		}
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
 		return fmt.Errorf("%s-RUNSERVER-SHUTDOWN %w", runner.serviceCode, err)
 	}
 
@@ -180,6 +190,15 @@ func (runner *HTTPServerRunner) shutdown(ctx context.Context) error {
 		return runner.listenError(err)
 	case <-shutdownCtx.Done():
 		return fmt.Errorf("%s-RUNSERVER-SHUTDOWN %w", runner.serviceCode, shutdownCtx.Err())
+	}
+}
+
+func (runner *HTTPServerRunner) pollServeError() (bool, error) {
+	select {
+	case err := <-runner.serveErr:
+		return true, err
+	default:
+		return false, nil
 	}
 }
 

--- a/internal/common/http_server.go
+++ b/internal/common/http_server.go
@@ -1,0 +1,157 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// HTTPServerRunner manages one configured HTTP server instance.
+type HTTPServerRunner struct {
+	server          *http.Server
+	serviceCode     string
+	shutdownTimeout time.Duration
+	serveErr        chan error
+}
+
+// SignalContext returns a context that is canceled on process interrupt or SIGTERM.
+func SignalContext() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(context.TODO(), os.Interrupt, syscall.SIGTERM)
+}
+
+// ServerAddress returns the configured HTTP listen address.
+func ServerAddress(cfg ServerConfig) string {
+	host := strings.TrimSpace(cfg.Host)
+	if host == "" {
+		host = DefaultConfig.ServerHost
+	}
+	return net.JoinHostPort(host, strconv.Itoa(cfg.Port))
+}
+
+// NewConfiguredHTTPServer creates an HTTP server with BaSyx timeout defaults.
+func NewConfiguredHTTPServer(cfg ServerConfig, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              ServerAddress(cfg),
+		Handler:           handler,
+		ReadHeaderTimeout: serverTimeout(cfg.ReadHeaderTimeoutSeconds, DefaultConfig.ServerReadHeaderTimeoutSeconds),
+		ReadTimeout:       serverTimeout(cfg.ReadTimeoutSeconds, DefaultConfig.ServerReadTimeoutSeconds),
+		WriteTimeout:      serverTimeout(cfg.WriteTimeoutSeconds, DefaultConfig.ServerWriteTimeoutSeconds),
+		IdleTimeout:       serverTimeout(cfg.IdleTimeoutSeconds, DefaultConfig.ServerIdleTimeoutSeconds),
+	}
+}
+
+// StartHTTPServer starts a configured HTTP server in a managed goroutine.
+func StartHTTPServer(serviceCode string, cfg ServerConfig, handler http.Handler) *HTTPServerRunner {
+	runner := &HTTPServerRunner{
+		server:          NewConfiguredHTTPServer(cfg, handler),
+		serviceCode:     normalizeServiceCode(serviceCode),
+		shutdownTimeout: serverTimeout(cfg.ShutdownTimeoutSeconds, DefaultConfig.ServerShutdownTimeoutSeconds),
+		serveErr:        make(chan error, 1),
+	}
+	go runner.listenAndServe()
+	return runner
+}
+
+// RunHTTPServer starts a configured HTTP server and blocks until it stops.
+func RunHTTPServer(ctx context.Context, serviceCode string, cfg ServerConfig, handler http.Handler) error {
+	return StartHTTPServer(serviceCode, cfg, handler).Wait(ctx)
+}
+
+// Wait blocks until the server fails to start, stops externally, or ctx is canceled.
+func (runner *HTTPServerRunner) Wait(ctx context.Context) error {
+	if runner == nil || runner.server == nil {
+		return fmt.Errorf("HTTP-RUNSERVER-CONTEXT server runner must not be nil")
+	}
+	if ctx == nil {
+		return fmt.Errorf("%s-RUNSERVER-CONTEXT context must not be nil", runner.serviceCode)
+	}
+
+	select {
+	case err := <-runner.serveErr:
+		return runner.listenError(err)
+	case <-ctx.Done():
+		log.Println("Shutting down server...")
+		return runner.shutdown(ctx)
+	}
+}
+
+func (runner *HTTPServerRunner) listenAndServe() {
+	err := runner.server.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) {
+		runner.serveErr <- nil
+		return
+	}
+	runner.serveErr <- err
+}
+
+func (runner *HTTPServerRunner) shutdown(ctx context.Context) error {
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), runner.shutdownTimeout)
+	defer cancel()
+
+	if err := runner.server.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("%s-RUNSERVER-SHUTDOWN %w", runner.serviceCode, err)
+	}
+
+	select {
+	case err := <-runner.serveErr:
+		return runner.listenError(err)
+	case <-shutdownCtx.Done():
+		return fmt.Errorf("%s-RUNSERVER-SHUTDOWN %w", runner.serviceCode, shutdownCtx.Err())
+	}
+}
+
+func (runner *HTTPServerRunner) listenError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s-RUNSERVER-LISTEN %w", runner.serviceCode, err)
+}
+
+func serverTimeout(seconds int, defaultSeconds int) time.Duration {
+	if seconds <= 0 {
+		seconds = defaultSeconds
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func normalizeServiceCode(serviceCode string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(serviceCode))
+	if normalized == "" {
+		return "HTTP"
+	}
+	return normalized
+}

--- a/internal/common/http_server_test.go
+++ b/internal/common/http_server_test.go
@@ -195,6 +195,29 @@ func TestRunServerContextCancellationCancelsRequestContext(t *testing.T) {
 	}
 }
 
+func TestWaitReturnsQueuedServeErrorBeforeCanceledContext(t *testing.T) {
+	serveErr := make(chan error, 1)
+	serveErr <- fmt.Errorf("listener stopped")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	runner := &HTTPServerRunner{
+		server:      &http.Server{ReadHeaderTimeout: time.Second},
+		serviceCode: "TEST",
+		serveErr:    serveErr,
+	}
+
+	err := runner.Wait(ctx)
+	if err == nil {
+		t.Fatal("expected queued serve error")
+	}
+	if !strings.Contains(err.Error(), "TEST-RUNSERVER-LISTEN") {
+		t.Fatalf("expected TEST-RUNSERVER-LISTEN error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "listener stopped") {
+		t.Fatalf("expected queued serve error details, got %v", err)
+	}
+}
+
 func TestStartHTTPServerReturnsListenErrorBeforeServing(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/common/http_server_test.go
+++ b/internal/common/http_server_test.go
@@ -62,7 +62,7 @@ func TestNewConfiguredHTTPServerAppliesTimeouts(t *testing.T) {
 		ShutdownTimeoutSeconds:   5,
 	}
 
-	server := NewConfiguredHTTPServer(cfg, http.NewServeMux())
+	server := NewConfiguredHTTPServer(t.Context(), cfg, http.NewServeMux())
 
 	if server.Addr != "[::1]:8082" {
 		t.Fatalf("expected IPv6 address, got %q", server.Addr)
@@ -78,19 +78,22 @@ func TestNewConfiguredHTTPServerAppliesTimeouts(t *testing.T) {
 func TestNewConfiguredHTTPServerDefaultsZeroTimeouts(t *testing.T) {
 	cfg := ServerConfig{Port: 8083}
 
-	server := NewConfiguredHTTPServer(cfg, http.NewServeMux())
+	server := NewConfiguredHTTPServer(t.Context(), cfg, http.NewServeMux())
 
 	if server.ReadHeaderTimeout != 15*time.Second ||
-		server.ReadTimeout != 30*time.Second ||
-		server.WriteTimeout != 30*time.Second ||
+		server.ReadTimeout != 300*time.Second ||
+		server.WriteTimeout != 300*time.Second ||
 		server.IdleTimeout != 60*time.Second {
 		t.Fatalf("unexpected default server timeouts: %+v", server)
 	}
-	runner := StartHTTPServer("test", ServerConfig{Host: "127.0.0.1", Port: reserveHTTPServerTestPort(t)}, http.NotFoundHandler())
+	ctx, cancel := context.WithCancel(t.Context())
+	runner, err := StartHTTPServer(ctx, "test", ServerConfig{Host: "127.0.0.1"}, http.NotFoundHandler())
+	if err != nil {
+		t.Fatalf("unexpected start error: %v", err)
+	}
 	if runner.shutdownTimeout != 10*time.Second {
 		t.Fatalf("expected default shutdown timeout, got %v", runner.shutdownTimeout)
 	}
-	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	if err := runner.Wait(ctx); err != nil {
 		t.Fatalf("unexpected runner wait error: %v", err)
@@ -98,10 +101,8 @@ func TestNewConfiguredHTTPServerDefaultsZeroTimeouts(t *testing.T) {
 }
 
 func TestRunServerContextCancellationShutsDownHTTPServer(t *testing.T) {
-	port := reserveHTTPServerTestPort(t)
 	cfg := ServerConfig{
 		Host:                   "127.0.0.1",
-		Port:                   port,
 		ShutdownTimeoutSeconds: 1,
 	}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -110,13 +111,16 @@ func TestRunServerContextCancellationShutsDownHTTPServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	runner := StartHTTPServer("test", cfg, handler)
+	runner, err := StartHTTPServer(ctx, "test", cfg, handler)
+	if err != nil {
+		t.Fatalf("unexpected start error: %v", err)
+	}
 	waitErr := make(chan error, 1)
 	go func() {
 		waitErr <- runner.Wait(ctx)
 	}()
 
-	url := fmt.Sprintf("http://127.0.0.1:%d", port)
+	url := fmt.Sprintf("http://%s", runner.server.Addr)
 	waitForHTTPServer(t, url)
 	cancel()
 
@@ -130,39 +134,185 @@ func TestRunServerContextCancellationShutsDownHTTPServer(t *testing.T) {
 	}
 }
 
-func TestLoadConfigRejectsNonPositiveServerTimeout(t *testing.T) {
+func TestRunServerContextCancellationCancelsRequestContext(t *testing.T) {
+	cfg := ServerConfig{
+		Host:                   "127.0.0.1",
+		ShutdownTimeoutSeconds: 1,
+	}
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+		close(requestCanceled)
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	runner, err := StartHTTPServer(ctx, "test", cfg, handler)
+	if err != nil {
+		t.Fatalf("unexpected start error: %v", err)
+	}
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- runner.Wait(ctx)
+	}()
+
+	clientDone := make(chan struct{})
+	client := &http.Client{Timeout: 2 * time.Second}
+	go func() {
+		response, _ := client.Get(fmt.Sprintf("http://%s", runner.server.Addr))
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		close(clientDone)
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive request")
+	}
+	cancel()
+
+	select {
+	case <-requestCanceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request context was not canceled during shutdown")
+	}
+	select {
+	case err := <-waitErr:
+		if err != nil {
+			t.Fatalf("unexpected wait error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not shut down after request context cancellation")
+	}
+	select {
+	case <-clientDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client request did not finish")
+	}
+}
+
+func TestStartHTTPServerReturnsListenErrorBeforeServing(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind occupied listener: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	runner, err := StartHTTPServer(t.Context(), "test", ServerConfig{Host: "127.0.0.1", Port: port}, http.NotFoundHandler())
+	if err == nil {
+		t.Fatal("expected listen error for occupied port")
+	}
+	if runner != nil {
+		t.Fatal("expected nil runner on listen failure")
+	}
+	if !strings.Contains(err.Error(), "TEST-RUNSERVER-LISTEN") {
+		t.Fatalf("expected TEST-RUNSERVER-LISTEN error, got %v", err)
+	}
+}
+
+func TestLoadConfigAppliesServerTimeoutConfig(t *testing.T) {
+	unsetServerTimeoutEnv(t)
+	path := writeTempConfig(t, `server:
+  readHeaderTimeoutSeconds: 11
+  readTimeoutSeconds: 301
+  writeTimeoutSeconds: 302
+  idleTimeoutSeconds: 61
+  shutdownTimeoutSeconds: 12
+`)
+
+	cfg, err := LoadConfig(path, QUIET)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+
+	assertServerTimeouts(t, cfg.Server, 11, 301, 302, 61, 12)
+}
+
+func TestLoadConfigAppliesReadableServerTimeoutEnvironmentOverrides(t *testing.T) {
+	unsetServerTimeoutEnv(t)
+	t.Setenv("SERVER_READ_HEADER_TIMEOUT_SECONDS", "12")
+	t.Setenv("BASYX_SERVER_READ_TIMEOUT_SECONDS", "303")
+	t.Setenv("SERVER_WRITE_TIMEOUT_SECONDS", "304")
+	t.Setenv("BASYX_SERVER_IDLE_TIMEOUT_SECONDS", "62")
+	t.Setenv("SERVER_SHUTDOWN_TIMEOUT_SECONDS", "13")
+
+	cfg, err := LoadConfig("", QUIET)
+	if err != nil {
+		t.Fatalf("unexpected config load error: %v", err)
+	}
+
+	assertServerTimeouts(t, cfg.Server, 12, 303, 304, 62, 13)
+}
+
+func TestLoadConfigRejectsNonPositiveServerTimeouts(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		yamlKey string
+		value   int
+	}{
+		{name: "read header zero", yamlKey: "readHeaderTimeoutSeconds", value: 0},
+		{name: "read negative", yamlKey: "readTimeoutSeconds", value: -1},
+		{name: "write zero", yamlKey: "writeTimeoutSeconds", value: 0},
+		{name: "idle negative", yamlKey: "idleTimeoutSeconds", value: -1},
+		{name: "shutdown zero", yamlKey: "shutdownTimeoutSeconds", value: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unsetServerTimeoutEnv(t)
+			path := writeTempConfig(t, fmt.Sprintf("server:\n  %s: %d\n", tc.yamlKey, tc.value))
+
+			_, err := LoadConfig(path, QUIET)
+			if err == nil {
+				t.Fatal("expected config load error for non-positive server timeout")
+			}
+			if !strings.Contains(err.Error(), "CONFIG-SERVER-TIMEOUT") {
+				t.Fatalf("expected CONFIG-SERVER-TIMEOUT error, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.yamlKey) {
+				t.Fatalf("expected error to name %s, got %v", tc.yamlKey, err)
+			}
+		})
+	}
+}
+
+func unsetServerTimeoutEnv(t *testing.T) {
+	t.Helper()
 	for _, key := range []string{
 		"SERVER_READHEADERTIMEOUTSECONDS",
 		"SERVER_READTIMEOUTSECONDS",
 		"SERVER_WRITETIMEOUTSECONDS",
 		"SERVER_IDLETIMEOUTSECONDS",
 		"SERVER_SHUTDOWNTIMEOUTSECONDS",
+		"SERVER_READ_HEADER_TIMEOUT_SECONDS",
+		"SERVER_READ_TIMEOUT_SECONDS",
+		"SERVER_WRITE_TIMEOUT_SECONDS",
+		"SERVER_IDLE_TIMEOUT_SECONDS",
+		"SERVER_SHUTDOWN_TIMEOUT_SECONDS",
+		"BASYX_SERVER_READ_HEADER_TIMEOUT_SECONDS",
+		"BASYX_SERVER_READ_TIMEOUT_SECONDS",
+		"BASYX_SERVER_WRITE_TIMEOUT_SECONDS",
+		"BASYX_SERVER_IDLE_TIMEOUT_SECONDS",
+		"BASYX_SERVER_SHUTDOWN_TIMEOUT_SECONDS",
 	} {
 		withUnsetEnv(t, key)
 	}
-	captureLogOutput(t)
-	path := writeTempConfig(t, "server:\n  readTimeoutSeconds: 0\n")
-
-	_, err := LoadConfig(path, QUIET)
-	if err == nil {
-		t.Fatal("expected config load error for non-positive server timeout")
-	}
-	if !strings.Contains(err.Error(), "CONFIG-SERVER-TIMEOUT") {
-		t.Fatalf("expected CONFIG-SERVER-TIMEOUT error, got %v", err)
-	}
 }
 
-func reserveHTTPServerTestPort(t *testing.T) int {
+func assertServerTimeouts(t *testing.T, cfg ServerConfig, readHeader int, read int, write int, idle int, shutdown int) {
 	t.Helper()
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("reserve local port: %v", err)
+	if cfg.ReadHeaderTimeoutSeconds != readHeader ||
+		cfg.ReadTimeoutSeconds != read ||
+		cfg.WriteTimeoutSeconds != write ||
+		cfg.IdleTimeoutSeconds != idle ||
+		cfg.ShutdownTimeoutSeconds != shutdown {
+		t.Fatalf("unexpected server timeouts: %+v", cfg)
 	}
-	port := listener.Addr().(*net.TCPAddr).Port
-	if err := listener.Close(); err != nil {
-		t.Fatalf("close local port reservation: %v", err)
-	}
-	return port
 }
 
 func waitForHTTPServer(t *testing.T, url string) {

--- a/internal/common/http_server_test.go
+++ b/internal/common/http_server_test.go
@@ -1,0 +1,183 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServerAddressUsesConfiguredHostAndPort(t *testing.T) {
+	cfg := ServerConfig{Host: "127.0.0.1", Port: 8081}
+
+	if actual := ServerAddress(cfg); actual != "127.0.0.1:8081" {
+		t.Fatalf("expected configured address, got %q", actual)
+	}
+}
+
+func TestServerAddressDefaultsBlankHost(t *testing.T) {
+	cfg := ServerConfig{Port: 8081}
+
+	if actual := ServerAddress(cfg); actual != "0.0.0.0:8081" {
+		t.Fatalf("expected default host address, got %q", actual)
+	}
+}
+
+func TestNewConfiguredHTTPServerAppliesTimeouts(t *testing.T) {
+	cfg := ServerConfig{
+		Host:                     "::1",
+		Port:                     8082,
+		ReadHeaderTimeoutSeconds: 1,
+		ReadTimeoutSeconds:       2,
+		WriteTimeoutSeconds:      3,
+		IdleTimeoutSeconds:       4,
+		ShutdownTimeoutSeconds:   5,
+	}
+
+	server := NewConfiguredHTTPServer(cfg, http.NewServeMux())
+
+	if server.Addr != "[::1]:8082" {
+		t.Fatalf("expected IPv6 address, got %q", server.Addr)
+	}
+	if server.ReadHeaderTimeout != time.Second ||
+		server.ReadTimeout != 2*time.Second ||
+		server.WriteTimeout != 3*time.Second ||
+		server.IdleTimeout != 4*time.Second {
+		t.Fatalf("unexpected server timeouts: %+v", server)
+	}
+}
+
+func TestNewConfiguredHTTPServerDefaultsZeroTimeouts(t *testing.T) {
+	cfg := ServerConfig{Port: 8083}
+
+	server := NewConfiguredHTTPServer(cfg, http.NewServeMux())
+
+	if server.ReadHeaderTimeout != 15*time.Second ||
+		server.ReadTimeout != 30*time.Second ||
+		server.WriteTimeout != 30*time.Second ||
+		server.IdleTimeout != 60*time.Second {
+		t.Fatalf("unexpected default server timeouts: %+v", server)
+	}
+	runner := StartHTTPServer("test", ServerConfig{Host: "127.0.0.1", Port: reserveHTTPServerTestPort(t)}, http.NotFoundHandler())
+	if runner.shutdownTimeout != 10*time.Second {
+		t.Fatalf("expected default shutdown timeout, got %v", runner.shutdownTimeout)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := runner.Wait(ctx); err != nil {
+		t.Fatalf("unexpected runner wait error: %v", err)
+	}
+}
+
+func TestRunServerContextCancellationShutsDownHTTPServer(t *testing.T) {
+	port := reserveHTTPServerTestPort(t)
+	cfg := ServerConfig{
+		Host:                   "127.0.0.1",
+		Port:                   port,
+		ShutdownTimeoutSeconds: 1,
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	runner := StartHTTPServer("test", cfg, handler)
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- runner.Wait(ctx)
+	}()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d", port)
+	waitForHTTPServer(t, url)
+	cancel()
+
+	select {
+	case err := <-waitErr:
+		if err != nil {
+			t.Fatalf("unexpected wait error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not shut down after context cancellation")
+	}
+}
+
+func TestLoadConfigRejectsNonPositiveServerTimeout(t *testing.T) {
+	for _, key := range []string{
+		"SERVER_READHEADERTIMEOUTSECONDS",
+		"SERVER_READTIMEOUTSECONDS",
+		"SERVER_WRITETIMEOUTSECONDS",
+		"SERVER_IDLETIMEOUTSECONDS",
+		"SERVER_SHUTDOWNTIMEOUTSECONDS",
+	} {
+		withUnsetEnv(t, key)
+	}
+	captureLogOutput(t)
+	path := writeTempConfig(t, "server:\n  readTimeoutSeconds: 0\n")
+
+	_, err := LoadConfig(path, QUIET)
+	if err == nil {
+		t.Fatal("expected config load error for non-positive server timeout")
+	}
+	if !strings.Contains(err.Error(), "CONFIG-SERVER-TIMEOUT") {
+		t.Fatalf("expected CONFIG-SERVER-TIMEOUT error, got %v", err)
+	}
+}
+
+func reserveHTTPServerTestPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve local port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close local port reservation: %v", err)
+	}
+	return port
+}
+
+func waitForHTTPServer(t *testing.T, url string) {
+	t.Helper()
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		response, err := client.Get(url)
+		if err == nil {
+			_ = response.Body.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server at %s did not become reachable: %v", url, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary
- Add shared HTTP server lifecycle helpers with configured timeouts and graceful shutdown.
- Replace direct `http.ListenAndServe` usage across production services.
- Use signal-aware contexts in service entrypoints.
- Add server timeout config defaults to production service templates.
- Add common tests for address construction, timeout defaults, config validation, and context cancellation shutdown.
- Add a reusable AI review prompt under developer documentation.

Closes #447 