### PR TITLE
Prevent hidden duplicate disclosure in create paths

### DIFF
--- a/docu/security/README.md
+++ b/docu/security/README.md
@@ -10,6 +10,8 @@ For build and release supply-chain security (image signing, provenance attestati
 
 For PostgreSQL-backed ABAC policy versions, management API behavior, and ABAC policy evidence, see [ABAC_POLICY_REPOSITORY.md](ABAC_POLICY_REPOSITORY.md).
 
+For AAS Registry-specific `CREATE`, `UPDATE`, `READ`, `DELETE`, and status-code semantics, see [REGISTRY_SECURITY.md](REGISTRY_SECURITY.md).
+
 For history evidence deployment guidance and NIS2-relevant operator responsibilities, see [NIS2_HISTORY_EVIDENCE.md](NIS2_HISTORY_EVIDENCE.md).
 
 ## High-level architecture
@@ -282,6 +284,9 @@ Notes:
 Relevant code:
 - [internal/common/security/authorize.go](internal/common/security/authorize.go)
 - [internal/common/security/filter_helpers.go](internal/common/security/filter_helpers.go)
+
+Registry-specific operation semantics:
+- [docu/security/REGISTRY_SECURITY.md](REGISTRY_SECURITY.md)
 
 ## Claims enrichment
 

--- a/docu/security/README.md
+++ b/docu/security/README.md
@@ -282,8 +282,8 @@ Notes:
 - Security-specific work should be scoped inside `if shouldEnforce { ... }` to avoid unnecessary overhead when formula checks are not required.
 
 Relevant code:
-- [internal/common/security/authorize.go](internal/common/security/authorize.go)
-- [internal/common/security/filter_helpers.go](internal/common/security/filter_helpers.go)
+- [internal/common/security/authorize.go](../../internal/common/security/authorize.go)
+- [internal/common/security/filter_helpers.go](../../internal/common/security/filter_helpers.go)
 
 Registry-specific operation semantics:
 - [docu/security/REGISTRY_SECURITY.md](REGISTRY_SECURITY.md)

--- a/docu/security/REGISTRY_SECURITY.md
+++ b/docu/security/REGISTRY_SECURITY.md
@@ -307,7 +307,7 @@ flowchart TB
 - Route rights: `internal/common/security/abac_engine_methods.go`
 - ABAC middleware response mapping: `internal/common/security/authorize.go`
 - `CREATE`/`UPDATE` formula selection: `internal/common/security/authorize.go`
-- `CREATE` duplicate precheck: `internal/common/registryprecheck/create.go`
+- Shared `CREATE` duplicate precheck: `internal/common/createprecheck/create.go`
 - AAS Registry API mapping: `internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go`
 - AAS Registry persistence: `internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go`
 - Descriptor SQL filtering and readback: `internal/common/descriptors/AssetAdminShellDescriptorHandler.go`

--- a/docu/security/REGISTRY_SECURITY.md
+++ b/docu/security/REGISTRY_SECURITY.md
@@ -1,0 +1,313 @@
+# AAS Registry Security Semantics
+
+This document describes the current AAS Registry authorization and status-code behavior for descriptor rights: `CREATE`, `UPDATE`, `READ`, and `DELETE`. It focuses on `shell-descriptors` routes and the shared flow used by the nested submodel-descriptor routes.
+
+## Layers
+
+Security is enforced across middleware, API/controller code, and persistence code. A `403` can come directly from ABAC middleware before the handler runs, or from the API/data path after a route was allowed but the specific data or payload failed formula checks.
+
+```mermaid
+flowchart LR
+  Client[Client]
+  OIDC[OIDC middleware<br/>internal/common/security/oidc.go<br/>401 for missing or invalid required auth]
+  ABAC[ABAC middleware<br/>internal/common/security/authorize.go<br/>403 for denied route<br/>404/405 for route-model misses]
+  API[AAS Registry API/controller<br/>internal/aasregistry/api<br/>decodes input, selects formulas,<br/>maps domain errors to HTTP]
+  Data[Persistence/data layer<br/>internal/aasregistry/persistence<br/>internal/common/descriptors<br/>applies QueryFilter, readback,<br/>existence checks, history]
+  DB[(PostgreSQL)]
+
+  Client --> OIDC --> ABAC --> API --> Data --> DB
+  Data -->|ErrNotFound / ErrDenied / ErrConflict| API
+  API -->|400 / 403 / 404 / 409 / 500| Client
+  ABAC -->|403 / 404 / 405| Client
+  OIDC -->|401| Client
+```
+
+## Route Rights
+
+The AAS Registry route-to-rights mapping is centralized in `internal/common/security/abac_engine_methods.go`.
+
+```mermaid
+flowchart TB
+  subgraph ReadRoutes[READ]
+    GetAll["GET /shell-descriptors"]
+    Query["POST /query/shell-descriptors"]
+    GetOne["GET /shell-descriptors/{aasIdentifier}"]
+    GetSMAll["GET /shell-descriptors/{aasIdentifier}/submodel-descriptors"]
+    GetSMOne["GET /shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}"]
+  end
+
+  subgraph CreateRoutes[CREATE]
+    PostAAS["POST /shell-descriptors"]
+    PostSM["POST /shell-descriptors/{aasIdentifier}/submodel-descriptors"]
+  end
+
+  subgraph UpsertRoutes[CREATE or UPDATE]
+    PutAAS["PUT /shell-descriptors/{aasIdentifier}"]
+    PutSM["PUT /shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}"]
+  end
+
+  subgraph DeleteRoutes[DELETE]
+    DeleteAAS["DELETE /shell-descriptors/{aasIdentifier}"]
+    DeleteSM["DELETE /shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}"]
+  end
+```
+
+The upsert route can be authorized through either `CREATE` or `UPDATE`. The API layer then checks raw existence and selects the active formula by existence.
+
+```mermaid
+flowchart LR
+  UpsertRequest["Upsert route<br/>PUT /shell-descriptors/{aasIdentifier}"]
+  Exists{"Raw descriptor exists?<br/>checked without QueryFilter"}
+  CreateFormula["Select CREATE formula"]
+  UpdateFormula["Select UPDATE formula"]
+  FalseFormula["Missing right-specific formula<br/>select constant false"]
+
+  UpsertRequest --> Exists
+  Exists -->|No| CreateFormula
+  Exists -->|Yes| UpdateFormula
+  CreateFormula -->|formula missing| FalseFormula
+  UpdateFormula -->|formula missing| FalseFormula
+```
+
+## Common Request Flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant C as Client
+  participant O as OIDC
+  participant A as ABAC
+  participant H as API Handler
+  participant P as Persistence
+  participant D as PostgreSQL
+
+  C->>O: HTTP request
+  O->>O: validate token, issuer, audience, scopes
+  alt required authentication fails
+    O-->>C: 401
+  else identity accepted
+    O->>A: claims in context
+  end
+
+  A->>A: map method + route to rights
+  alt path unknown to ABAC route model
+    A-->>C: 404
+  else path exists for another method
+    A-->>C: 405
+  else route is known for this method
+    A->>A: evaluate rules and formulas
+  end
+  alt route denied
+    A-->>C: 403
+  else route allowed
+    A->>H: request context with optional QueryFilter
+  end
+
+  H->>H: decode input and choose operation semantics
+  H->>P: call persistence with context
+  P->>D: SQL with active QueryFilter where required
+  D-->>P: rows or SQL error
+  P-->>H: result or domain error
+  H-->>C: mapped HTTP response
+```
+
+For all protected registry endpoints, the ABAC middleware first checks whether the path exists in the route model and whether the requested method is valid for that path. A method mismatch returns `405` from the security layer before any `READ`, `CREATE`, `UPDATE`, or `DELETE` handler runs.
+
+```mermaid
+flowchart TB
+  Request["Any protected registry request"]
+  RouteModel{"Path exists in ABAC route model?"}
+  MethodModel{"Method exists for that path?"}
+  RuleEval["Evaluate ABAC rules and formulas"]
+  Handler["Run right-specific API/data flow<br/>READ / CREATE / UPDATE / DELETE"]
+
+  Request --> RouteModel
+  RouteModel -->|No| R404["404 security layer"]
+  RouteModel -->|Yes| MethodModel
+  MethodModel -->|No| R405["405 security layer"]
+  MethodModel -->|Yes| RuleEval
+  RuleEval -->|Denied| R403["403 security layer"]
+  RuleEval -->|Allowed| Handler
+```
+
+For route-level denies, the response is created by the security layer. For data-specific denials, hidden duplicates, failed write readback, and filtered `READ` results, the response is created by the API/data path.
+
+## READ Semantics
+
+`READ` routes apply the `READ` formula to SQL and return only visible data. Single descriptor reads return `404` when the row is missing or filtered out by `READ`. The common route/method gate above has already handled `404` for unknown routes, `405` for method mismatches, and `403` for route-level denial.
+
+```mermaid
+flowchart TB
+  Start["READ request<br/>GET /shell-descriptors<br/>POST /query/shell-descriptors<br/>GET /shell-descriptors/{aasIdentifier}"]
+  Decode{"Path/query valid?"}
+  ReadKind{"READ kind"}
+  ListSQL["Apply READ formula in SQL<br/>hidden descriptors omitted"]
+  SingleSQL["Apply READ formula in SQL<br/>load one descriptor"]
+  SingleVisible{"Descriptor visible?"}
+  FragmentFilter["Apply fragment filters<br/>protected fragments may be removed"]
+
+  Start --> Decode
+  Decode -->|No| R400["400 API layer"]
+  Decode -->|Yes| ReadKind
+  ReadKind -->|List or query| ListSQL --> R200List["200 API/data layer<br/>possibly empty result"]
+  ReadKind -->|Single by ID| SingleSQL --> SingleVisible
+  SingleVisible -->|No| R404Data["404 API/data layer<br/>missing or hidden"]
+  SingleVisible -->|Yes| FragmentFilter --> R200One["200 API/data layer"]
+  ListSQL -->|SQL/build failure| R500["500 API/data layer"]
+  SingleSQL -->|SQL/build failure| R500
+```
+
+## CREATE Semantics
+
+`CREATE` covers `POST /shell-descriptors` and the create branch of the upsert route. Before inserting, the API performs a raw existence precheck without the active formula. If the ID exists, the precheck then performs a visibility-aware read unless the `CREATE` formula is unrestricted.
+
+```mermaid
+flowchart TB
+  Start["CREATE request<br/>POST /shell-descriptors"]
+  RouteAllowed{"ABAC route CREATE allowed?"}
+  Decode{"Payload valid?"}
+  HasID{"Body id present?"}
+  RawExists{"Raw descriptor exists?<br/>Without QueryFilter"}
+  VisibilityNeeded{"Duplicate visibility read needed?"}
+  ExistingVisible{"Existing descriptor visible<br/>under current context?"}
+  Insert["Insert in transaction"]
+  Readback{"Post-insert readback visible<br/>under CREATE formula?"}
+
+  Start --> RouteAllowed
+  RouteAllowed -->|No| R403Security["403 security layer"]
+  RouteAllowed -->|Yes| Decode
+  Decode -->|No| R400["400 API/data layer"]
+  Decode -->|Yes| HasID
+  HasID -->|No| Insert
+  HasID -->|Yes| RawExists
+  RawExists -->|Error| R500Pre["500 API/data layer"]
+  RawExists -->|No| Insert
+  RawExists -->|Yes| VisibilityNeeded
+  VisibilityNeeded -->|No, unrestricted CREATE| R409Visible["409 API/data layer<br/>visible duplicate"]
+  VisibilityNeeded -->|Yes| ExistingVisible
+  ExistingVisible -->|Yes| R409Visible
+  ExistingVisible -->|No| R403Hidden["403 API/data layer<br/>Denied-Exists, hidden duplicate"]
+  ExistingVisible -->|Visibility read error| R500Pre
+  Insert -->|Unique violation/race| R409Race["409 API/data layer"]
+  Insert -->|Insert/internal error| R500Insert["500 API/data layer"]
+  Insert --> Readback
+  Readback -->|Yes| R201["201 API/data layer"]
+  Readback -->|No| R403Payload["403 API/data layer<br/>payload violates CREATE formula<br/>transaction rolls back"]
+```
+
+Two `CREATE` cases intentionally return `403`: an existing descriptor hidden from the caller, and a new payload that the caller is not allowed to create.
+
+## UPDATE Semantics
+
+`UPDATE` covers the existing-descriptor branch of `PUT /shell-descriptors/{aasIdentifier}`. The same route uses `CREATE` when the descriptor is missing. The path ID and body ID must match.
+
+```mermaid
+flowchart TB
+  Start["CREATE or UPDATE request<br/>PUT /shell-descriptors/{aasIdentifier}"]
+  RouteAllowed{"ABAC route allows<br/>CREATE or UPDATE?"}
+  Decode{"Path id decodes<br/>and body id matches?"}
+  RawExists{"Raw descriptor exists?<br/>Without QueryFilter"}
+
+  Start --> RouteAllowed
+  RouteAllowed -->|No| R403Security["403 security layer"]
+  RouteAllowed -->|Yes| Decode
+  Decode -->|No| R400["400 API layer"]
+  Decode -->|Yes| RawExists
+  RawExists -->|Error| R500Pre["500 API/data layer"]
+  RawExists -->|No| SelectCreate
+  RawExists -->|Yes| SelectUpdate
+
+  subgraph CreatePath[CREATE branch]
+    SelectCreate["Select CREATE formula"]
+    Insert["Insert in transaction"]
+    CreateReadback{"Readback visible<br/>under CREATE formula?"}
+    SelectCreate --> Insert --> CreateReadback
+  end
+
+  CreateReadback -->|Yes| R201["201 API/data layer"]
+  CreateReadback -->|No| R403Create["403 API/data layer<br/>payload violates CREATE formula"]
+  Insert -->|Unique conflict| R409Create["409 API/data layer"]
+  Insert -->|Internal error| R500Create["500 API/data layer"]
+
+  subgraph UpdatePath[UPDATE branch]
+    SelectUpdate["Select UPDATE formula"]
+    PreRead{"Current descriptor visible/updatable<br/>under UPDATE formula?"}
+    Replace["Delete and insert replacement<br/>in one transaction"]
+    UpdateReadback{"Replacement visible<br/>under UPDATE formula?"}
+    SelectUpdate --> PreRead
+    PreRead -->|Yes| Replace --> UpdateReadback
+  end
+
+  PreRead -->|No| R403Current["403 API/data layer<br/>existing descriptor not updatable"]
+  UpdateReadback -->|Yes| R204["204 API/data layer"]
+  UpdateReadback -->|No| R403Replacement["403 API/data layer<br/>replacement violates UPDATE formula"]
+  Replace -->|Unique conflict| R409Update["409 API/data layer"]
+  Replace -->|Internal error| R500Update["500 API/data layer"]
+```
+
+`UPDATE` is stricter than a normal `READ` for hidden existing data: hidden existing data can look like `404` on `READ`, but the existing-descriptor write path maps the hidden/not-updatable condition to `403`.
+
+## DELETE Semantics
+
+`DELETE` covers `DELETE /shell-descriptors/{aasIdentifier}`. The data layer first reads the descriptor for authorization and history, then deletes by raw ID in the same transaction.
+
+```mermaid
+flowchart TB
+  Start["DELETE request<br/>DELETE /shell-descriptors/{aasIdentifier}"]
+  RouteAllowed{"ABAC route DELETE allowed?"}
+  Decode{"Path id decodes?"}
+  ReadExisting{"Descriptor visible<br/>under DELETE formula?"}
+  Delete["Delete descriptor by raw id<br/>append deletion history"]
+
+  Start --> RouteAllowed
+  RouteAllowed -->|No| R403Security["403 security layer"]
+  RouteAllowed -->|Yes| Decode
+  Decode -->|No| R400["400 API layer"]
+  Decode -->|Yes| ReadExisting
+  ReadExisting -->|No, missing or hidden| R404["404 API/data layer"]
+  ReadExisting -->|Yes| Delete --> R204["204 API/data layer"]
+  ReadExisting -->|Internal error| R500Read["500 API/data layer"]
+  Delete -->|Internal error| R500Delete["500 API/data layer"]
+```
+
+Nested submodel-descriptor delete routes follow the same route-level pattern, but their API mapping also has explicit `ErrDenied -> 403` handling for submodel-specific access denial.
+
+## Status Code Summary
+
+```mermaid
+flowchart TB
+  Request[Registry request]
+  Auth{"OIDC required and valid?"}
+  Route{"ABAC route decision"}
+  Handler["API/data path"]
+  Success{"Operation succeeds?"}
+  Domain{"Domain outcome"}
+
+  Request --> Auth
+  Auth -->|No| S401["401<br/>Security layer"]
+  Auth -->|Yes or anonymous allowed| Route
+  Route -->|Denied| S403Security["403<br/>Security layer"]
+  Route -->|Unknown route| S404Security["404<br/>Security layer"]
+  Route -->|Method mismatch| S405["405<br/>Security layer"]
+  Route -->|Allowed| Handler
+  Handler -->|Decode/validation failure| S400["400<br/>API layer"]
+  Handler --> Success
+  Success -->|READ| S200["200<br/>API/data layer"]
+  Success -->|CREATE| S201["201<br/>API/data layer"]
+  Success -->|UPDATE or DELETE| S204["204<br/>API/data layer"]
+  Success -->|No| Domain
+  Domain -->|Hidden duplicate, formula violation,<br/>or write access denied| S403Data["403<br/>API/data layer"]
+  Domain -->|Missing or hidden READ/DELETE target| S404Data["404<br/>API/data layer"]
+  Domain -->|Visible duplicate or unique conflict| S409["409<br/>API/data layer"]
+  Domain -->|Transaction, SQL, history,<br/>or configuration error| S500["500<br/>API/data layer"]
+```
+
+## Implementation References
+
+- Route rights: `internal/common/security/abac_engine_methods.go`
+- ABAC middleware response mapping: `internal/common/security/authorize.go`
+- `CREATE`/`UPDATE` formula selection: `internal/common/security/authorize.go`
+- `CREATE` duplicate precheck: `internal/common/registryprecheck/create.go`
+- AAS Registry API mapping: `internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go`
+- AAS Registry persistence: `internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go`
+- Descriptor SQL filtering and readback: `internal/common/descriptors/AssetAdminShellDescriptorHandler.go`

--- a/internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go
+++ b/internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go
@@ -176,7 +176,6 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) PostAssetAdministrationS
 			},
 			"AAS with given id already exists",
 			"AAS Descriptor access not allowed",
-			registryprecheck.WithReadRequest(http.MethodGet, "/shell-descriptors/"+common.EncodeString(assetAdministrationShellDescriptor.Id)),
 		)
 		if precheckErr != nil {
 			statusCode, step := registryprecheck.ResponseStatus(precheckErr)
@@ -480,7 +479,6 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) PostSubmodelDescriptorTh
 			},
 			"Submodel with given id already exists for this AAS",
 			"Submodel Descriptor access not allowed",
-			registryprecheck.WithReadRequest(http.MethodGet, "/shell-descriptors/"+aasIdentifier+"/submodel-descriptors/"+common.EncodeString(submodelDescriptor.Id)),
 		)
 		if precheckErr != nil {
 			statusCode, step := registryprecheck.ResponseStatus(precheckErr)

--- a/internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go
+++ b/internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go
@@ -45,9 +45,9 @@ import (
 
 	persistence_postgresql "github.com/eclipse-basyx/basyx-go-components/internal/aasregistry/persistence"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
-	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 )
 
@@ -165,7 +165,7 @@ func filterAssetAdministrationShellDescriptorPages(
 // PostAssetAdministrationShellDescriptor - Creates a new Asset Administration Shell Descriptor, i.e. registers an AAS
 func (s *AssetAdministrationShellRegistryAPIAPIService) PostAssetAdministrationShellDescriptor(ctx context.Context, assetAdministrationShellDescriptor model.AssetAdministrationShellDescriptor) (model.ImplResponse, error) {
 	if strings.TrimSpace(assetAdministrationShellDescriptor.Id) != "" {
-		precheckErr := registryprecheck.EnsureVisibleCreate(
+		precheckErr := createprecheck.EnsureVisibleCreate(
 			ctx,
 			func(checkCtx context.Context) (bool, error) {
 				return s.aasRegistryBackend.ExistsAASByID(checkCtx, assetAdministrationShellDescriptor.Id)
@@ -178,11 +178,11 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) PostAssetAdministrationS
 			"AAS Descriptor access not allowed",
 		)
 		if precheckErr != nil {
-			statusCode, step := registryprecheck.ResponseStatus(precheckErr)
+			statusCode, step := createprecheck.ResponseStatus(precheckErr)
 			log.Printf("🧩 [%s] Error in PostAssetAdministrationShellDescriptor: create precheck failed (aasId=%q): %v", componentName, assetAdministrationShellDescriptor.Id, precheckErr)
 			return common.NewErrorResponse(
 				precheckErr, statusCode, componentName, "PostAssetAdministrationShellDescriptor", step,
-			), registryprecheck.ReturnError(precheckErr)
+			), createprecheck.ReturnError(precheckErr)
 		}
 	}
 
@@ -468,7 +468,7 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) PostSubmodelDescriptorTh
 	}
 
 	if strings.TrimSpace(submodelDescriptor.Id) != "" {
-		precheckErr := registryprecheck.EnsureVisibleCreate(
+		precheckErr := createprecheck.EnsureVisibleCreate(
 			ctx,
 			func(checkCtx context.Context) (bool, error) {
 				return s.aasRegistryBackend.ExistsSubmodelForAAS(checkCtx, decodedAAS, submodelDescriptor.Id)
@@ -481,11 +481,11 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) PostSubmodelDescriptorTh
 			"Submodel Descriptor access not allowed",
 		)
 		if precheckErr != nil {
-			statusCode, step := registryprecheck.ResponseStatus(precheckErr)
+			statusCode, step := createprecheck.ResponseStatus(precheckErr)
 			log.Printf("🧩 [%s] Error in PostSubmodelDescriptorThroughSuperpath: create precheck failed (aasId=%q submodelId=%q): %v", componentName, decodedAAS, submodelDescriptor.Id, precheckErr)
 			return common.NewErrorResponse(
 				precheckErr, statusCode, componentName, "PostSubmodelDescriptorThroughSuperpath", step,
-			), registryprecheck.ReturnError(precheckErr)
+			), createprecheck.ReturnError(precheckErr)
 		}
 	}
 

--- a/internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go
+++ b/internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go
@@ -176,6 +176,7 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) PostAssetAdministrationS
 			},
 			"AAS with given id already exists",
 			"AAS Descriptor access not allowed",
+			registryprecheck.WithReadRequest(http.MethodGet, "/shell-descriptors/"+common.EncodeString(assetAdministrationShellDescriptor.Id)),
 		)
 		if precheckErr != nil {
 			statusCode, step := registryprecheck.ResponseStatus(precheckErr)
@@ -479,6 +480,7 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) PostSubmodelDescriptorTh
 			},
 			"Submodel with given id already exists for this AAS",
 			"Submodel Descriptor access not allowed",
+			registryprecheck.WithReadRequest(http.MethodGet, "/shell-descriptors/"+aasIdentifier+"/submodel-descriptors/"+common.EncodeString(submodelDescriptor.Id)),
 		)
 		if precheckErr != nil {
 			statusCode, step := registryprecheck.ResponseStatus(precheckErr)

--- a/internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go
+++ b/internal/aasregistry/api/api_asset_administration_shell_registry_api_service.go
@@ -47,6 +47,7 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 )
 
@@ -163,20 +164,25 @@ func filterAssetAdministrationShellDescriptorPages(
 
 // PostAssetAdministrationShellDescriptor - Creates a new Asset Administration Shell Descriptor, i.e. registers an AAS
 func (s *AssetAdministrationShellRegistryAPIAPIService) PostAssetAdministrationShellDescriptor(ctx context.Context, assetAdministrationShellDescriptor model.AssetAdministrationShellDescriptor) (model.ImplResponse, error) {
-	// Existence check: AAS with same Id should not already exist (lightweight)
 	if strings.TrimSpace(assetAdministrationShellDescriptor.Id) != "" {
-		if exists, chkErr := s.aasRegistryBackend.ExistsAASByID(ctx, assetAdministrationShellDescriptor.Id); chkErr != nil {
-			log.Printf("🧩 [%s] Error in PostAssetAdministrationShellDescriptor: existence check failed (aasId=%q): %v", componentName, assetAdministrationShellDescriptor.Id, chkErr)
+		precheckErr := registryprecheck.EnsureVisibleCreate(
+			ctx,
+			func(checkCtx context.Context) (bool, error) {
+				return s.aasRegistryBackend.ExistsAASByID(checkCtx, assetAdministrationShellDescriptor.Id)
+			},
+			func(readCtx context.Context) error {
+				_, readErr := s.aasRegistryBackend.GetAssetAdministrationShellDescriptorByID(readCtx, assetAdministrationShellDescriptor.Id)
+				return readErr
+			},
+			"AAS with given id already exists",
+			"AAS Descriptor access not allowed",
+		)
+		if precheckErr != nil {
+			statusCode, step := registryprecheck.ResponseStatus(precheckErr)
+			log.Printf("🧩 [%s] Error in PostAssetAdministrationShellDescriptor: create precheck failed (aasId=%q): %v", componentName, assetAdministrationShellDescriptor.Id, precheckErr)
 			return common.NewErrorResponse(
-				chkErr, http.StatusInternalServerError, componentName, "PostAssetAdministrationShellDescriptor", "Unhandled-Precheck",
-			), chkErr
-		} else if exists {
-			// TODO: should return 403 if no access on existing shell. Currently user gets 409 even if he has no access rights.
-			e := common.NewErrConflict("AAS with given id already exists")
-			log.Printf("🧩 [%s] Error in PostAssetAdministrationShellDescriptor: conflict (aasId=%q): %v", componentName, assetAdministrationShellDescriptor.Id, e)
-			return common.NewErrorResponse(
-				e, http.StatusConflict, componentName, "PostAssetAdministrationShellDescriptor", "Conflict-Exists",
-			), nil
+				precheckErr, statusCode, componentName, "PostAssetAdministrationShellDescriptor", step,
+			), registryprecheck.ReturnError(precheckErr)
 		}
 	}
 
@@ -461,20 +467,25 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) PostSubmodelDescriptorTh
 		return *resp, err
 	}
 
-	// Conflict check: lightweight existence for submodel under this AAS
 	if strings.TrimSpace(submodelDescriptor.Id) != "" {
-		if exists, chkErr := s.aasRegistryBackend.ExistsSubmodelForAAS(ctx, decodedAAS, submodelDescriptor.Id); chkErr != nil {
-			log.Printf("🧩 [%s] Error in PostSubmodelDescriptorThroughSuperpath: existence check failed (aasId=%q submodelId=%q): %v", componentName, decodedAAS, submodelDescriptor.Id, chkErr)
+		precheckErr := registryprecheck.EnsureVisibleCreate(
+			ctx,
+			func(checkCtx context.Context) (bool, error) {
+				return s.aasRegistryBackend.ExistsSubmodelForAAS(checkCtx, decodedAAS, submodelDescriptor.Id)
+			},
+			func(readCtx context.Context) error {
+				_, readErr := s.aasRegistryBackend.GetSubmodelDescriptorForAASByID(readCtx, decodedAAS, submodelDescriptor.Id)
+				return readErr
+			},
+			"Submodel with given id already exists for this AAS",
+			"Submodel Descriptor access not allowed",
+		)
+		if precheckErr != nil {
+			statusCode, step := registryprecheck.ResponseStatus(precheckErr)
+			log.Printf("🧩 [%s] Error in PostSubmodelDescriptorThroughSuperpath: create precheck failed (aasId=%q submodelId=%q): %v", componentName, decodedAAS, submodelDescriptor.Id, precheckErr)
 			return common.NewErrorResponse(
-				chkErr, http.StatusInternalServerError, componentName, "PostSubmodelDescriptorThroughSuperpath", "Unhandled-Precheck",
-			), chkErr
-		} else if exists {
-			// TODO: should return 403 if no access on existing submodel. Currently user gets 409 even if he has no access rights.
-			e := common.NewErrConflict("Submodel with given id already exists for this AAS")
-			log.Printf("🧩 [%s] Error in PostSubmodelDescriptorThroughSuperpath: conflict (aasId=%q submodelId=%q): %v", componentName, decodedAAS, submodelDescriptor.Id, e)
-			return common.NewErrorResponse(
-				e, http.StatusConflict, componentName, "PostSubmodelDescriptorThroughSuperpath", "Conflict-Exists",
-			), nil
+				precheckErr, statusCode, componentName, "PostSubmodelDescriptorThroughSuperpath", step,
+			), registryprecheck.ReturnError(precheckErr)
 		}
 	}
 

--- a/internal/aasregistry/api/bulk_atomic_operations.go
+++ b/internal/aasregistry/api/bulk_atomic_operations.go
@@ -35,6 +35,7 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/asyncbulk"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 )
 
@@ -95,43 +96,39 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) ensureAASDescriptorsDoNo
 	identifiers []string,
 	failure *asyncbulk.ItemFailure,
 ) error {
-	if auth.GetQueryFilter(ctx) != nil {
-		return s.ensureVisibleAASDescriptorsDoNotExist(ctx, tx, identifiers, failure)
-	}
-
 	existing, err := s.aasRegistryBackend.ExistingAASDescriptorIDsInTransaction(ctx, tx, identifiers)
 	if err != nil {
 		*failure = asyncbulk.ItemFailure{Index: 0, Identifier: firstIdentifier(identifiers), StatusCode: http.StatusInternalServerError, Message: err.Error()}
 		return err
 	}
-	for index, identifier := range identifiers {
-		if _, found := existing[identifier]; found {
-			err := common.NewErrConflict("AAS with given id already exists")
-			*failure = asyncbulk.ItemFailure{Index: index, Identifier: identifier, StatusCode: http.StatusConflict, Message: err.Error()}
-			return err
-		}
-	}
-	return nil
+	return s.ensureVisibleAASDescriptorDuplicates(ctx, tx, identifiers, existing, failure)
 }
 
-func (s *AssetAdministrationShellRegistryAPIAPIService) ensureVisibleAASDescriptorsDoNotExist(
+func (s *AssetAdministrationShellRegistryAPIAPIService) ensureVisibleAASDescriptorDuplicates(
 	ctx context.Context,
 	tx *sql.Tx,
 	identifiers []string,
+	existing map[string]struct{},
 	failure *asyncbulk.ItemFailure,
 ) error {
 	for index, identifier := range identifiers {
-		_, err := s.aasRegistryBackend.GetAssetAdministrationShellDescriptorByIDInTransaction(ctx, tx, identifier)
-		if err == nil {
-			err = common.NewErrConflict("AAS with given id already exists")
-			*failure = asyncbulk.ItemFailure{Index: index, Identifier: identifier, StatusCode: http.StatusConflict, Message: err.Error()}
-			return err
-		}
-		if common.IsErrNotFound(err) {
+		if _, found := existing[identifier]; !found {
 			continue
 		}
-		*failure = asyncbulk.ItemFailure{Index: index, Identifier: identifier, StatusCode: aasBulkCreateErrorStatusCode(err), Message: err.Error()}
-		return err
+		err := registryprecheck.EnsureVisibleDuplicate(
+			ctx,
+			true,
+			func(readCtx context.Context) error {
+				_, readErr := s.aasRegistryBackend.GetAssetAdministrationShellDescriptorByIDInTransaction(readCtx, tx, identifier)
+				return readErr
+			},
+			"AAS with given id already exists",
+			"AAS Descriptor access not allowed",
+		)
+		if err != nil {
+			*failure = asyncbulk.ItemFailure{Index: index, Identifier: identifier, StatusCode: aasBulkCreateErrorStatusCode(err), Message: err.Error()}
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/aasregistry/api/bulk_atomic_operations.go
+++ b/internal/aasregistry/api/bulk_atomic_operations.go
@@ -34,8 +34,8 @@ import (
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/asyncbulk"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
-	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 )
 
@@ -115,7 +115,7 @@ func (s *AssetAdministrationShellRegistryAPIAPIService) ensureVisibleAASDescript
 		if _, found := existing[identifier]; !found {
 			continue
 		}
-		err := registryprecheck.EnsureVisibleDuplicate(
+		err := createprecheck.EnsureVisibleDuplicate(
 			ctx,
 			true,
 			func(readCtx context.Context) error {

--- a/internal/aasregistry/api/create_precheck_test.go
+++ b/internal/aasregistry/api/create_precheck_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ import (
 func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *testing.T) {
 	t.Parallel()
 
-	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 
 	err := registryprecheck.EnsureVisibleCreate(
 		ctx,
@@ -60,7 +61,7 @@ func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *te
 func TestRegistryCreatePrecheckReturnsConflictForVisibleDescriptor(t *testing.T) {
 	t.Parallel()
 
-	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 
 	err := registryprecheck.EnsureVisibleCreate(
 		ctx,
@@ -104,7 +105,7 @@ func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
 	require.ErrorIs(t, err, rawErr)
 
 	filteredErr := errors.New("filtered read failed")
-	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 	err = registryprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) { return true, nil },
@@ -113,4 +114,18 @@ func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
 		"AAS Descriptor access not allowed",
 	)
 	require.ErrorIs(t, err, filteredErr)
+}
+
+func limitedCreateQueryFilter() *auth.QueryFilter {
+	falseExpression := grammar.LogicalExpression{Boolean: boolPtr(false)}
+	return &auth.QueryFilter{
+		Formula: &falseExpression,
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: falseExpression,
+		},
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/internal/aasregistry/api/create_precheck_test.go
+++ b/internal/aasregistry/api/create_precheck_test.go
@@ -32,8 +32,8 @@ import (
 	"testing"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
-	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +43,7 @@ func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *te
 
 	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 
-	err := registryprecheck.EnsureVisibleCreate(
+	err := createprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) { return true, nil },
 		func(context.Context) error { return common.NewErrNotFound("hidden descriptor") },
@@ -54,7 +54,7 @@ func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *te
 	require.Error(t, err)
 	require.True(t, common.IsErrDenied(err))
 	require.False(t, common.IsErrConflict(err))
-	statusCode, _ := registryprecheck.ResponseStatus(err)
+	statusCode, _ := createprecheck.ResponseStatus(err)
 	require.Equal(t, http.StatusForbidden, statusCode)
 }
 
@@ -63,7 +63,7 @@ func TestRegistryCreatePrecheckReturnsConflictForVisibleDescriptor(t *testing.T)
 
 	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 
-	err := registryprecheck.EnsureVisibleCreate(
+	err := createprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) { return true, nil },
 		func(context.Context) error { return nil },
@@ -73,14 +73,14 @@ func TestRegistryCreatePrecheckReturnsConflictForVisibleDescriptor(t *testing.T)
 
 	require.Error(t, err)
 	require.True(t, common.IsErrConflict(err))
-	statusCode, _ := registryprecheck.ResponseStatus(err)
+	statusCode, _ := createprecheck.ResponseStatus(err)
 	require.Equal(t, http.StatusConflict, statusCode)
 }
 
 func TestRegistryCreatePrecheckAllowsMissingDescriptor(t *testing.T) {
 	t.Parallel()
 
-	err := registryprecheck.EnsureVisibleCreate(
+	err := createprecheck.EnsureVisibleCreate(
 		context.Background(),
 		func(context.Context) (bool, error) { return false, nil },
 		func(context.Context) error { return errors.New("read must not be called") },
@@ -95,7 +95,7 @@ func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
 	t.Parallel()
 
 	rawErr := errors.New("raw existence failed")
-	err := registryprecheck.EnsureVisibleCreate(
+	err := createprecheck.EnsureVisibleCreate(
 		context.Background(),
 		func(context.Context) (bool, error) { return false, rawErr },
 		func(context.Context) error { return nil },
@@ -106,7 +106,7 @@ func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
 
 	filteredErr := errors.New("filtered read failed")
 	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
-	err = registryprecheck.EnsureVisibleCreate(
+	err = createprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) { return true, nil },
 		func(context.Context) error { return filteredErr },

--- a/internal/aasregistry/api/create_precheck_test.go
+++ b/internal/aasregistry/api/create_precheck_test.go
@@ -1,0 +1,116 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package aasregistryapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
+	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+
+	err := registryprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) { return true, nil },
+		func(context.Context) error { return common.NewErrNotFound("hidden descriptor") },
+		"AAS with given id already exists",
+		"AAS Descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrDenied(err))
+	require.False(t, common.IsErrConflict(err))
+	statusCode, _ := registryprecheck.ResponseStatus(err)
+	require.Equal(t, http.StatusForbidden, statusCode)
+}
+
+func TestRegistryCreatePrecheckReturnsConflictForVisibleDescriptor(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+
+	err := registryprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) { return true, nil },
+		func(context.Context) error { return nil },
+		"AAS with given id already exists",
+		"AAS Descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrConflict(err))
+	statusCode, _ := registryprecheck.ResponseStatus(err)
+	require.Equal(t, http.StatusConflict, statusCode)
+}
+
+func TestRegistryCreatePrecheckAllowsMissingDescriptor(t *testing.T) {
+	t.Parallel()
+
+	err := registryprecheck.EnsureVisibleCreate(
+		context.Background(),
+		func(context.Context) (bool, error) { return false, nil },
+		func(context.Context) error { return errors.New("read must not be called") },
+		"AAS with given id already exists",
+		"AAS Descriptor access not allowed",
+	)
+
+	require.NoError(t, err)
+}
+
+func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
+	t.Parallel()
+
+	rawErr := errors.New("raw existence failed")
+	err := registryprecheck.EnsureVisibleCreate(
+		context.Background(),
+		func(context.Context) (bool, error) { return false, rawErr },
+		func(context.Context) error { return nil },
+		"AAS with given id already exists",
+		"AAS Descriptor access not allowed",
+	)
+	require.ErrorIs(t, err, rawErr)
+
+	filteredErr := errors.New("filtered read failed")
+	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+	err = registryprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) { return true, nil },
+		func(context.Context) error { return filteredErr },
+		"AAS with given id already exists",
+		"AAS Descriptor access not allowed",
+	)
+	require.ErrorIs(t, err, filteredErr)
+}

--- a/internal/aasregistry/security_tests/it_config.json
+++ b/internal/aasregistry/security_tests/it_config.json
@@ -128,12 +128,12 @@
     "expectedStatus": 201
   },
   {
-    "context": "POST Descriptor D - User B - DENIED",
+    "context": "POST Descriptor D - User B - CONFLICT",
     "token": { "user": "usery", "password": "pwd" },
     "method": "POST",
     "endpoint": "http://localhost:6004/shell-descriptors",
     "data": "postBody/simple_aas_D.json",
-    "expectedStatus": 403
+    "expectedStatus": 409
   },
   {
     "context": "POST Descriptor X - User B - DENIED",
@@ -183,6 +183,222 @@
     "data": "postBody/simple_aas_X.json",
     "shouldMatch": "postBody/simple_aas_X.json",
     "expectedStatus": 201
+  },
+  {
+    "context": "DUPLICATE POST Descriptor A - User X - CONFLICT",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_A.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor B - User X - FORBIDDEN",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_B.json",
+    "expectedStatus": 403
+  },
+  {
+    "context": "DUPLICATE POST Descriptor C - User X - FORBIDDEN",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_C.json",
+    "expectedStatus": 403
+  },
+  {
+    "context": "DUPLICATE POST Descriptor D - User X - CONFLICT",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_D.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor X - User X - FORBIDDEN",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_X.json",
+    "expectedStatus": 403
+  },
+  {
+    "context": "DUPLICATE POST Descriptor A - User Y - CONFLICT",
+    "token": { "user": "usery", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_A.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor B - User Y - CONFLICT",
+    "token": { "user": "usery", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_B.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor C - User Y - CONFLICT",
+    "token": { "user": "usery", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_C.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor D - User Y - CONFLICT",
+    "token": { "user": "usery", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_D.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor X - User Y - FORBIDDEN",
+    "token": { "user": "usery", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_X.json",
+    "expectedStatus": 403
+  },
+  {
+    "context": "DUPLICATE POST Descriptor A - ADMIN - CONFLICT",
+    "token": { "user": "admin", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_A.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor B - ADMIN - CONFLICT",
+    "token": { "user": "admin", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_B.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor C - ADMIN - CONFLICT",
+    "token": { "user": "admin", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_C.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor D - ADMIN - CONFLICT",
+    "token": { "user": "admin", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_D.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE POST Descriptor X - ADMIN - CONFLICT",
+    "token": { "user": "admin", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/shell-descriptors",
+    "data": "postBody/simple_aas_X.json",
+    "expectedStatus": 409
+  },
+  {
+    "context": "DUPLICATE BULK POST Descriptor A - User X - CONFLICT",
+    "action": "ASSERT_BULK_FAILURE",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/bulk/shell-descriptors",
+    "data": "postBody/bulk_create_aas_a.json",
+    "expectedStatus": 202,
+    "expectedBulkFailureStatus": 409,
+    "expectedBulkFailureIndex": 0,
+    "expectedBulkFailureIdentifier": "https://example.org/A"
+  },
+  {
+    "context": "DUPLICATE BULK POST Descriptor B - User X - FORBIDDEN",
+    "action": "ASSERT_BULK_FAILURE",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/bulk/shell-descriptors",
+    "data": "postBody/bulk_create_aas_b.json",
+    "expectedStatus": 202,
+    "expectedBulkFailureStatus": 403,
+    "expectedBulkFailureIndex": 0,
+    "expectedBulkFailureIdentifier": "https://example.org/B"
+  },
+  {
+    "context": "DUPLICATE BULK POST Descriptor C - User X - FORBIDDEN",
+    "action": "ASSERT_BULK_FAILURE",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/bulk/shell-descriptors",
+    "data": "postBody/bulk_create_aas_c.json",
+    "expectedStatus": 202,
+    "expectedBulkFailureStatus": 403,
+    "expectedBulkFailureIndex": 0,
+    "expectedBulkFailureIdentifier": "https://example.org/C"
+  },
+  {
+    "context": "DUPLICATE BULK POST Descriptor D - User X - CONFLICT",
+    "action": "ASSERT_BULK_FAILURE",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/bulk/shell-descriptors",
+    "data": "postBody/bulk_create_aas_d.json",
+    "expectedStatus": 202,
+    "expectedBulkFailureStatus": 409,
+    "expectedBulkFailureIndex": 0,
+    "expectedBulkFailureIdentifier": "https://example.org/D"
+  },
+  {
+    "context": "DUPLICATE BULK POST Descriptor X - User X - FORBIDDEN",
+    "action": "ASSERT_BULK_FAILURE",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/bulk/shell-descriptors",
+    "data": "postBody/bulk_create_aas_x.json",
+    "expectedStatus": 202,
+    "expectedBulkFailureStatus": 403,
+    "expectedBulkFailureIndex": 0,
+    "expectedBulkFailureIdentifier": "https://example.org/X"
+  },
+  {
+    "context": "DUPLICATE BULK POST Descriptor B - User Y - CONFLICT",
+    "action": "ASSERT_BULK_FAILURE",
+    "token": { "user": "usery", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/bulk/shell-descriptors",
+    "data": "postBody/bulk_create_aas_b.json",
+    "expectedStatus": 202,
+    "expectedBulkFailureStatus": 409,
+    "expectedBulkFailureIndex": 0,
+    "expectedBulkFailureIdentifier": "https://example.org/B"
+  },
+  {
+    "context": "DUPLICATE BULK POST Descriptor X - User Y - FORBIDDEN",
+    "action": "ASSERT_BULK_FAILURE",
+    "token": { "user": "usery", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/bulk/shell-descriptors",
+    "data": "postBody/bulk_create_aas_x.json",
+    "expectedStatus": 202,
+    "expectedBulkFailureStatus": 403,
+    "expectedBulkFailureIndex": 0,
+    "expectedBulkFailureIdentifier": "https://example.org/X"
+  },
+  {
+    "context": "DUPLICATE BULK POST Descriptor X - ADMIN - CONFLICT",
+    "action": "ASSERT_BULK_FAILURE",
+    "token": { "user": "admin", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "http://localhost:6004/bulk/shell-descriptors",
+    "data": "postBody/bulk_create_aas_x.json",
+    "expectedStatus": 202,
+    "expectedBulkFailureStatus": 409,
+    "expectedBulkFailureIndex": 0,
+    "expectedBulkFailureIdentifier": "https://example.org/X"
   },
   {
     "context": "GET Descriptor A - User ANONONYM - ALLOWED",
@@ -512,7 +728,7 @@
   { "context": "POST Submodel A - User Y - CONFLICT", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
   { "context": "POST Submodel B - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "shouldMatch": "postBody/simple_smd_b.json", "expectedStatus": 201 },
   { "context": "POST Submodel C - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "shouldMatch": "postBody/simple_smd_c.json", "expectedStatus": 201 },
-  { "context": "POST Submodel D - User Y - DENIED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 403 },
+  { "context": "POST Submodel D - User Y - CONFLICT", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
   { "context": "POST Submodel X - User Y - DENIED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
 
   { "context": "POST Submodel A - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
@@ -520,6 +736,24 @@
   { "context": "POST Submodel C - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 409 },
   { "context": "POST Submodel D - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
   { "context": "POST Submodel X - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "shouldMatch": "postBody/simple_smd_x.json", "expectedStatus": 201 },
+
+  { "context": "DUPLICATE POST Submodel A - User X - CONFLICT", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel B - User X - FORBIDDEN", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "expectedStatus": 403 },
+  { "context": "DUPLICATE POST Submodel C - User X - FORBIDDEN", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 403 },
+  { "context": "DUPLICATE POST Submodel D - User X - CONFLICT", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel X - User X - FORBIDDEN", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
+
+  { "context": "DUPLICATE POST Submodel A - User Y - CONFLICT", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel B - User Y - CONFLICT", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel C - User Y - CONFLICT", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel D - User Y - CONFLICT", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel X - User Y - FORBIDDEN", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
+
+  { "context": "DUPLICATE POST Submodel A - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel B - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel C - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel D - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
+  { "context": "DUPLICATE POST Submodel X - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 409 },
 
   { "context": "GET Submodel A - ANON - ALLOWED", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE", "shouldMatch": "expected/expected_smd_a.json", "expectedStatus": 200 },
   { "context": "GET Submodel A trailing slash - ANON - NOT FOUND", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE/", "expectedStatus": 404 },

--- a/internal/aasregistry/security_tests/it_config.json
+++ b/internal/aasregistry/security_tests/it_config.json
@@ -128,12 +128,12 @@
     "expectedStatus": 201
   },
   {
-    "context": "POST Descriptor D - User B - ALLOWED",
+    "context": "POST Descriptor D - User B - DENIED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "POST",
     "endpoint": "http://localhost:6004/shell-descriptors",
     "data": "postBody/simple_aas_D.json",
-    "expectedStatus": 409
+    "expectedStatus": 403
   },
   {
     "context": "POST Descriptor X - User B - DENIED",
@@ -512,7 +512,7 @@
   { "context": "POST Submodel A - User Y - CONFLICT", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
   { "context": "POST Submodel B - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "shouldMatch": "postBody/simple_smd_b.json", "expectedStatus": 201 },
   { "context": "POST Submodel C - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "shouldMatch": "postBody/simple_smd_c.json", "expectedStatus": 201 },
-  { "context": "POST Submodel D - User Y - DENIED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
+  { "context": "POST Submodel D - User Y - DENIED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 403 },
   { "context": "POST Submodel X - User Y - DENIED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
 
   { "context": "POST Submodel A - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },

--- a/internal/aasregistry/security_tests/postBody/bulk_create_aas_a.json
+++ b/internal/aasregistry/security_tests/postBody/bulk_create_aas_a.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "https://example.org/A",
+    "specificAssetIds": [
+      {
+        "name": "customerPartId",
+        "value": "248795",
+        "externalSubjectId": {
+          "type": "ExternalReference",
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "PUBLIC_READABLE"
+            },
+            {
+              "type": "GlobalReference",
+              "value": "WRITTEN_BY_X"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/internal/aasregistry/security_tests/postBody/bulk_create_aas_c.json
+++ b/internal/aasregistry/security_tests/postBody/bulk_create_aas_c.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "https://example.org/C",
+    "specificAssetIds": [
+      {
+        "name": "manufacturerPartId",
+        "value": "23749",
+        "externalSubjectId": {
+          "type": "ExternalReference",
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "WRITTEN_BY_Y"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/internal/aasregistry/security_tests/postBody/bulk_create_aas_d.json
+++ b/internal/aasregistry/security_tests/postBody/bulk_create_aas_d.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "https://example.org/D",
+    "specificAssetIds": [
+      {
+        "name": "manufacturerPartId",
+        "value": "2389048",
+        "externalSubjectId": {
+          "type": "ExternalReference",
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "WRITTEN_BY_X"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/internal/aasregistry/security_tests/postBody/bulk_create_aas_x.json
+++ b/internal/aasregistry/security_tests/postBody/bulk_create_aas_x.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "https://example.org/X",
+    "specificAssetIds": [
+      {
+        "name": "producerPartId",
+        "value": "248795",
+        "externalSubjectId": {
+          "type": "ExternalReference",
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "SPECIAL"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/internal/aasrepository/persistence/aas_create_visibility_test.go
+++ b/internal/aasrepository/persistence/aas_create_visibility_test.go
@@ -1,0 +1,87 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package persistence
+
+import (
+	"context"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAASRepositoryCreateExistingUnauthorizedShellDoesNotReturnConflict(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	sut := &AssetAdministrationShellDatabase{db: db}
+	aasID := "urn:example:aas:hidden-existing"
+	assetInformation := types.NewAssetInformation(types.AssetKindInstance)
+	globalAssetID := "urn:example:asset:hidden-existing"
+	assetInformation.SetGlobalAssetID(&globalAssetID)
+	aas := types.NewAssetAdministrationShell(aasID, assetInformation)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT "id" FROM "aas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
+	mock.ExpectQuery(`SELECT "id" FROM "aas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
+	mock.ExpectQuery(`FROM "aas" AS "aas".*FALSE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectRollback()
+
+	err = sut.CreateAssetAdministrationShell(contextWithRestrictedCreateAAS(t), aas)
+	require.Error(t, err)
+	require.Truef(t, common.IsErrDenied(err), "got %v", err)
+	require.False(t, common.IsErrConflict(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func contextWithRestrictedCreateAAS(t *testing.T) context.Context {
+	t.Helper()
+
+	return auth.WithQueryFilter(aasSigningTestContext(t), limitedCreateQueryFilterForRepositoryTests())
+}
+
+func limitedCreateQueryFilterForRepositoryTests() *auth.QueryFilter {
+	denied := false
+	expr := grammar.LogicalExpression{Boolean: &denied}
+	return &auth.QueryFilter{
+		Formula: &expr,
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: expr,
+		},
+	}
+}

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -45,6 +45,7 @@ import (
 	"github.com/doug-martin/goqu/v9"
 	persistenceutils "github.com/eclipse-basyx/basyx-go-components/internal/aasrepository/persistence/utils"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/descriptors"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/history"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/jws"
@@ -359,6 +360,37 @@ func (s *AssetAdministrationShellDatabase) checkAASVisibilityInTx(ctx context.Co
 	return false, false, common.NewInternalServerError("AASREPO-ABACCHKAAS-EXECSQL " + scanErr.Error())
 }
 
+func (s *AssetAdministrationShellDatabase) ensureVisibleAASCreateDoesNotExist(ctx context.Context, tx *sql.Tx, aasIdentifier string) error {
+	return createprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) {
+			_, err := persistenceutils.GetAssetAdministrationShellDatabaseID(tx, aasIdentifier)
+			if err == nil {
+				return true, nil
+			}
+			if errors.Is(err, sql.ErrNoRows) {
+				return false, nil
+			}
+			return false, common.NewInternalServerError("AASREPO-NEWAAS-CHKDUP-GETAASDBID " + err.Error())
+		},
+		func(readCtx context.Context) error {
+			exists, visible, err := s.checkAASVisibilityInTx(readCtx, tx, aasIdentifier)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return common.NewErrNotFound("AASREPO-NEWAAS-CHKDUP-NOTFOUND existing AAS not found")
+			}
+			if !visible {
+				return common.NewErrDenied("AASREPO-NEWAAS-CHKDUP-ABACDENIED existing AAS is not accessible under ABAC constraints")
+			}
+			return nil
+		},
+		"AASREPO-NEWAAS-CONFLICT AAS with given id already exists",
+		"AASREPO-NEWAAS-CHKDUP-ABACDENIED existing AAS is not accessible under ABAC constraints",
+	)
+}
+
 // CreateAssetAdministrationShell persists a new AAS and performs an ABAC re-check before commit when enabled.
 func (s *AssetAdministrationShellDatabase) CreateAssetAdministrationShell(ctx context.Context, aas types.IAssetAdministrationShell) error {
 	return common.ExecuteInTransaction(
@@ -378,6 +410,10 @@ func (s *AssetAdministrationShellDatabase) CreateAssetAdministrationShellInTrans
 	}
 
 	if err := s.verifyAssetAdministrationShell(aas, "AASREPO-NEWAAS-VERIFY"); err != nil {
+		return err
+	}
+
+	if err := s.ensureVisibleAASCreateDoesNotExist(ctx, tx, aas.ID()); err != nil {
 		return err
 	}
 

--- a/internal/common/createprecheck/create.go
+++ b/internal/common/createprecheck/create.go
@@ -23,8 +23,8 @@
 * SPDX-License-Identifier: MIT
 ******************************************************************************/
 
-// Package registryprecheck contains registry API precheck helpers.
-package registryprecheck
+// Package createprecheck contains helpers for create operations that must avoid hidden duplicate disclosure.
+package createprecheck
 
 import (
 	"context"
@@ -35,10 +35,10 @@ import (
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 )
 
-// ExistsFunc checks raw descriptor existence without visibility filtering.
+// ExistsFunc checks raw resource existence without visibility filtering.
 type ExistsFunc func(context.Context) (bool, error)
 
-// ReadFunc performs a visibility-aware descriptor read.
+// ReadFunc performs a visibility-aware resource read.
 type ReadFunc func(context.Context) error
 
 // EnsureVisibleCreate verifies that a create request does not disclose hidden duplicates.
@@ -50,36 +50,36 @@ func EnsureVisibleCreate(
 	deniedMessage string,
 ) error {
 	if exists == nil {
-		return common.NewInternalServerError("REGPRECHECK-CREATE-EXISTSCALLBACK existence callback must not be nil")
+		return common.NewInternalServerError("CREATEPRECHECK-CREATE-EXISTSCALLBACK existence callback must not be nil")
 	}
 	if read == nil {
-		return common.NewInternalServerError("REGPRECHECK-CREATE-READCALLBACK read callback must not be nil")
+		return common.NewInternalServerError("CREATEPRECHECK-CREATE-READCALLBACK read callback must not be nil")
 	}
 
-	descriptorExists, err := exists(auth.WithoutQueryFilter(ctx))
+	resourceExists, err := exists(auth.WithoutQueryFilter(ctx))
 	if err != nil {
 		return err
 	}
-	return EnsureVisibleDuplicate(ctx, descriptorExists, read, conflictMessage, deniedMessage)
+	return EnsureVisibleDuplicate(ctx, resourceExists, read, conflictMessage, deniedMessage)
 }
 
-// EnsureVisibleDuplicate maps an existing descriptor to conflict or denied
+// EnsureVisibleDuplicate maps an existing resource to conflict or denied
 // without disclosing duplicates hidden by the active create formula.
 func EnsureVisibleDuplicate(
 	ctx context.Context,
-	descriptorExists bool,
+	resourceExists bool,
 	read ReadFunc,
 	conflictMessage string,
 	deniedMessage string,
 ) error {
-	if !descriptorExists {
+	if !resourceExists {
 		return nil
 	}
 	if canSkipDuplicateVisibilityRead(ctx) {
 		return common.NewErrConflict(conflictMessage)
 	}
 	if read == nil {
-		return common.NewInternalServerError("REGPRECHECK-CREATE-READCALLBACK read callback must not be nil")
+		return common.NewInternalServerError("CREATEPRECHECK-CREATE-READCALLBACK read callback must not be nil")
 	}
 
 	if err := read(ctx); err != nil {

--- a/internal/common/createprecheck/create_test.go
+++ b/internal/common/createprecheck/create_test.go
@@ -23,7 +23,7 @@
 * SPDX-License-Identifier: MIT
 ******************************************************************************/
 
-package registryprecheck
+package createprecheck
 
 import (
 	"context"

--- a/internal/common/registryprecheck/create.go
+++ b/internal/common/registryprecheck/create.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 )
 
@@ -66,7 +67,8 @@ func EnsureVisibleCreate(
 		return common.NewErrConflict(conflictMessage)
 	}
 
-	if err = read(ctx); err != nil {
+	readCtx := auth.SelectFormulaForRight(ctx, grammar.RightsEnumREAD)
+	if err = read(readCtx); err != nil {
 		if common.IsErrNotFound(err) || common.IsErrDenied(err) {
 			return common.NewErrDenied(deniedMessage)
 		}

--- a/internal/common/registryprecheck/create.go
+++ b/internal/common/registryprecheck/create.go
@@ -1,0 +1,99 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+// Package registryprecheck contains registry API precheck helpers.
+package registryprecheck
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+)
+
+// ExistsFunc checks raw descriptor existence without visibility filtering.
+type ExistsFunc func(context.Context) (bool, error)
+
+// ReadFunc performs a visibility-aware descriptor read.
+type ReadFunc func(context.Context) error
+
+// EnsureVisibleCreate verifies that a create request does not disclose hidden duplicates.
+func EnsureVisibleCreate(
+	ctx context.Context,
+	exists ExistsFunc,
+	read ReadFunc,
+	conflictMessage string,
+	deniedMessage string,
+) error {
+	if exists == nil {
+		return common.NewInternalServerError("REGPRECHECK-CREATE-EXISTSCALLBACK existence callback must not be nil")
+	}
+	if read == nil {
+		return common.NewInternalServerError("REGPRECHECK-CREATE-READCALLBACK read callback must not be nil")
+	}
+
+	descriptorExists, err := exists(auth.WithoutQueryFilter(ctx))
+	if err != nil {
+		return err
+	}
+	if !descriptorExists {
+		return nil
+	}
+	if auth.GetQueryFilter(ctx) == nil {
+		return common.NewErrConflict(conflictMessage)
+	}
+
+	if err = read(ctx); err != nil {
+		if common.IsErrNotFound(err) || common.IsErrDenied(err) {
+			return common.NewErrDenied(deniedMessage)
+		}
+		return err
+	}
+	return common.NewErrConflict(conflictMessage)
+}
+
+// ResponseStatus maps create precheck errors to an HTTP status and response step.
+func ResponseStatus(err error) (int, string) {
+	switch {
+	case common.IsErrConflict(err):
+		return http.StatusConflict, "Conflict-Exists"
+	case common.IsErrDenied(err):
+		return http.StatusForbidden, "Denied-Exists"
+	case common.IsErrBadRequest(err):
+		return http.StatusBadRequest, "BadRequest-Precheck"
+	default:
+		return http.StatusInternalServerError, "Unhandled-Precheck"
+	}
+}
+
+// ReturnError keeps internal precheck failures visible to generated service callers.
+func ReturnError(err error) error {
+	statusCode, _ := ResponseStatus(err)
+	if statusCode >= http.StatusInternalServerError {
+		return err
+	}
+	return nil
+}

--- a/internal/common/registryprecheck/create.go
+++ b/internal/common/registryprecheck/create.go
@@ -41,22 +41,6 @@ type ExistsFunc func(context.Context) (bool, error)
 // ReadFunc performs a visibility-aware descriptor read.
 type ReadFunc func(context.Context) error
 
-type createOptions struct {
-	readMethod string
-	readPath   string
-}
-
-// CreateOption configures create precheck behavior.
-type CreateOption func(*createOptions)
-
-// WithReadRequest evaluates duplicate visibility using the matching read route.
-func WithReadRequest(method, path string) CreateOption {
-	return func(options *createOptions) {
-		options.readMethod = method
-		options.readPath = path
-	}
-}
-
 // EnsureVisibleCreate verifies that a create request does not disclose hidden duplicates.
 func EnsureVisibleCreate(
 	ctx context.Context,
@@ -64,7 +48,6 @@ func EnsureVisibleCreate(
 	read ReadFunc,
 	conflictMessage string,
 	deniedMessage string,
-	options ...CreateOption,
 ) error {
 	if exists == nil {
 		return common.NewInternalServerError("REGPRECHECK-CREATE-EXISTSCALLBACK existence callback must not be nil")
@@ -77,15 +60,29 @@ func EnsureVisibleCreate(
 	if err != nil {
 		return err
 	}
+	return EnsureVisibleDuplicate(ctx, descriptorExists, read, conflictMessage, deniedMessage)
+}
+
+// EnsureVisibleDuplicate maps an existing descriptor to conflict or denied
+// without disclosing duplicates hidden by the active create formula.
+func EnsureVisibleDuplicate(
+	ctx context.Context,
+	descriptorExists bool,
+	read ReadFunc,
+	conflictMessage string,
+	deniedMessage string,
+) error {
 	if !descriptorExists {
 		return nil
 	}
-	if auth.GetQueryFilter(ctx) == nil {
+	if canSkipDuplicateVisibilityRead(ctx) {
 		return common.NewErrConflict(conflictMessage)
 	}
+	if read == nil {
+		return common.NewInternalServerError("REGPRECHECK-CREATE-READCALLBACK read callback must not be nil")
+	}
 
-	readCtx := duplicateReadContext(ctx, options)
-	if err = read(readCtx); err != nil {
+	if err := read(ctx); err != nil {
 		if common.IsErrNotFound(err) || common.IsErrDenied(err) {
 			return common.NewErrDenied(deniedMessage)
 		}
@@ -94,19 +91,21 @@ func EnsureVisibleCreate(
 	return common.NewErrConflict(conflictMessage)
 }
 
-func duplicateReadContext(ctx context.Context, optionFuncs []CreateOption) context.Context {
-	options := createOptions{}
-	for _, applyOption := range optionFuncs {
-		if applyOption != nil {
-			applyOption(&options)
-		}
+func canSkipDuplicateVisibilityRead(ctx context.Context) bool {
+	queryFilter := auth.GetQueryFilter(ctx)
+	if queryFilter == nil {
+		return true
 	}
-	if options.readMethod != "" && options.readPath != "" {
-		if readCtx, ok := auth.ContextWithAuthorizationFilterForRequest(ctx, options.readMethod, options.readPath); ok {
-			return readCtx
-		}
+	if len(queryFilter.FormulasByRight) > 0 {
+		return auth.HasUnrestrictedFormulaForRight(ctx, grammar.RightsEnumCREATE)
 	}
-	return auth.SelectFormulaForRight(ctx, grammar.RightsEnumREAD)
+	if queryFilter.Formula == nil {
+		return true
+	}
+	if queryFilter.Formula.Boolean != nil && *queryFilter.Formula.Boolean {
+		return true
+	}
+	return false
 }
 
 // ResponseStatus maps create precheck errors to an HTTP status and response step.

--- a/internal/common/registryprecheck/create.go
+++ b/internal/common/registryprecheck/create.go
@@ -41,6 +41,22 @@ type ExistsFunc func(context.Context) (bool, error)
 // ReadFunc performs a visibility-aware descriptor read.
 type ReadFunc func(context.Context) error
 
+type createOptions struct {
+	readMethod string
+	readPath   string
+}
+
+// CreateOption configures create precheck behavior.
+type CreateOption func(*createOptions)
+
+// WithReadRequest evaluates duplicate visibility using the matching read route.
+func WithReadRequest(method, path string) CreateOption {
+	return func(options *createOptions) {
+		options.readMethod = method
+		options.readPath = path
+	}
+}
+
 // EnsureVisibleCreate verifies that a create request does not disclose hidden duplicates.
 func EnsureVisibleCreate(
 	ctx context.Context,
@@ -48,6 +64,7 @@ func EnsureVisibleCreate(
 	read ReadFunc,
 	conflictMessage string,
 	deniedMessage string,
+	options ...CreateOption,
 ) error {
 	if exists == nil {
 		return common.NewInternalServerError("REGPRECHECK-CREATE-EXISTSCALLBACK existence callback must not be nil")
@@ -67,7 +84,7 @@ func EnsureVisibleCreate(
 		return common.NewErrConflict(conflictMessage)
 	}
 
-	readCtx := auth.SelectFormulaForRight(ctx, grammar.RightsEnumREAD)
+	readCtx := duplicateReadContext(ctx, options)
 	if err = read(readCtx); err != nil {
 		if common.IsErrNotFound(err) || common.IsErrDenied(err) {
 			return common.NewErrDenied(deniedMessage)
@@ -75,6 +92,21 @@ func EnsureVisibleCreate(
 		return err
 	}
 	return common.NewErrConflict(conflictMessage)
+}
+
+func duplicateReadContext(ctx context.Context, optionFuncs []CreateOption) context.Context {
+	options := createOptions{}
+	for _, applyOption := range optionFuncs {
+		if applyOption != nil {
+			applyOption(&options)
+		}
+	}
+	if options.readMethod != "" && options.readPath != "" {
+		if readCtx, ok := auth.ContextWithAuthorizationFilterForRequest(ctx, options.readMethod, options.readPath); ok {
+			return readCtx
+		}
+	}
+	return auth.SelectFormulaForRight(ctx, grammar.RightsEnumREAD)
 }
 
 // ResponseStatus maps create precheck errors to an HTTP status and response step.

--- a/internal/common/registryprecheck/create_test.go
+++ b/internal/common/registryprecheck/create_test.go
@@ -1,0 +1,122 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package registryprecheck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureVisibleCreateUsesReadScopedFormula(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: booleanExpression(true),
+			grammar.RightsEnumREAD:   booleanExpression(false),
+		},
+	})
+
+	err := EnsureVisibleCreate(
+		ctx,
+		existingDescriptor,
+		readUsingActiveFormula,
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrDenied(err))
+	require.False(t, common.IsErrConflict(err))
+}
+
+func TestEnsureVisibleCreateReturnsConflictWhenReadScopedFormulaAllowsDescriptor(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: booleanExpression(true),
+			grammar.RightsEnumREAD:   booleanExpression(true),
+		},
+	})
+
+	err := EnsureVisibleCreate(
+		ctx,
+		existingDescriptor,
+		readUsingActiveFormula,
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrConflict(err))
+}
+
+func TestEnsureVisibleCreateFailsClosedWhenReadScopedFormulaIsMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: booleanExpression(true),
+		},
+	})
+
+	err := EnsureVisibleCreate(
+		ctx,
+		existingDescriptor,
+		readUsingActiveFormula,
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrDenied(err))
+	require.False(t, common.IsErrConflict(err))
+}
+
+func existingDescriptor(context.Context) (bool, error) {
+	return true, nil
+}
+
+func readUsingActiveFormula(ctx context.Context) error {
+	queryFilter := auth.GetQueryFilter(ctx)
+	if queryFilter == nil || queryFilter.Formula == nil || queryFilter.Formula.Boolean == nil {
+		return nil
+	}
+	if *queryFilter.Formula.Boolean {
+		return nil
+	}
+	return common.NewErrNotFound("descriptor hidden by read formula")
+}
+
+func booleanExpression(value bool) grammar.LogicalExpression {
+	return grammar.LogicalExpression{Boolean: &value}
+}

--- a/internal/common/registryprecheck/create_test.go
+++ b/internal/common/registryprecheck/create_test.go
@@ -27,6 +27,7 @@ package registryprecheck
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
@@ -35,43 +36,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnsureVisibleCreateUsesReadScopedFormula(t *testing.T) {
+func TestEnsureVisibleCreateSkipsReadWithoutQueryFilter(t *testing.T) {
 	t.Parallel()
 
-	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{
-		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
-			grammar.RightsEnumCREATE: booleanExpression(true),
-			grammar.RightsEnumREAD:   booleanExpression(false),
-		},
-	})
-
 	err := EnsureVisibleCreate(
-		ctx,
+		context.Background(),
 		existingDescriptor,
-		readUsingActiveFormula,
-		"descriptor already exists",
-		"descriptor access not allowed",
-	)
-
-	require.Error(t, err)
-	require.True(t, common.IsErrDenied(err))
-	require.False(t, common.IsErrConflict(err))
-}
-
-func TestEnsureVisibleCreateReturnsConflictWhenReadScopedFormulaAllowsDescriptor(t *testing.T) {
-	t.Parallel()
-
-	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{
-		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
-			grammar.RightsEnumCREATE: booleanExpression(true),
-			grammar.RightsEnumREAD:   booleanExpression(true),
-		},
-	})
-
-	err := EnsureVisibleCreate(
-		ctx,
-		existingDescriptor,
-		readUsingActiveFormula,
+		readMustNotBeCalled,
 		"descriptor already exists",
 		"descriptor access not allowed",
 	)
@@ -80,10 +51,11 @@ func TestEnsureVisibleCreateReturnsConflictWhenReadScopedFormulaAllowsDescriptor
 	require.True(t, common.IsErrConflict(err))
 }
 
-func TestEnsureVisibleCreateFailsClosedWhenReadScopedFormulaIsMissing(t *testing.T) {
+func TestEnsureVisibleCreateSkipsReadWithUnrestrictedCreateFormula(t *testing.T) {
 	t.Parallel()
 
 	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{
+		Formula: boolExpressionPtr(true),
 		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
 			grammar.RightsEnumCREATE: booleanExpression(true),
 		},
@@ -92,7 +64,41 @@ func TestEnsureVisibleCreateFailsClosedWhenReadScopedFormulaIsMissing(t *testing
 	err := EnsureVisibleCreate(
 		ctx,
 		existingDescriptor,
-		readUsingActiveFormula,
+		readMustNotBeCalled,
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrConflict(err))
+}
+
+func TestEnsureVisibleCreateReturnsConflictWhenFilteredReadAllowsDescriptor(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
+
+	err := EnsureVisibleCreate(
+		ctx,
+		existingDescriptor,
+		func(context.Context) error { return nil },
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrConflict(err))
+}
+
+func TestEnsureVisibleCreateReturnsDeniedWhenFilteredReadHidesDescriptor(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
+
+	err := EnsureVisibleCreate(
+		ctx,
+		existingDescriptor,
+		func(context.Context) error { return common.NewErrNotFound("hidden descriptor") },
 		"descriptor already exists",
 		"descriptor access not allowed",
 	)
@@ -102,19 +108,97 @@ func TestEnsureVisibleCreateFailsClosedWhenReadScopedFormulaIsMissing(t *testing
 	require.False(t, common.IsErrConflict(err))
 }
 
+func TestEnsureVisibleCreateAllowsMissingDescriptor(t *testing.T) {
+	t.Parallel()
+
+	err := EnsureVisibleCreate(
+		context.Background(),
+		func(context.Context) (bool, error) { return false, nil },
+		readMustNotBeCalled,
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+
+	require.NoError(t, err)
+}
+
+func TestEnsureVisibleDuplicateAllowsMissingDescriptor(t *testing.T) {
+	t.Parallel()
+
+	err := EnsureVisibleDuplicate(
+		context.Background(),
+		false,
+		readMustNotBeCalled,
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+
+	require.NoError(t, err)
+}
+
+func TestEnsureVisibleDuplicateReturnsDeniedWhenFilteredReadHidesDescriptor(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
+
+	err := EnsureVisibleDuplicate(
+		ctx,
+		true,
+		func(context.Context) error { return common.NewErrDenied("hidden descriptor") },
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrDenied(err))
+	require.False(t, common.IsErrConflict(err))
+}
+
+func TestEnsureVisibleCreatePropagatesCallbackErrors(t *testing.T) {
+	t.Parallel()
+
+	rawErr := errors.New("raw existence failed")
+	err := EnsureVisibleCreate(
+		context.Background(),
+		func(context.Context) (bool, error) { return false, rawErr },
+		func(context.Context) error { return nil },
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+	require.ErrorIs(t, err, rawErr)
+
+	filteredErr := errors.New("filtered read failed")
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
+	err = EnsureVisibleCreate(
+		ctx,
+		existingDescriptor,
+		func(context.Context) error { return filteredErr },
+		"descriptor already exists",
+		"descriptor access not allowed",
+	)
+	require.ErrorIs(t, err, filteredErr)
+}
+
 func existingDescriptor(context.Context) (bool, error) {
 	return true, nil
 }
 
-func readUsingActiveFormula(ctx context.Context) error {
-	queryFilter := auth.GetQueryFilter(ctx)
-	if queryFilter == nil || queryFilter.Formula == nil || queryFilter.Formula.Boolean == nil {
-		return nil
+func readMustNotBeCalled(context.Context) error {
+	return errors.New("read must not be called")
+}
+
+func limitedCreateQueryFilter() *auth.QueryFilter {
+	return &auth.QueryFilter{
+		Formula: boolExpressionPtr(false),
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: booleanExpression(false),
+		},
 	}
-	if *queryFilter.Formula.Boolean {
-		return nil
-	}
-	return common.NewErrNotFound("descriptor hidden by read formula")
+}
+
+func boolExpressionPtr(value bool) *grammar.LogicalExpression {
+	expr := booleanExpression(value)
+	return &expr
 }
 
 func booleanExpression(value bool) grammar.LogicalExpression {

--- a/internal/common/security/abac_put_rights_test.go
+++ b/internal/common/security/abac_put_rights_test.go
@@ -28,10 +28,8 @@ package auth
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
-	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 	apis "github.com/eclipse-basyx/basyx-go-components/pkg/aasregistryapi"
 	"github.com/go-chi/chi/v5"
@@ -169,39 +167,6 @@ func TestSelectFormulaForRight_DefaultsToFalseIfMissing(t *testing.T) {
 	assertFormulaByRightBoolean(t, qf, grammar.RightsEnumREAD, false)
 }
 
-func TestContextWithAuthorizationFilterForRequest_ReevaluatesReadRoute(t *testing.T) {
-	t.Parallel()
-
-	model := mustParseCreateReadAccessModel(t)
-	createExpr := boolExpression(false)
-	ctx := context.WithValue(context.Background(), ClaimsKey, Claims{})
-	ctx = context.WithValue(ctx, authorizationEvaluatorKey, authorizationEvaluator{
-		Model: model,
-		Opts:  grammar.DefaultSimplifyOptions(),
-	})
-	ctx = WithQueryFilter(ctx, &QueryFilter{
-		Formula: &createExpr,
-		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
-			grammar.RightsEnumCREATE: createExpr,
-		},
-	})
-
-	readCtx, ok := ContextWithAuthorizationFilterForRequest(
-		ctx,
-		http.MethodGet,
-		"/shell-descriptors/"+common.EncodeString("https://example.org/A"),
-	)
-
-	if !ok {
-		t.Fatalf("expected request filter evaluation")
-	}
-	qf := GetQueryFilter(readCtx)
-	assertFormulaByRightBoolean(t, qf, grammar.RightsEnumREAD, true)
-	if qf.Formula != nil && qf.Formula.Boolean != nil && !*qf.Formula.Boolean {
-		t.Fatalf("expected read route to replace fail-closed create formula")
-	}
-}
-
 func TestMergeQueryFilter_FailsClosedOnCloneError(t *testing.T) {
 	t.Parallel()
 
@@ -246,45 +211,6 @@ func mustParsePUTAccessModelWithSingleRight(t *testing.T, right grammar.RightsEn
     ]
   }
 }`, right)
-
-	router := chi.NewRouter()
-	ctrl := apis.NewAssetAdministrationShellRegistryAPIAPIController(nil, "/*")
-	for _, rt := range ctrl.Routes() {
-		router.Method(rt.Method, rt.Pattern, rt.HandlerFunc)
-	}
-
-	model, err := ParseAccessModel([]byte(modelJSON), router, "")
-	if err != nil {
-		t.Fatalf("parse model failed: %v", err)
-	}
-	return model
-}
-
-func mustParseCreateReadAccessModel(t *testing.T) *AccessModel {
-	t.Helper()
-
-	modelJSON := `{
-  "AllAccessPermissionRules": {
-    "DEFATTRIBUTES": [
-      { "name": "anonymous", "attributes": [ { "GLOBAL": "ANONYMOUS" } ] }
-    ],
-    "DEFOBJECTS": [
-      { "name": "create_shells", "objects": [ { "ROUTE": "/shell-descriptors" } ] },
-      { "name": "read_shell", "objects": [ { "ROUTE": "/shell-descriptors/*" } ] }
-    ],
-    "DEFACLS": [
-      { "name": "create", "acl": { "USEATTRIBUTES": "anonymous", "RIGHTS": ["CREATE"], "ACCESS": "ALLOW" } },
-      { "name": "read", "acl": { "USEATTRIBUTES": "anonymous", "RIGHTS": ["READ"], "ACCESS": "ALLOW" } }
-    ],
-    "DEFFORMULAS": [
-      { "name": "always_true", "formula": { "$boolean": true } }
-    ],
-    "rules": [
-      { "USEACL": "create", "USEOBJECTS": ["create_shells"], "USEFORMULA": "always_true" },
-      { "USEACL": "read", "USEOBJECTS": ["read_shell"], "USEFORMULA": "always_true" }
-    ]
-  }
-}`
 
 	router := chi.NewRouter()
 	ctrl := apis.NewAssetAdministrationShellRegistryAPIAPIController(nil, "/*")

--- a/internal/common/security/abac_put_rights_test.go
+++ b/internal/common/security/abac_put_rights_test.go
@@ -28,8 +28,10 @@ package auth
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 	apis "github.com/eclipse-basyx/basyx-go-components/pkg/aasregistryapi"
 	"github.com/go-chi/chi/v5"
@@ -167,6 +169,39 @@ func TestSelectFormulaForRight_DefaultsToFalseIfMissing(t *testing.T) {
 	assertFormulaByRightBoolean(t, qf, grammar.RightsEnumREAD, false)
 }
 
+func TestContextWithAuthorizationFilterForRequest_ReevaluatesReadRoute(t *testing.T) {
+	t.Parallel()
+
+	model := mustParseCreateReadAccessModel(t)
+	createExpr := boolExpression(false)
+	ctx := context.WithValue(context.Background(), ClaimsKey, Claims{})
+	ctx = context.WithValue(ctx, authorizationEvaluatorKey, authorizationEvaluator{
+		Model: model,
+		Opts:  grammar.DefaultSimplifyOptions(),
+	})
+	ctx = WithQueryFilter(ctx, &QueryFilter{
+		Formula: &createExpr,
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: createExpr,
+		},
+	})
+
+	readCtx, ok := ContextWithAuthorizationFilterForRequest(
+		ctx,
+		http.MethodGet,
+		"/shell-descriptors/"+common.EncodeString("https://example.org/A"),
+	)
+
+	if !ok {
+		t.Fatalf("expected request filter evaluation")
+	}
+	qf := GetQueryFilter(readCtx)
+	assertFormulaByRightBoolean(t, qf, grammar.RightsEnumREAD, true)
+	if qf.Formula != nil && qf.Formula.Boolean != nil && !*qf.Formula.Boolean {
+		t.Fatalf("expected read route to replace fail-closed create formula")
+	}
+}
+
 func TestMergeQueryFilter_FailsClosedOnCloneError(t *testing.T) {
 	t.Parallel()
 
@@ -211,6 +246,45 @@ func mustParsePUTAccessModelWithSingleRight(t *testing.T, right grammar.RightsEn
     ]
   }
 }`, right)
+
+	router := chi.NewRouter()
+	ctrl := apis.NewAssetAdministrationShellRegistryAPIAPIController(nil, "/*")
+	for _, rt := range ctrl.Routes() {
+		router.Method(rt.Method, rt.Pattern, rt.HandlerFunc)
+	}
+
+	model, err := ParseAccessModel([]byte(modelJSON), router, "")
+	if err != nil {
+		t.Fatalf("parse model failed: %v", err)
+	}
+	return model
+}
+
+func mustParseCreateReadAccessModel(t *testing.T) *AccessModel {
+	t.Helper()
+
+	modelJSON := `{
+  "AllAccessPermissionRules": {
+    "DEFATTRIBUTES": [
+      { "name": "anonymous", "attributes": [ { "GLOBAL": "ANONYMOUS" } ] }
+    ],
+    "DEFOBJECTS": [
+      { "name": "create_shells", "objects": [ { "ROUTE": "/shell-descriptors" } ] },
+      { "name": "read_shell", "objects": [ { "ROUTE": "/shell-descriptors/*" } ] }
+    ],
+    "DEFACLS": [
+      { "name": "create", "acl": { "USEATTRIBUTES": "anonymous", "RIGHTS": ["CREATE"], "ACCESS": "ALLOW" } },
+      { "name": "read", "acl": { "USEATTRIBUTES": "anonymous", "RIGHTS": ["READ"], "ACCESS": "ALLOW" } }
+    ],
+    "DEFFORMULAS": [
+      { "name": "always_true", "formula": { "$boolean": true } }
+    ],
+    "rules": [
+      { "USEACL": "create", "USEOBJECTS": ["create_shells"], "USEFORMULA": "always_true" },
+      { "USEACL": "read", "USEOBJECTS": ["read_shell"], "USEFORMULA": "always_true" }
+    ]
+  }
+}`
 
 	router := chi.NewRouter()
 	ctrl := apis.NewAssetAdministrationShellRegistryAPIAPIController(nil, "/*")

--- a/internal/common/security/abac_put_rights_test.go
+++ b/internal/common/security/abac_put_rights_test.go
@@ -130,6 +130,43 @@ func TestSelectPutFormulaByExistence_FailsClosedOnCloneError(t *testing.T) {
 	assertFormulaByRightBoolean(t, qf, grammar.RightsEnumUPDATE, false)
 }
 
+func TestSelectFormulaForRight_SelectsRequestedRight(t *testing.T) {
+	t.Parallel()
+
+	readExpr := boolExpression(false)
+	createExpr := boolExpression(true)
+	ctx := context.WithValue(context.Background(), filterKey, &QueryFilter{
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: createExpr,
+			grammar.RightsEnumREAD:   readExpr,
+		},
+	})
+
+	readCtx := SelectFormulaForRight(ctx, grammar.RightsEnumREAD)
+	qf := GetQueryFilter(readCtx)
+
+	assertBooleanFormulaPointer(t, qf.Formula, false)
+	assertFormulaByRightBoolean(t, qf, grammar.RightsEnumCREATE, true)
+	assertFormulaByRightBoolean(t, qf, grammar.RightsEnumREAD, false)
+}
+
+func TestSelectFormulaForRight_DefaultsToFalseIfMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(context.Background(), filterKey, &QueryFilter{
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: boolExpression(true),
+		},
+	})
+
+	readCtx := SelectFormulaForRight(ctx, grammar.RightsEnumREAD)
+	qf := GetQueryFilter(readCtx)
+
+	assertBooleanFormulaPointer(t, qf.Formula, false)
+	assertFormulaByRightBoolean(t, qf, grammar.RightsEnumCREATE, true)
+	assertFormulaByRightBoolean(t, qf, grammar.RightsEnumREAD, false)
+}
+
 func TestMergeQueryFilter_FailsClosedOnCloneError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/common/security/authorize.go
+++ b/internal/common/security/authorize.go
@@ -69,8 +69,6 @@ const (
 	filterKey ctxKey = "queryFilter"
 	// authorizationDecisionKey stores the ABAC decision made for the request.
 	authorizationDecisionKey ctxKey = "authorizationDecision"
-	// authorizationEvaluatorKey stores the request-scoped ABAC evaluator.
-	authorizationEvaluatorKey ctxKey = "authorizationEvaluator"
 )
 
 // ResolveResource extracts a Resource from an HTTP request.
@@ -81,11 +79,6 @@ type AuthorizationDecision struct {
 	Result        string
 	PolicyID      string
 	MatchedRuleID string
-}
-
-type authorizationEvaluator struct {
-	Model *AccessModel
-	Opts  grammar.SimplifyOptions
 }
 
 // AccessModelProvider supplies the currently active compiled ABAC model.
@@ -157,10 +150,6 @@ func ABACMiddleware(settings ABACSettings) func(http.Handler) http.Handler {
 					Result:        string(DecisionAllow),
 					PolicyID:      evaluation.PolicyID,
 					MatchedRuleID: evaluation.MatchedRuleID,
-				})
-				ctx = context.WithValue(ctx, authorizationEvaluatorKey, authorizationEvaluator{
-					Model: model,
-					Opts:  opts,
 				})
 				if evaluation.QueryFilter != nil {
 					ctx = context.WithValue(ctx, filterKey, evaluation.QueryFilter)
@@ -348,32 +337,6 @@ func SelectFormulaForRight(ctx context.Context, right grammar.RightsEnum) contex
 	qf.FormulasByRight[right] = fallback
 	qf.Formula = &fallback
 	return WithQueryFilter(ctx, qf)
-}
-
-// ContextWithAuthorizationFilterForRequest evaluates a request route with the
-// same ABAC model and claims as ctx, then replaces the active query filter.
-func ContextWithAuthorizationFilterForRequest(ctx context.Context, method, path string) (context.Context, bool) {
-	evaluator, ok := ctx.Value(authorizationEvaluatorKey).(authorizationEvaluator)
-	if !ok || evaluator.Model == nil {
-		return ctx, false
-	}
-	claims := ClaimsFromContext(ctx)
-	if claims == nil {
-		return ctx, false
-	}
-
-	evaluation := evaluator.Model.AuthorizeWithFilterWithOptions(EvalInput{
-		Method: method,
-		Path:   path,
-		Claims: claims,
-	}, evaluator.Opts)
-	if !evaluation.Allowed {
-		return WithQueryFilter(ctx, failClosedQueryFilter(grammar.RightsEnumREAD)), true
-	}
-	if evaluation.QueryFilter == nil {
-		return WithoutQueryFilter(ctx), true
-	}
-	return WithQueryFilter(ctx, evaluation.QueryFilter), true
 }
 
 // MergeQueryFilter combines an existing QueryFilter with a user query.

--- a/internal/common/security/authorize.go
+++ b/internal/common/security/authorize.go
@@ -304,6 +304,41 @@ func HasUnrestrictedFormulaForRight(ctx context.Context, right grammar.RightsEnu
 	return *expr.Boolean
 }
 
+// SelectFormulaForRight selects the active QueryFilter.Formula for the requested right.
+func SelectFormulaForRight(ctx context.Context, right grammar.RightsEnum) context.Context {
+	existing := GetQueryFilter(ctx)
+	if existing == nil {
+		return ctx
+	}
+
+	qf, cloneErr := CloneQueryFilter(existing)
+	if cloneErr != nil {
+		log.Printf("AUTH-SELECTQF-CLONEERR failed to clone query filter: %v", cloneErr)
+		return WithQueryFilter(ctx, failClosedQueryFilter(right))
+	}
+	if qf == nil {
+		return WithQueryFilter(ctx, failClosedQueryFilter(right))
+	}
+
+	if qf.FormulasByRight == nil {
+		qf.FormulasByRight = make(map[grammar.RightsEnum]grammar.LogicalExpression)
+		fallback := boolExpression(false)
+		qf.FormulasByRight[right] = fallback
+		qf.Formula = &fallback
+		return WithQueryFilter(ctx, qf)
+	}
+
+	if selected, ok := qf.FormulasByRight[right]; ok {
+		qf.Formula = &selected
+		return WithQueryFilter(ctx, qf)
+	}
+
+	fallback := boolExpression(false)
+	qf.FormulasByRight[right] = fallback
+	qf.Formula = &fallback
+	return WithQueryFilter(ctx, qf)
+}
+
 // MergeQueryFilter combines an existing QueryFilter with a user query.
 // It guards nils and merges conditions and filter fragments using logical AND.
 func MergeQueryFilter(ctx context.Context, query grammar.Query) context.Context {
@@ -376,41 +411,11 @@ func MergeQueryFilter(ctx context.Context, query grammar.Query) context.Context 
 // If the requested right-specific formula is unavailable, Formula is set to a
 // constant false expression.
 func SelectPutFormulaByExistence(ctx context.Context, dataExists bool) context.Context {
-	existing := GetQueryFilter(ctx)
-	if existing == nil {
-		return ctx
-	}
 	right := grammar.RightsEnumCREATE
 	if dataExists {
 		right = grammar.RightsEnumUPDATE
 	}
-
-	qf, cloneErr := CloneQueryFilter(existing)
-	if cloneErr != nil {
-		log.Printf("SMREPO-SELECTPUTQF-CLONEERR failed to clone query filter: %v", cloneErr)
-		return WithQueryFilter(ctx, failClosedQueryFilter(right))
-	}
-	if qf == nil {
-		return WithQueryFilter(ctx, failClosedQueryFilter(right))
-	}
-
-	if qf.FormulasByRight == nil {
-		qf.FormulasByRight = make(map[grammar.RightsEnum]grammar.LogicalExpression)
-		fallback := boolExpression(false)
-		qf.FormulasByRight[right] = fallback
-		qf.Formula = &fallback
-		return WithQueryFilter(ctx, qf)
-	}
-
-	if selected, ok := qf.FormulasByRight[right]; ok {
-		qf.Formula = &selected
-		return WithQueryFilter(ctx, qf)
-	}
-
-	fallback := boolExpression(false)
-	qf.FormulasByRight[right] = fallback
-	qf.Formula = &fallback
-	return WithQueryFilter(ctx, qf)
+	return SelectFormulaForRight(ctx, right)
 }
 
 func failClosedQueryFilter(rights ...grammar.RightsEnum) *QueryFilter {

--- a/internal/common/security/authorize.go
+++ b/internal/common/security/authorize.go
@@ -69,6 +69,8 @@ const (
 	filterKey ctxKey = "queryFilter"
 	// authorizationDecisionKey stores the ABAC decision made for the request.
 	authorizationDecisionKey ctxKey = "authorizationDecision"
+	// authorizationEvaluatorKey stores the request-scoped ABAC evaluator.
+	authorizationEvaluatorKey ctxKey = "authorizationEvaluator"
 )
 
 // ResolveResource extracts a Resource from an HTTP request.
@@ -79,6 +81,11 @@ type AuthorizationDecision struct {
 	Result        string
 	PolicyID      string
 	MatchedRuleID string
+}
+
+type authorizationEvaluator struct {
+	Model *AccessModel
+	Opts  grammar.SimplifyOptions
 }
 
 // AccessModelProvider supplies the currently active compiled ABAC model.
@@ -150,6 +157,10 @@ func ABACMiddleware(settings ABACSettings) func(http.Handler) http.Handler {
 					Result:        string(DecisionAllow),
 					PolicyID:      evaluation.PolicyID,
 					MatchedRuleID: evaluation.MatchedRuleID,
+				})
+				ctx = context.WithValue(ctx, authorizationEvaluatorKey, authorizationEvaluator{
+					Model: model,
+					Opts:  opts,
 				})
 				if evaluation.QueryFilter != nil {
 					ctx = context.WithValue(ctx, filterKey, evaluation.QueryFilter)
@@ -337,6 +348,32 @@ func SelectFormulaForRight(ctx context.Context, right grammar.RightsEnum) contex
 	qf.FormulasByRight[right] = fallback
 	qf.Formula = &fallback
 	return WithQueryFilter(ctx, qf)
+}
+
+// ContextWithAuthorizationFilterForRequest evaluates a request route with the
+// same ABAC model and claims as ctx, then replaces the active query filter.
+func ContextWithAuthorizationFilterForRequest(ctx context.Context, method, path string) (context.Context, bool) {
+	evaluator, ok := ctx.Value(authorizationEvaluatorKey).(authorizationEvaluator)
+	if !ok || evaluator.Model == nil {
+		return ctx, false
+	}
+	claims := ClaimsFromContext(ctx)
+	if claims == nil {
+		return ctx, false
+	}
+
+	evaluation := evaluator.Model.AuthorizeWithFilterWithOptions(EvalInput{
+		Method: method,
+		Path:   path,
+		Claims: claims,
+	}, evaluator.Opts)
+	if !evaluation.Allowed {
+		return WithQueryFilter(ctx, failClosedQueryFilter(grammar.RightsEnumREAD)), true
+	}
+	if evaluation.QueryFilter == nil {
+		return WithoutQueryFilter(ctx), true
+	}
+	return WithQueryFilter(ctx, evaluation.QueryFilter), true
 }
 
 // MergeQueryFilter combines an existing QueryFilter with a user query.

--- a/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
+++ b/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
@@ -43,6 +43,7 @@ import (
 	"github.com/doug-martin/goqu/v9"
 	_ "github.com/doug-martin/goqu/v9/dialect/postgres" // Postgres Driver for Goqu
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/history"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
@@ -280,6 +281,30 @@ func (b *ConceptDescriptionBackend) checkConceptDescriptionVisibilityInTx(ctx co
 	return false, false, common.NewInternalServerError("CDREPO-ABACCHKCD-EXECSQL " + scanErr.Error())
 }
 
+func (b *ConceptDescriptionBackend) ensureVisibleConceptDescriptionCreateDoesNotExist(ctx context.Context, tx *sql.Tx, id string) error {
+	return createprecheck.EnsureVisibleCreate(
+		ctx,
+		func(checkCtx context.Context) (bool, error) {
+			return conceptDescriptionExistsInTx(checkCtx, tx, id)
+		},
+		func(readCtx context.Context) error {
+			exists, visible, err := b.checkConceptDescriptionVisibilityInTx(readCtx, tx, id)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return common.NewErrNotFound("CDREPO-CRTCD-CHKDUP-NOTFOUND existing concept description not found")
+			}
+			if !visible {
+				return common.NewErrDenied("CDREPO-CRTCD-CHKDUP-ABACDENIED existing concept description is not accessible under ABAC constraints")
+			}
+			return nil
+		},
+		"Concept description with the given ID already exists - use PUT for Replacement",
+		"CDREPO-CRTCD-CHKDUP-ABACDENIED existing concept description is not accessible under ABAC constraints",
+	)
+}
+
 // CreateConceptDescription inserts a new concept description into the database.
 func (b *ConceptDescriptionBackend) CreateConceptDescription(ctx context.Context, cd types.IConceptDescription) (err error) {
 	tx, cleanup, err := common.StartTransaction(b.db)
@@ -288,12 +313,8 @@ func (b *ConceptDescriptionBackend) CreateConceptDescription(ctx context.Context
 	}
 	defer cleanup(&err)
 
-	exists, err := conceptDescriptionExistsInTx(ctx, tx, cd.ID())
-	if err != nil {
+	if err = b.ensureVisibleConceptDescriptionCreateDoesNotExist(ctx, tx, cd.ID()); err != nil {
 		return err
-	}
-	if exists {
-		return common.NewErrConflict("Concept description with the given ID already exists - use PUT for Replacement")
 	}
 
 	if err = b.createConceptDescriptionInTx(ctx, tx, cd); err != nil {

--- a/internal/conceptdescriptionrepository/persistence/concept_description_create_visibility_test.go
+++ b/internal/conceptdescriptionrepository/persistence/concept_description_create_visibility_test.go
@@ -1,0 +1,93 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package persistence
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConceptDescriptionRepositoryCreateExistingUnauthorizedConceptDescriptionDoesNotReturnConflict(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	sut := &ConceptDescriptionBackend{db: db}
+	conceptDescription := types.NewConceptDescription("urn:example:cd:hidden-existing")
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT 1 FROM "concept_description"`).
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
+	mock.ExpectQuery(`SELECT 1 FROM "concept_description"`).
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
+	mock.ExpectQuery(`SELECT "id" FROM "concept_description".*FALSE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectRollback()
+
+	err = sut.CreateConceptDescription(contextWithRestrictedCreateConceptDescription(t), conceptDescription)
+	require.Error(t, err)
+	require.True(t, common.IsErrDenied(err))
+	require.False(t, common.IsErrConflict(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func contextWithRestrictedCreateConceptDescription(t *testing.T) context.Context {
+	t.Helper()
+
+	cfg := &common.Config{}
+	var cfgCtx context.Context
+	handler := common.ConfigMiddleware(cfg)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		cfgCtx = r.Context()
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.NotNil(t, cfgCtx)
+	return auth.WithQueryFilter(cfgCtx, limitedCreateQueryFilterForRepositoryTests())
+}
+
+func limitedCreateQueryFilterForRepositoryTests() *auth.QueryFilter {
+	denied := false
+	expr := grammar.LogicalExpression{Boolean: &denied}
+	return &auth.QueryFilter{
+		Formula: &expr,
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: expr,
+		},
+	}
+}

--- a/internal/smregistry/api/api_submodel_registry_api_service.go
+++ b/internal/smregistry/api/api_submodel_registry_api_service.go
@@ -46,6 +46,7 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 	smregistrypostgresql "github.com/eclipse-basyx/basyx-go-components/internal/smregistry/persistence"
 )
@@ -152,17 +153,24 @@ func (s *SubmodelRegistryAPIAPIService) QuerySubmodelDescriptors(
 // PostSubmodelDescriptor - Creates a new Submodel Descriptor, i.e. registers a submodel
 func (s *SubmodelRegistryAPIAPIService) PostSubmodelDescriptor(ctx context.Context, submodelDescriptor model.SubmodelDescriptor) (model.ImplResponse, error) {
 	if strings.TrimSpace(submodelDescriptor.Id) != "" {
-		if exists, chkErr := s.smRegistryBackend.ExistsSubmodelByID(ctx, submodelDescriptor.Id); chkErr != nil {
-			log.Printf("[ERROR] [%s] Error in PostSubmodelDescriptor: existence check failed (submodelId=%q): %v", componentName, submodelDescriptor.Id, chkErr)
+		precheckErr := registryprecheck.EnsureVisibleCreate(
+			ctx,
+			func(checkCtx context.Context) (bool, error) {
+				return s.smRegistryBackend.ExistsSubmodelByID(checkCtx, submodelDescriptor.Id)
+			},
+			func(readCtx context.Context) error {
+				_, readErr := s.smRegistryBackend.GetSubmodelDescriptorByID(readCtx, submodelDescriptor.Id)
+				return readErr
+			},
+			"Submodel with given id already exists",
+			"Submodel Descriptor access not allowed",
+		)
+		if precheckErr != nil {
+			statusCode, step := registryprecheck.ResponseStatus(precheckErr)
+			log.Printf("[ERROR] [%s] Error in PostSubmodelDescriptor: create precheck failed (submodelId=%q): %v", componentName, submodelDescriptor.Id, precheckErr)
 			return common.NewErrorResponse(
-				chkErr, http.StatusInternalServerError, componentName, "PostSubmodelDescriptor", "Unhandled-Precheck",
-			), chkErr
-		} else if exists {
-			e := common.NewErrConflict("Submodel with given id already exists")
-			log.Printf("[ERROR] [%s] Error in PostSubmodelDescriptor: conflict (submodelId=%q): %v", componentName, submodelDescriptor.Id, e)
-			return common.NewErrorResponse(
-				e, http.StatusConflict, componentName, "PostSubmodelDescriptor", "Conflict-Exists",
-			), nil
+				precheckErr, statusCode, componentName, "PostSubmodelDescriptor", step,
+			), registryprecheck.ReturnError(precheckErr)
 		}
 	}
 

--- a/internal/smregistry/api/api_submodel_registry_api_service.go
+++ b/internal/smregistry/api/api_submodel_registry_api_service.go
@@ -164,7 +164,6 @@ func (s *SubmodelRegistryAPIAPIService) PostSubmodelDescriptor(ctx context.Conte
 			},
 			"Submodel with given id already exists",
 			"Submodel Descriptor access not allowed",
-			registryprecheck.WithReadRequest(http.MethodGet, "/submodel-descriptors/"+common.EncodeString(submodelDescriptor.Id)),
 		)
 		if precheckErr != nil {
 			statusCode, step := registryprecheck.ResponseStatus(precheckErr)

--- a/internal/smregistry/api/api_submodel_registry_api_service.go
+++ b/internal/smregistry/api/api_submodel_registry_api_service.go
@@ -44,9 +44,9 @@ import (
 	"time"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
-	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 	smregistrypostgresql "github.com/eclipse-basyx/basyx-go-components/internal/smregistry/persistence"
 )
@@ -153,7 +153,7 @@ func (s *SubmodelRegistryAPIAPIService) QuerySubmodelDescriptors(
 // PostSubmodelDescriptor - Creates a new Submodel Descriptor, i.e. registers a submodel
 func (s *SubmodelRegistryAPIAPIService) PostSubmodelDescriptor(ctx context.Context, submodelDescriptor model.SubmodelDescriptor) (model.ImplResponse, error) {
 	if strings.TrimSpace(submodelDescriptor.Id) != "" {
-		precheckErr := registryprecheck.EnsureVisibleCreate(
+		precheckErr := createprecheck.EnsureVisibleCreate(
 			ctx,
 			func(checkCtx context.Context) (bool, error) {
 				return s.smRegistryBackend.ExistsSubmodelByID(checkCtx, submodelDescriptor.Id)
@@ -166,11 +166,11 @@ func (s *SubmodelRegistryAPIAPIService) PostSubmodelDescriptor(ctx context.Conte
 			"Submodel Descriptor access not allowed",
 		)
 		if precheckErr != nil {
-			statusCode, step := registryprecheck.ResponseStatus(precheckErr)
+			statusCode, step := createprecheck.ResponseStatus(precheckErr)
 			log.Printf("[ERROR] [%s] Error in PostSubmodelDescriptor: create precheck failed (submodelId=%q): %v", componentName, submodelDescriptor.Id, precheckErr)
 			return common.NewErrorResponse(
 				precheckErr, statusCode, componentName, "PostSubmodelDescriptor", step,
-			), registryprecheck.ReturnError(precheckErr)
+			), createprecheck.ReturnError(precheckErr)
 		}
 	}
 

--- a/internal/smregistry/api/api_submodel_registry_api_service.go
+++ b/internal/smregistry/api/api_submodel_registry_api_service.go
@@ -164,6 +164,7 @@ func (s *SubmodelRegistryAPIAPIService) PostSubmodelDescriptor(ctx context.Conte
 			},
 			"Submodel with given id already exists",
 			"Submodel Descriptor access not allowed",
+			registryprecheck.WithReadRequest(http.MethodGet, "/submodel-descriptors/"+common.EncodeString(submodelDescriptor.Id)),
 		)
 		if precheckErr != nil {
 			statusCode, step := registryprecheck.ResponseStatus(precheckErr)

--- a/internal/smregistry/api/bulk_atomic_operations.go
+++ b/internal/smregistry/api/bulk_atomic_operations.go
@@ -35,6 +35,7 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/asyncbulk"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 )
 
@@ -192,43 +193,39 @@ func (s *SubmodelRegistryAPIAPIService) ensureSubmodelDescriptorsDoNotExist(
 	identifiers []string,
 	failure *asyncbulk.ItemFailure,
 ) error {
-	if auth.GetQueryFilter(ctx) != nil {
-		return s.ensureVisibleSubmodelDescriptorsDoNotExist(ctx, tx, identifiers, failure)
-	}
-
 	existing, err := s.smRegistryBackend.ExistingSubmodelDescriptorIDsInTransaction(ctx, tx, identifiers)
 	if err != nil {
 		*failure = asyncbulk.ItemFailure{Index: 0, Identifier: firstIdentifier(identifiers), StatusCode: http.StatusInternalServerError, Message: err.Error()}
 		return err
 	}
-	for index, identifier := range identifiers {
-		if _, found := existing[identifier]; found {
-			err := common.NewErrConflict("Submodel with given id already exists")
-			*failure = asyncbulk.ItemFailure{Index: index, Identifier: identifier, StatusCode: http.StatusConflict, Message: err.Error()}
-			return err
-		}
-	}
-	return nil
+	return s.ensureVisibleSubmodelDescriptorDuplicates(ctx, tx, identifiers, existing, failure)
 }
 
-func (s *SubmodelRegistryAPIAPIService) ensureVisibleSubmodelDescriptorsDoNotExist(
+func (s *SubmodelRegistryAPIAPIService) ensureVisibleSubmodelDescriptorDuplicates(
 	ctx context.Context,
 	tx *sql.Tx,
 	identifiers []string,
+	existing map[string]struct{},
 	failure *asyncbulk.ItemFailure,
 ) error {
 	for index, identifier := range identifiers {
-		_, err := s.smRegistryBackend.GetSubmodelDescriptorByIDInTransaction(ctx, tx, identifier)
-		if err == nil {
-			err = common.NewErrConflict("Submodel with given id already exists")
-			*failure = asyncbulk.ItemFailure{Index: index, Identifier: identifier, StatusCode: http.StatusConflict, Message: err.Error()}
-			return err
-		}
-		if common.IsErrNotFound(err) {
+		if _, found := existing[identifier]; !found {
 			continue
 		}
-		*failure = asyncbulk.ItemFailure{Index: index, Identifier: identifier, StatusCode: smBulkCreateErrorStatusCode(err), Message: err.Error()}
-		return err
+		err := registryprecheck.EnsureVisibleDuplicate(
+			ctx,
+			true,
+			func(readCtx context.Context) error {
+				_, readErr := s.smRegistryBackend.GetSubmodelDescriptorByIDInTransaction(readCtx, tx, identifier)
+				return readErr
+			},
+			"Submodel with given id already exists",
+			"Submodel Descriptor access not allowed",
+		)
+		if err != nil {
+			*failure = asyncbulk.ItemFailure{Index: index, Identifier: identifier, StatusCode: smBulkCreateErrorStatusCode(err), Message: err.Error()}
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/smregistry/api/bulk_atomic_operations.go
+++ b/internal/smregistry/api/bulk_atomic_operations.go
@@ -34,8 +34,8 @@ import (
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/asyncbulk"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
-	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 )
 
@@ -212,7 +212,7 @@ func (s *SubmodelRegistryAPIAPIService) ensureVisibleSubmodelDescriptorDuplicate
 		if _, found := existing[identifier]; !found {
 			continue
 		}
-		err := registryprecheck.EnsureVisibleDuplicate(
+		err := createprecheck.EnsureVisibleDuplicate(
 			ctx,
 			true,
 			func(readCtx context.Context) error {

--- a/internal/smregistry/api/create_precheck_test.go
+++ b/internal/smregistry/api/create_precheck_test.go
@@ -32,8 +32,8 @@ import (
 	"testing"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
-	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +43,7 @@ func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *te
 
 	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 
-	err := registryprecheck.EnsureVisibleCreate(
+	err := createprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) { return true, nil },
 		func(context.Context) error { return common.NewErrNotFound("hidden descriptor") },
@@ -54,7 +54,7 @@ func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *te
 	require.Error(t, err)
 	require.True(t, common.IsErrDenied(err))
 	require.False(t, common.IsErrConflict(err))
-	statusCode, _ := registryprecheck.ResponseStatus(err)
+	statusCode, _ := createprecheck.ResponseStatus(err)
 	require.Equal(t, http.StatusForbidden, statusCode)
 }
 
@@ -63,7 +63,7 @@ func TestRegistryCreatePrecheckReturnsConflictForVisibleDescriptor(t *testing.T)
 
 	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 
-	err := registryprecheck.EnsureVisibleCreate(
+	err := createprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) { return true, nil },
 		func(context.Context) error { return nil },
@@ -73,14 +73,14 @@ func TestRegistryCreatePrecheckReturnsConflictForVisibleDescriptor(t *testing.T)
 
 	require.Error(t, err)
 	require.True(t, common.IsErrConflict(err))
-	statusCode, _ := registryprecheck.ResponseStatus(err)
+	statusCode, _ := createprecheck.ResponseStatus(err)
 	require.Equal(t, http.StatusConflict, statusCode)
 }
 
 func TestRegistryCreatePrecheckAllowsMissingDescriptor(t *testing.T) {
 	t.Parallel()
 
-	err := registryprecheck.EnsureVisibleCreate(
+	err := createprecheck.EnsureVisibleCreate(
 		context.Background(),
 		func(context.Context) (bool, error) { return false, nil },
 		func(context.Context) error { return errors.New("read must not be called") },
@@ -95,7 +95,7 @@ func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
 	t.Parallel()
 
 	rawErr := errors.New("raw existence failed")
-	err := registryprecheck.EnsureVisibleCreate(
+	err := createprecheck.EnsureVisibleCreate(
 		context.Background(),
 		func(context.Context) (bool, error) { return false, rawErr },
 		func(context.Context) error { return nil },
@@ -106,7 +106,7 @@ func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
 
 	filteredErr := errors.New("filtered read failed")
 	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
-	err = registryprecheck.EnsureVisibleCreate(
+	err = createprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) { return true, nil },
 		func(context.Context) error { return filteredErr },

--- a/internal/smregistry/api/create_precheck_test.go
+++ b/internal/smregistry/api/create_precheck_test.go
@@ -1,0 +1,116 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package smregistryapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
+	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+
+	err := registryprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) { return true, nil },
+		func(context.Context) error { return common.NewErrNotFound("hidden descriptor") },
+		"Submodel with given id already exists",
+		"Submodel Descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrDenied(err))
+	require.False(t, common.IsErrConflict(err))
+	statusCode, _ := registryprecheck.ResponseStatus(err)
+	require.Equal(t, http.StatusForbidden, statusCode)
+}
+
+func TestRegistryCreatePrecheckReturnsConflictForVisibleDescriptor(t *testing.T) {
+	t.Parallel()
+
+	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+
+	err := registryprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) { return true, nil },
+		func(context.Context) error { return nil },
+		"Submodel with given id already exists",
+		"Submodel Descriptor access not allowed",
+	)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrConflict(err))
+	statusCode, _ := registryprecheck.ResponseStatus(err)
+	require.Equal(t, http.StatusConflict, statusCode)
+}
+
+func TestRegistryCreatePrecheckAllowsMissingDescriptor(t *testing.T) {
+	t.Parallel()
+
+	err := registryprecheck.EnsureVisibleCreate(
+		context.Background(),
+		func(context.Context) (bool, error) { return false, nil },
+		func(context.Context) error { return errors.New("read must not be called") },
+		"Submodel with given id already exists",
+		"Submodel Descriptor access not allowed",
+	)
+
+	require.NoError(t, err)
+}
+
+func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
+	t.Parallel()
+
+	rawErr := errors.New("raw existence failed")
+	err := registryprecheck.EnsureVisibleCreate(
+		context.Background(),
+		func(context.Context) (bool, error) { return false, rawErr },
+		func(context.Context) error { return nil },
+		"Submodel with given id already exists",
+		"Submodel Descriptor access not allowed",
+	)
+	require.ErrorIs(t, err, rawErr)
+
+	filteredErr := errors.New("filtered read failed")
+	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+	err = registryprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) { return true, nil },
+		func(context.Context) error { return filteredErr },
+		"Submodel with given id already exists",
+		"Submodel Descriptor access not allowed",
+	)
+	require.ErrorIs(t, err, filteredErr)
+}

--- a/internal/smregistry/api/create_precheck_test.go
+++ b/internal/smregistry/api/create_precheck_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/registryprecheck"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ import (
 func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *testing.T) {
 	t.Parallel()
 
-	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 
 	err := registryprecheck.EnsureVisibleCreate(
 		ctx,
@@ -60,7 +61,7 @@ func TestRegistryCreateExistingUnauthorizedDescriptorDoesNotReturnConflict(t *te
 func TestRegistryCreatePrecheckReturnsConflictForVisibleDescriptor(t *testing.T) {
 	t.Parallel()
 
-	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 
 	err := registryprecheck.EnsureVisibleCreate(
 		ctx,
@@ -104,7 +105,7 @@ func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
 	require.ErrorIs(t, err, rawErr)
 
 	filteredErr := errors.New("filtered read failed")
-	ctx := auth.WithQueryFilter(context.Background(), &auth.QueryFilter{})
+	ctx := auth.WithQueryFilter(context.Background(), limitedCreateQueryFilter())
 	err = registryprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) { return true, nil },
@@ -113,4 +114,18 @@ func TestRegistryCreatePrecheckPropagatesErrors(t *testing.T) {
 		"Submodel Descriptor access not allowed",
 	)
 	require.ErrorIs(t, err, filteredErr)
+}
+
+func limitedCreateQueryFilter() *auth.QueryFilter {
+	falseExpression := grammar.LogicalExpression{Boolean: boolPtr(false)}
+	return &auth.QueryFilter{
+		Formula: &falseExpression,
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: falseExpression,
+		},
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/internal/submodelrepository/api/api_submodel_repository_api_service.go
+++ b/internal/submodelrepository/api/api_submodel_repository_api_service.go
@@ -76,6 +76,23 @@ func newAPIErrorResponse(err error, status int, operation string, info string) g
 	return common.NewErrorResponse(err, status, componentName, operation, info)
 }
 
+func newPostSubmodelElementByPathErrorResponse(err error) gen.ImplResponse {
+	const operation = "PostSubmodelElementByPathSubmodelRepo"
+
+	switch {
+	case common.IsErrDenied(err):
+		return newAPIErrorResponse(err, http.StatusForbidden, operation, "Denied")
+	case common.IsErrNotFound(err) || errors.Is(err, sql.ErrNoRows):
+		return newAPIErrorResponse(err, http.StatusNotFound, operation, "ParentOrSubmodelNotFound")
+	case common.IsErrConflict(err):
+		return newAPIErrorResponse(err, http.StatusConflict, operation, "Conflict")
+	case common.IsErrBadRequest(err):
+		return newAPIErrorResponse(err, http.StatusBadRequest, operation, "BadRequest")
+	default:
+		return newAPIErrorResponse(err, http.StatusInternalServerError, operation, "AddSubmodelElementWithPath")
+	}
+}
+
 func submodelValueToAnyMap(value gen.SubmodelValue) map[string]any {
 	result := make(map[string]any, len(value))
 	for key, val := range value {
@@ -2087,16 +2104,7 @@ func (s *SubmodelRepositoryAPIAPIService) PostSubmodelElementByPathSubmodelRepo(
 
 	err := s.submodelBackend.AddSubmodelElementWithPath(ctx, decodedSubmodelIdentifier, idShortPath, submodelElement)
 	if err != nil {
-		if common.IsErrNotFound(err) || errors.Is(err, sql.ErrNoRows) {
-			return newAPIErrorResponse(err, http.StatusNotFound, operation, "ParentOrSubmodelNotFound"), nil
-		}
-		if common.IsErrConflict(err) {
-			return newAPIErrorResponse(err, http.StatusConflict, operation, "Conflict"), nil
-		}
-		if common.IsErrBadRequest(err) {
-			return newAPIErrorResponse(err, http.StatusBadRequest, operation, "BadRequest"), nil
-		}
-		return newAPIErrorResponse(err, http.StatusInternalServerError, operation, "AddSubmodelElementWithPath"), nil
+		return newPostSubmodelElementByPathErrorResponse(err), nil
 	}
 
 	parsedElement, parseErr := jsonization.ToJsonable(submodelElement)

--- a/internal/submodelrepository/api/api_submodel_repository_api_service_test.go
+++ b/internal/submodelrepository/api/api_submodel_repository_api_service_test.go
@@ -144,6 +144,16 @@ func TestInvokeOperationValueOnlyReturnsBadRequest(t *testing.T) {
 	require.Equal(t, 400, response.Code)
 }
 
+func TestPostSubmodelElementByPathSubmodelRepoMapsDeniedToForbidden(t *testing.T) {
+	t.Parallel()
+
+	response := newPostSubmodelElementByPathErrorResponse(
+		common.NewErrDenied("SMREPO-ADDSMEBYPATH-CHKDUP-ABACDENIED existing submodel element is not accessible under ABAC constraints"),
+	)
+
+	require.Equal(t, http.StatusForbidden, response.Code)
+}
+
 func TestGetOperationAsyncStatusReturnsRedirectWithLocation(t *testing.T) {
 	sut := NewSubmodelRepositoryAPIAPIService(persistencepostgresql.SubmodelDatabase{})
 

--- a/internal/submodelrepository/persistence/queries/submodel_database_queries.go
+++ b/internal/submodelrepository/persistence/queries/submodel_database_queries.go
@@ -357,11 +357,17 @@ func BuildDeleteSubmodelSemanticIDSQL(submodelDatabaseID int) (string, []any, er
 		ToSQL()
 }
 
-// BuildSiblingIDShortCollisionSQL builds the sibling idShort collision query.
-func BuildSiblingIDShortCollisionSQL(submodelDatabaseID int, parentElementID *int, idShort string) (string, []any, error) {
+// BuildSiblingIDShortCollisionPathSQL builds the sibling idShort collision path query.
+func BuildSiblingIDShortCollisionPathSQL(submodelDatabaseID int, parentElementID *int, idShort string) (string, []any, error) {
+	return siblingIDShortCollisionDataset(submodelDatabaseID, parentElementID, idShort).
+		Select(goqu.C("idshort_path")).
+		Limit(1).
+		ToSQL()
+}
+
+func siblingIDShortCollisionDataset(submodelDatabaseID int, parentElementID *int, idShort string) *goqu.SelectDataset {
 	dialect := goqu.Dialect(common.Dialect)
-	query := dialect.From("submodel_element").
-		Select(goqu.COUNT("*"))
+	query := dialect.From("submodel_element")
 
 	whereExpressions := []goqu.Expression{
 		goqu.C("submodel_id").Eq(submodelDatabaseID),
@@ -374,7 +380,7 @@ func BuildSiblingIDShortCollisionSQL(submodelDatabaseID int, parentElementID *in
 		whereExpressions = append(whereExpressions, goqu.C("parent_sme_id").Eq(*parentElementID))
 	}
 
-	return query.Where(whereExpressions...).ToSQL()
+	return query.Where(whereExpressions...)
 }
 
 // BuildSubmodelElementModelTypeByPathSQL builds the model type lookup query for an element path.

--- a/internal/submodelrepository/persistence/submodel_create_visibility_test.go
+++ b/internal/submodelrepository/persistence/submodel_create_visibility_test.go
@@ -1,0 +1,120 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package persistence
+
+import (
+	"context"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmodelRepositoryCreateExistingUnauthorizedSubmodelDoesNotReturnConflict(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	sut := &SubmodelDatabase{db: db}
+	submodel := types.NewSubmodel("urn:example:sm:hidden-existing")
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT "id" FROM "submodel"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+	mock.ExpectQuery(`SELECT "id" FROM "submodel"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+	mock.ExpectQuery(`SELECT "id" FROM "submodel".*FALSE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectRollback()
+
+	err = sut.CreateSubmodel(contextWithRestrictedCreateSubmodel(t), submodel)
+	require.Error(t, err)
+	require.True(t, common.IsErrDenied(err))
+	require.False(t, common.IsErrConflict(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSubmodelRepositoryCreateExistingUnauthorizedSubmodelElementDoesNotReturnConflict(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	sut := &SubmodelDatabase{db: db}
+	submodelID := "urn:example:sm:element-hidden-existing"
+	element := types.NewProperty(types.DataTypeDefXSDString)
+	idShort := "HiddenElement"
+	element.SetIDShort(&idShort)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT "id" FROM "submodel"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+	mock.ExpectQuery(`SELECT MAX\("position"\) FROM "submodel_element"`).
+		WillReturnRows(sqlmock.NewRows([]string{"max"}).AddRow(-1))
+	mock.ExpectQuery(`SELECT .*FROM "submodel_element"`).
+		WillReturnRows(sqlmock.NewRows([]string{"idshort_path"}).AddRow("HiddenElement"))
+	mock.ExpectQuery(`SELECT "id" FROM "submodel"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+	mock.ExpectQuery(`SELECT .*"sme"\."id".*FROM "submodel_element" AS "sme".*"sme"\."idshort_path" =`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(7))
+	mock.ExpectQuery(`SELECT .*"sme"\."id".*FROM "submodel_element" AS "sme".*FALSE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectRollback()
+
+	err = sut.AddSubmodelElement(contextWithRestrictedCreateSubmodel(t), submodelID, element)
+	require.Error(t, err)
+	require.Truef(t, common.IsErrDenied(err), "got %v", err)
+	require.False(t, common.IsErrConflict(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func contextWithRestrictedCreateSubmodel(t *testing.T) context.Context {
+	t.Helper()
+
+	return auth.WithQueryFilter(contextWithABACDisabled(t), limitedCreateQueryFilterForRepositoryTests())
+}
+
+func limitedCreateQueryFilterForRepositoryTests() *auth.QueryFilter {
+	denied := false
+	expr := grammar.LogicalExpression{Boolean: &denied}
+	return &auth.QueryFilter{
+		Formula: &expr,
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumCREATE: expr,
+		},
+	}
+}

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -129,6 +129,8 @@ func TestCreateSubmodelInsertFailureRollsBack(t *testing.T) {
 	submodel.SetIDShort(&idShort)
 
 	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT "id" FROM "submodel"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
 		WillReturnError(errors.New("insert failed"))
 	mock.ExpectRollback()
@@ -155,6 +157,8 @@ func TestCreateSubmodelDuplicateIdentifierReturnsConflict(t *testing.T) {
 	submodel.SetIDShort(&idShort)
 
 	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT "id" FROM "submodel"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
 		WillReturnError(&pgconn.PgError{Code: "23505"})
 	mock.ExpectRollback()
@@ -781,70 +785,6 @@ func TestQuerySubmodelsMissingConditionReturnsBadRequest(t *testing.T) {
 	require.Empty(t, cursor)
 	require.True(t, common.IsErrBadRequest(err))
 	require.Contains(t, err.Error(), "SMREPO-QUERYSMS-INVALIDQUERY")
-}
-
-func TestIsIDShortDuplicateEmptyIDShortReturnsFalse(t *testing.T) {
-	t.Parallel()
-
-	element := types.NewProperty(types.DataTypeDefXSDString)
-
-	collision := isIDShortDuplicate(nil, 1, nil, element)
-	require.False(t, collision)
-}
-
-func TestIsIDShortDuplicateTopLevelReturnsTrue(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() {
-		_ = db.Close()
-	}()
-
-	mock.ExpectBegin()
-	tx, err := db.Begin()
-	require.NoError(t, err)
-
-	idShort := "duplicate"
-	element := types.NewProperty(types.DataTypeDefXSDString)
-	element.SetIDShort(&idShort)
-
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM "submodel_element"`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectRollback()
-
-	collision := isIDShortDuplicate(tx, 42, nil, element)
-	require.True(t, collision)
-	require.NoError(t, tx.Rollback())
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestIsIDShortDuplicateNestedReturnsFalse(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() {
-		_ = db.Close()
-	}()
-
-	mock.ExpectBegin()
-	tx, err := db.Begin()
-	require.NoError(t, err)
-
-	idShort := "nested"
-	element := types.NewProperty(types.DataTypeDefXSDString)
-	element.SetIDShort(&idShort)
-
-	parentID := 99
-	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM "submodel_element"`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectRollback()
-
-	collision := isIDShortDuplicate(tx, 42, &parentID, element)
-	require.False(t, collision)
-	require.NoError(t, tx.Rollback())
-	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestGetSubmodelReferencesReturnsModelReferencesWithSingleSubmodelKey(t *testing.T) {

--- a/internal/submodelrepository/persistence/submodel_element_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_element_write_database.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/FriedJannik/aas-go-sdk/types"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/history"
 	gen "github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
@@ -43,7 +44,7 @@ import (
 	persistenceutils "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence/utils"
 )
 
-func (s *SubmodelDatabase) addTopLevelSubmodelElementInTransaction(tx *sql.Tx, submodelID string, submodelElement types.ISubmodelElement) (string, error) {
+func (s *SubmodelDatabase) addTopLevelSubmodelElementInTransaction(ctx context.Context, tx *sql.Tx, submodelID string, submodelElement types.ISubmodelElement) (string, error) {
 	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseID(tx, submodelID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -68,8 +69,17 @@ func (s *SubmodelDatabase) addTopLevelSubmodelElementInTransaction(tx *sql.Tx, s
 		startPosition = int(maxPosition.Int64) + 1
 	}
 
-	if isIDShortDuplicate(tx, submodelDatabaseID, nil, submodelElement) {
-		return "", common.NewErrConflict("SMREPO-ADDSME-COLLISION Duplicate submodel element idShort")
+	if err = s.ensureVisibleSubmodelElementCreateDoesNotExist(
+		ctx,
+		tx,
+		submodelID,
+		submodelDatabaseID,
+		nil,
+		submodelElement,
+		"SMREPO-ADDSME-COLLISION Duplicate submodel element idShort",
+		"SMREPO-ADDSME-CHKDUP-ABACDENIED existing submodel element is not accessible under ABAC constraints",
+	); err != nil {
+		return "", err
 	}
 
 	_, err = submodelelements.InsertSubmodelElements(
@@ -149,7 +159,7 @@ func (s *SubmodelDatabase) AddSubmodelElement(ctx context.Context, submodelID st
 	}
 	defer cleanup(&err)
 
-	insertedPath, err := s.addTopLevelSubmodelElementInTransaction(tx, submodelID, submodelElement)
+	insertedPath, err := s.addTopLevelSubmodelElementInTransaction(ctx, tx, submodelID, submodelElement)
 	if err != nil {
 		return err
 	}
@@ -214,8 +224,17 @@ func (s *SubmodelDatabase) addSubmodelElementWithPathInTransaction(ctx context.C
 		return err
 	}
 
-	if isIDShortDuplicate(tx, submodelDatabaseID, &parentElementID, submodelElement) {
-		return common.NewErrConflict("SMREPO-ADDSMEBYPATH-COLLISION Duplicate submodel element idShort")
+	if err = s.ensureVisibleSubmodelElementCreateDoesNotExist(
+		ctx,
+		tx,
+		submodelID,
+		submodelDatabaseID,
+		&parentElementID,
+		submodelElement,
+		"SMREPO-ADDSMEBYPATH-COLLISION Duplicate submodel element idShort",
+		"SMREPO-ADDSMEBYPATH-CHKDUP-ABACDENIED existing submodel element is not accessible under ABAC constraints",
+	); err != nil {
+		return err
 	}
 
 	_, err = submodelelements.InsertSubmodelElements(
@@ -441,7 +460,7 @@ func (s *SubmodelDatabase) createSubmodelElementForPut(
 	submodelElement.SetIDShort(&targetIDShort)
 
 	if isTopLevelPutCreate(parentPath) {
-		if _, err = s.addTopLevelSubmodelElementInTransaction(tx, submodelID, submodelElement); err != nil {
+		if _, err = s.addTopLevelSubmodelElementInTransaction(ctx, tx, submodelID, submodelElement); err != nil {
 			return submodelElementRootMutation{}, err
 		}
 		return submodelElementRootMutation{currentPath: idShortPath}, nil
@@ -682,23 +701,69 @@ func (s *SubmodelDatabase) UpdateSubmodelValueOnly(ctx context.Context, submodel
 	return tx.Commit()
 }
 
-func isIDShortDuplicate(tx *sql.Tx, submodelDatabaseID int, parentElementID *int, submodelElement types.ISubmodelElement) bool {
+func (s *SubmodelDatabase) ensureVisibleSubmodelElementCreateDoesNotExist(
+	ctx context.Context,
+	tx *sql.Tx,
+	submodelID string,
+	submodelDatabaseID int,
+	parentElementID *int,
+	submodelElement types.ISubmodelElement,
+	conflictMessage string,
+	deniedMessage string,
+) error {
 	idShortPtr := submodelElement.IDShort()
 	if idShortPtr == nil || *idShortPtr == "" {
-		return false
+		return nil
 	}
 
-	sqlQuery, args, err := submodelqueries.BuildSiblingIDShortCollisionSQL(submodelDatabaseID, parentElementID, *idShortPtr)
+	duplicatePath := ""
+	return createprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) {
+			path, exists, err := siblingIDShortCollisionPathInTx(tx, submodelDatabaseID, parentElementID, *idShortPtr)
+			if err != nil {
+				return false, err
+			}
+			duplicatePath = path
+			return exists, nil
+		},
+		func(readCtx context.Context) error {
+			if duplicatePath == "" {
+				return common.NewInternalServerError("SMREPO-CHKSMEDUP-EMPTYPATH existing submodel element duplicate path is empty")
+			}
+			exists, visible, err := s.checkSubmodelElementVisibilityInTx(readCtx, tx, submodelID, duplicatePath)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return common.NewErrNotFound("SMREPO-CHKSMEDUP-NOTFOUND existing submodel element not found")
+			}
+			if !visible {
+				return common.NewErrDenied(deniedMessage)
+			}
+			return nil
+		},
+		conflictMessage,
+		deniedMessage,
+	)
+}
+
+func siblingIDShortCollisionPathInTx(tx *sql.Tx, submodelDatabaseID int, parentElementID *int, idShort string) (string, bool, error) {
+	query, args, err := submodelqueries.BuildSiblingIDShortCollisionPathSQL(submodelDatabaseID, parentElementID, idShort)
 	if err != nil {
-		return false
+		return "", false, common.NewInternalServerError("SMREPO-CHKSMEDUP-BUILDPATHQ " + err.Error())
 	}
 
-	var count int
-	if err = tx.QueryRow(sqlQuery, args...).Scan(&count); err != nil {
-		return false
+	var idShortPath string
+	err = tx.QueryRow(query, args...).Scan(&idShortPath)
+	if err == nil {
+		return idShortPath, true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
 	}
 
-	return count > 0
+	return "", false, common.NewInternalServerError("SMREPO-CHKSMEDUP-EXECPATHQ " + err.Error())
 }
 
 func getSMEModelTypeByPathInTx(tx *sql.Tx, submodelID string, idShortOrPath string) (*types.ModelType, error) {

--- a/internal/submodelrepository/persistence/submodel_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_write_database.go
@@ -29,10 +29,12 @@ package persistence
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/FriedJannik/aas-go-sdk/types"
 	"github.com/FriedJannik/aas-go-sdk/verification"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/createprecheck"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/history"
 	gen "github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
@@ -86,6 +88,10 @@ func (s *SubmodelDatabase) CreateSubmodelInTransaction(ctx context.Context, tx *
 }
 
 func (s *SubmodelDatabase) createSubmodelInTransactionValidated(ctx context.Context, tx *sql.Tx, submodel types.ISubmodel) error {
+	if err := s.ensureVisibleSubmodelCreateDoesNotExist(ctx, tx, submodel.ID()); err != nil {
+		return err
+	}
+
 	err := s.createSubmodelInTransaction(tx, submodel)
 	if err != nil {
 		return err
@@ -108,6 +114,37 @@ func (s *SubmodelDatabase) createSubmodelInTransactionValidated(ctx context.Cont
 		}
 	}
 	return nil
+}
+
+func (s *SubmodelDatabase) ensureVisibleSubmodelCreateDoesNotExist(ctx context.Context, tx *sql.Tx, submodelID string) error {
+	return createprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) {
+			_, err := persistenceutils.GetSubmodelDatabaseID(tx, submodelID)
+			if err == nil {
+				return true, nil
+			}
+			if errors.Is(err, sql.ErrNoRows) {
+				return false, nil
+			}
+			return false, common.NewInternalServerError("SMREPO-NEWSM-CHKDUP-GETSMDATABASEID " + err.Error())
+		},
+		func(readCtx context.Context) error {
+			exists, visible, err := s.checkSubmodelVisibilityInTx(readCtx, tx, submodelID)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return common.NewErrNotFound("SMREPO-NEWSM-CHKDUP-NOTFOUND existing submodel not found")
+			}
+			if !visible {
+				return common.NewErrDenied("SMREPO-NEWSM-CHKDUP-ABACDENIED existing submodel is not accessible under ABAC constraints")
+			}
+			return nil
+		},
+		"SMREPO-NEWSM-CREATE-CONFLICT submodel identifier already exists",
+		"SMREPO-NEWSM-CHKDUP-ABACDENIED existing submodel is not accessible under ABAC constraints",
+	)
 }
 
 func (s *SubmodelDatabase) createSubmodelInTransaction(tx *sql.Tx, submodel types.ISubmodel) error {


### PR DESCRIPTION
## Summary

Fix duplicate-create prechecks so hidden existing resources are not disclosed through `409 Conflict` responses. The shared helper now lives under `internal/common/createprecheck` and is used by registry and repository create paths.

## Changes

- Rename `registryprecheck` to `createprecheck`
- Keep raw existence checks for technical duplicate detection
- Return `409 Conflict` only when the existing resource is visible under the active create context
- Return `403 Forbidden` for hidden existing duplicates
- Apply the behavior to:
  - AAS Registry
  - Submodel Registry
  - AAS Repository
  - Submodel Repository
  - Concept Description Repository
  - Submodel element create/by-path create duplicate checks
- Fix by-path submodel element POST error mapping so denied duplicate checks return `403`

## Tests

- Added regression tests for hidden duplicate create checks
- Added API status mapping coverage for by-path submodel element create
- Verified with unit tests, vet, lint, and submodel repository integration tests

Closes #452 