### PR TITLE
Fix Docker-backed integration test collisions

### DIFF
--- a/internal/aasenvironment/integration_tests/aasenvironment_bulk_integration_test.go
+++ b/internal/aasenvironment/integration_tests/aasenvironment_bulk_integration_test.go
@@ -43,8 +43,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const aasEnvBaseURL = "http://127.0.0.1:6004"
-
 var aasEnvNoRedirectClient = &http.Client{
 	Timeout: 10 * time.Second,
 	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {

--- a/internal/aasenvironment/integration_tests/aasenvironment_integration_test.go
+++ b/internal/aasenvironment/integration_tests/aasenvironment_integration_test.go
@@ -40,7 +40,10 @@ import (
 )
 
 const composeFilePath = "./docker_compose/docker_compose.yml"
-const integrationTestDSN = "host=127.0.0.1 port=6432 user=admin password=admin123 dbname=basyxTestDB sslmode=disable"
+
+var aasEnvBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
+var aasEnvSyncOffBaseURL = testenv.LocalURLFromEnv("BASYX_IT_SYNC_OFF_API_PORT", 6005)
+var integrationTestDSN = testenv.PostgresKeywordDSNFromEnv("BASYX_IT_DB_PORT", 6432, "basyxTestDB")
 
 var allowedIntegrationPackages = map[string]struct{}{
 	"github.com/eclipse-basyx/basyx-go-components/internal/aasregistry/integration_tests":                  {},
@@ -52,10 +55,26 @@ var allowedIntegrationPackages = map[string]struct{}{
 }
 
 func TestMain(m *testing.M) {
+	runtime := testenv.NewComposeRuntimeOrExit("aasenvironment-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "sync-off-api", EnvVar: "BASYX_IT_SYNC_OFF_API_PORT"},
+		{Name: "sync-off-db", EnvVar: "BASYX_IT_SYNC_OFF_DB_PORT"},
+	})
+	aasEnvBaseURL = runtime.LocalURL("api")
+	aasEnvSyncOffBaseURL = runtime.LocalURL("sync-off-api")
+	integrationTestDSN = runtime.PostgresKeywordDSN("db", "basyxTestDB")
+	serializationBaseURL = runtime.LocalURL("api")
+	serializationIntegrationDSN = runtime.PostgresKeywordDSN("db", "basyxTestDB")
+	uploadIntegrationDSN = runtime.PostgresKeywordDSN("db", "basyxTestDB")
+	uploadSyncDisabledIntegrationDSN = runtime.PostgresKeywordDSN("sync-off-db", "basyxTestDBSyncOff")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     composeFilePath,
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.Env(),
 		PreDownBeforeUp: true,
-		HealthURL:       "http://127.0.0.1:6004/health",
+		HealthURL:       aasEnvBaseURL + "/health",
 		HealthTimeout:   3 * time.Minute,
 	}))
 }

--- a/internal/aasenvironment/integration_tests/aasenvironment_serialization_integration_test.go
+++ b/internal/aasenvironment/integration_tests/aasenvironment_serialization_integration_test.go
@@ -50,6 +50,7 @@ import (
 	aastypes "github.com/FriedJannik/aas-go-sdk/types"
 	aasxmlization "github.com/FriedJannik/aas-go-sdk/xmlization"
 	aasx "github.com/aas-core-works/aas-package3-golang"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,10 +62,10 @@ const (
 	serializationThreeAasxJsonAltDownloadPath          = "testdata_results/threeAASDuplicateFilesSerializationTest_downloaded_json_alt_from_xml_aasx_upload.aasx"
 	serializationThreeAasXmlDownloadFromXmlUploadPath  = "testdata_results/threeAASDuplicateFilesSerializationTest_downloaded_xml_from_xml_aasx_upload.xml"
 	serializationThreeAasJsonDownloadFromXmlUploadPath = "testdata_results/threeAASDuplicateFilesSerializationTest_downloaded_json_from_xml_aasx_upload.json"
-	serializationBaseURL                               = "http://127.0.0.1:6004"
-
-	serializationIntegrationDSN = "host=127.0.0.1 port=6432 user=admin password=admin123 dbname=basyxTestDB sslmode=disable"
 )
+
+var serializationBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
+var serializationIntegrationDSN = testenv.PostgresKeywordDSNFromEnv("BASYX_IT_DB_PORT", 6432, "basyxTestDB")
 
 func TestSerializationDownloadAasXmlAfterThreeAasUpload(t *testing.T) {
 	skipSerializationTestsInCI(t)

--- a/internal/aasenvironment/integration_tests/aasenvironment_upload_integration_test.go
+++ b/internal/aasenvironment/integration_tests/aasenvironment_upload_integration_test.go
@@ -53,8 +53,6 @@ const actionUploadMultipart = "UPLOAD_MULTIPART"
 const actionVerifyAASXAttachments = "VERIFY_AASX_ATTACHMENTS"
 const actionVerifyAASXThumbnail = "VERIFY_AASX_THUMBNAIL"
 const actionVerifyEndpointSnapshot = "VERIFY_ENDPOINT_SNAPSHOT"
-const uploadIntegrationDSN = "host=127.0.0.1 port=6432 user=admin password=admin123 dbname=basyxTestDB sslmode=disable"
-const uploadSyncDisabledIntegrationDSN = "host=127.0.0.1 port=6433 user=admin password=admin123 dbname=basyxTestDBSyncOff sslmode=disable"
 const expectationRequired = "required"
 const expectationAbsent = "absent"
 const expectationOptional = "optional"
@@ -63,6 +61,10 @@ const uploadHeaderPartFileName = "X-Upload-Part-FileName"
 const uploadHeaderPartOmitFileName = "X-Upload-Part-OmitFileName"
 const uploadHeaderRequestFileName = "X-Upload-FileName"
 const uploadHeaderExpectedErrorContains = "X-Upload-Expected-Error-Contains"
+
+var uploadIntegrationDSN = testenv.PostgresKeywordDSNFromEnv("BASYX_IT_DB_PORT", 6432, "basyxTestDB")
+var uploadSyncDisabledIntegrationDSN = testenv.PostgresKeywordDSNFromEnv("BASYX_IT_SYNC_OFF_DB_PORT", 6433, "basyxTestDBSyncOff")
+
 const uploadHeaderExpectedErrorContainsSecondary = "X-Upload-Expected-Error-Contains-Secondary"
 
 var numericValuePattern = regexp.MustCompile(`^\d+$`)
@@ -101,7 +103,7 @@ func TestRegistrySyncIntegration(t *testing.T) {
 
 func TestRegistrySyncDisabledIntegration(t *testing.T) {
 	resetDatabaseForUploadIT(t, uploadSyncDisabledIntegrationDSN)
-	waitForIntegrationHealth(t, "http://127.0.0.1:6005/health", 2*time.Minute)
+	waitForIntegrationHealth(t, aasEnvSyncOffBaseURL+"/health", 2*time.Minute)
 	runUploadJSONSuite(t, "registry_sync_disabled_it_config.json")
 }
 

--- a/internal/aasenvironment/integration_tests/docker_compose/docker_compose.yml
+++ b/internal/aasenvironment/integration_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db_it:
     image: postgres:18
-    container_name: postgres_db_it
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -17,14 +16,13 @@ services:
 
   db_it_sync_off:
     image: postgres:18
-    container_name: postgres_db_it_sync_off
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDBSyncOff
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6433:5432"
+      - "127.0.0.1:${BASYX_IT_SYNC_OFF_DB_PORT:-6433}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDBSyncOff"]
       interval: 10s
@@ -52,12 +50,12 @@ services:
       - ABAC_ENABLED=false
       - GENERAL_AASREGISTRYINTEGRATION=true
       - GENERAL_SUBMODELREGISTRYINTEGRATION=true
-      - GENERAL_EXTERNALURL=http://127.0.0.1:6004
+      - GENERAL_EXTERNALURL=http://127.0.0.1:${BASYX_IT_API_PORT:-6004}
       - JWS_PRIVATEKEYPATH=/app/rsa-key.pem
     volumes:
       - ../../../submodelrepository/integration_tests/docker_compose/rsa-key.pem:/app/rsa-key.pem:ro
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     extra_hosts:
       - "localhost:host-gateway"
     depends_on:
@@ -87,7 +85,7 @@ services:
     volumes:
       - ../../../submodelrepository/integration_tests/docker_compose/rsa-key.pem:/app/rsa-key.pem:ro
     ports:
-      - "6005:5004"
+      - "127.0.0.1:${BASYX_IT_SYNC_OFF_API_PORT:-6005}:5004"
     extra_hosts:
       - "localhost:host-gateway"
     depends_on:
@@ -95,7 +93,6 @@ services:
         condition: service_completed_successfully
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile
@@ -113,7 +110,6 @@ services:
         condition: service_healthy
 
   basyx_configuration_sync_off:
-    container_name: basyx_configuration_sync_off
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_put_shell_with_submodels.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_put_shell_with_submodels.json
@@ -24,7 +24,7 @@
         {
           "interface": "SUBMODEL-3.0",
           "protocolInformation": {
-            "href": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+            "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
             "endpointProtocol": "http"
           }
         }
@@ -35,7 +35,7 @@
     {
       "interface": "AAS-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+        "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_submodel_ref_post.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_submodel_ref_post.json
@@ -24,7 +24,7 @@
         {
           "interface": "SUBMODEL-3.0",
           "protocolInformation": {
-            "href": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+            "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
             "endpointProtocol": "http"
           }
         }
@@ -35,7 +35,7 @@
     {
       "interface": "AAS-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+        "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_metadata_patch.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_metadata_patch.json
@@ -44,7 +44,7 @@
         {
           "interface": "SUBMODEL-3.0",
           "protocolInformation": {
-            "href": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+            "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
             "endpointProtocol": "http"
           }
         }
@@ -55,7 +55,7 @@
     {
       "interface": "AAS-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+        "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_patch.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_patch.json
@@ -38,7 +38,7 @@
         {
           "interface": "SUBMODEL-3.0",
           "protocolInformation": {
-            "href": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+            "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
             "endpointProtocol": "http"
           }
         }
@@ -49,7 +49,7 @@
     {
       "interface": "AAS-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+        "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_put.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_put.json
@@ -38,7 +38,7 @@
         {
           "interface": "SUBMODEL-3.0",
           "protocolInformation": {
-            "href": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+            "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
             "endpointProtocol": "http"
           }
         }
@@ -49,7 +49,7 @@
     {
       "interface": "AAS-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+        "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_patch_submodel_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_patch_submodel_descriptor.json
@@ -24,7 +24,7 @@
     {
       "interface": "SUBMODEL-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+        "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_post_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_post_descriptor.json
@@ -21,7 +21,7 @@
     {
       "interface": "AAS-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+        "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_post_submodel_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_post_submodel_descriptor.json
@@ -18,7 +18,7 @@
     {
       "interface": "SUBMODEL-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+        "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_put_descriptor_asset_information.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_put_descriptor_asset_information.json
@@ -21,7 +21,7 @@
     {
       "interface": "AAS-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+        "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_put_submodel_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_put_submodel_descriptor.json
@@ -14,7 +14,7 @@
     {
       "interface": "SUBMODEL-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+        "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_uploaded_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_uploaded_descriptor.json
@@ -7,7 +7,7 @@
     {
       "interface": "AAS-3.0",
       "protocolInformation": {
-        "href": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtdXBsb2Fk",
+        "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtdXBsb2Fk",
         "endpointProtocol": "http"
       }
     }

--- a/internal/aasenvironment/integration_tests/registry_sync_disabled_it_config.json
+++ b/internal/aasenvironment/integration_tests/registry_sync_disabled_it_config.json
@@ -2,20 +2,20 @@
   {
     "context": "001 - Health Check (sync disabled)",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6005/health",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/health",
     "expectedStatus": 200
   },
   {
     "context": "002 - List empty AAS descriptors (sync disabled)",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6005/shell-descriptors",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/registry_sync_empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "003 - Create AAS via /shells (sync disabled)",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6005/shells",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/shells",
     "data": "testdata/registry_sync_post_shell.json",
     "shouldMatch": "testdata/registry_sync_post_shell.json",
     "expectedStatus": 201
@@ -23,13 +23,13 @@
   {
     "context": "004 - Verify AAS descriptor is not created when sync is disabled",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6005/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "expectedStatus": 404
   },
   {
     "context": "005 - Create submodel via /submodels (sync disabled)",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6005/submodels",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/submodels",
     "data": "testdata/registry_sync_post_submodel.json",
     "shouldMatch": "testdata/registry_sync_post_submodel.json",
     "expectedStatus": 201
@@ -37,39 +37,39 @@
   {
     "context": "006 - Verify submodel descriptor is not created when sync is disabled",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6005/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "expectedStatus": 404
   },
   {
     "context": "007 - Verify posted /submodels entry is not reachable via superpath without reference (sync disabled)",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6005/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "expectedStatus": 404
   },
   {
     "context": "008 - Create submodel via AAS superpath (sync disabled)",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6005/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
     "data": "testdata/registry_sync_put_superpath_submodel.json",
     "expectedStatus": 201
   },
   {
     "context": "009 - Verify superpath-created submodel is reachable via /submodels/{id} (sync disabled)",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6005/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
     "shouldMatch": "expected/registry_sync_get_superpath_submodel.json",
     "expectedStatus": 200
   },
   {
     "context": "010 - Verify AAS descriptor still not created after superpath update when sync is disabled",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6005/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "expectedStatus": 404
   },
   {
     "context": "011 - Verify submodel descriptor still not created after superpath update when sync is disabled",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6005/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+    "endpoint": "{{BASYX_IT_SYNC_OFF_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
     "expectedStatus": 404
   }
 ]

--- a/internal/aasenvironment/integration_tests/registry_sync_it_config.json
+++ b/internal/aasenvironment/integration_tests/registry_sync_it_config.json
@@ -2,26 +2,26 @@
   {
     "context": "001 - Health Check",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "expectedStatus": 200
   },
   {
     "context": "002 - List empty AAS descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/registry_sync_empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "002.1 - List empty AAS descriptors trailing slash",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "003 - Create AAS via /shells",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "data": "testdata/registry_sync_post_shell.json",
     "shouldMatch": "testdata/registry_sync_post_shell.json",
     "expectedStatus": 201
@@ -29,41 +29,41 @@
   {
     "context": "004 - Verify descriptor for posted shell",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_post_descriptor.json",
     "expectedStatus": 200
   },
   {
     "context": "005 - Verify discovery links for posted shell",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_post_lookup_links.json",
     "expectedStatus": 200
   },
   {
     "context": "005.1 - Lookup shells collection trailing slash",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/",
     "expectedStatus": 404
   },
   {
     "context": "006 - Update asset information via /shells/{id}/asset-information",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/asset-information",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/asset-information",
     "data": "testdata/registry_sync_put_asset_information.json",
     "expectedStatus": 204
   },
   {
     "context": "007 - Verify descriptor after asset information update",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_put_descriptor_asset_information.json",
     "expectedStatus": 200
   },
   {
     "context": "008 - Create submodel via /submodels",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "data": "testdata/registry_sync_post_submodel.json",
     "shouldMatch": "testdata/registry_sync_post_submodel.json",
     "expectedStatus": 201
@@ -71,162 +71,162 @@
   {
     "context": "009 - Verify descriptor for posted submodel",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "shouldMatch": "expected/registry_sync_post_submodel_descriptor.json",
     "expectedStatus": 200
   },
   {
     "context": "009.0 - List submodel descriptors trailing slash",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "009.1 - Verify posted /submodels entry is not reachable via superpath without reference",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "expectedStatus": 404
   },
   {
     "context": "010 - Patch submodel metadata via /submodels/{id}/$metadata",
     "method": "PATCH",
-    "endpoint": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0/$metadata",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0/$metadata",
     "data": "testdata/registry_sync_patch_submodel_metadata.json",
     "expectedStatus": 204
   },
   {
     "context": "011 - Verify descriptor after metadata patch",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "shouldMatch": "expected/registry_sync_patch_submodel_descriptor.json",
     "expectedStatus": 200
   },
   {
     "context": "012 - Update submodel via /submodels/{id}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "data": "testdata/registry_sync_put_submodel.json",
     "expectedStatus": 204
   },
   {
     "context": "013 - Verify descriptor for updated submodel",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "shouldMatch": "expected/registry_sync_put_submodel_descriptor.json",
     "expectedStatus": 200
   },
   {
     "context": "014 - Delete submodel via /submodels/{id}",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "expectedStatus": 204
   },
   {
     "context": "015 - Verify descriptor removed for deleted submodel",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "expectedStatus": 404
   },
   {
     "context": "016 - Create submodel via AAS superpath",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
     "data": "testdata/registry_sync_put_superpath_submodel.json",
     "expectedStatus": 201
   },
   {
     "context": "017 - Verify AAS descriptor after superpath submodel create",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_aas_descriptor_after_superpath_put.json",
     "expectedStatus": 200
   },
   {
     "context": "017.1 - Verify superpath-created submodel is reachable via /submodels/{id}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
     "shouldMatch": "expected/registry_sync_get_superpath_submodel.json",
     "expectedStatus": 200
   },
   {
     "context": "018 - Patch submodel via AAS superpath",
     "method": "PATCH",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
     "data": "testdata/registry_sync_patch_superpath_submodel.json",
     "expectedStatus": 204
   },
   {
     "context": "019 - Verify AAS descriptor after superpath submodel patch",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_aas_descriptor_after_superpath_patch.json",
     "expectedStatus": 200
   },
   {
     "context": "020 - Patch superpath submodel metadata",
     "method": "PATCH",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg/$metadata",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg/$metadata",
     "data": "testdata/registry_sync_patch_superpath_submodel_metadata.json",
     "expectedStatus": 204
   },
   {
     "context": "021 - Verify AAS descriptor after superpath metadata patch",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_aas_descriptor_after_superpath_metadata_patch.json",
     "expectedStatus": 200
   },
   {
     "context": "022 - Delete superpath submodel",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
     "expectedStatus": 204
   },
   {
     "context": "023 - Verify AAS descriptor after superpath submodel delete",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_put_descriptor_asset_information.json",
     "expectedStatus": 200
   },
   {
     "context": "024 - Create submodel reference in AAS",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodel-refs",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodel-refs",
     "data": "testdata/registry_sync_post_submodel_ref_existing.json",
     "expectedStatus": 201
   },
   {
     "context": "025 - Verify AAS descriptor after submodel reference create",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_aas_descriptor_after_submodel_ref_post.json",
     "expectedStatus": 200
   },
   {
     "context": "026 - Delete submodel reference in AAS",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodel-refs/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA/submodel-refs/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
     "expectedStatus": 204
   },
   {
     "context": "027 - Verify AAS descriptor after submodel reference delete",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_put_descriptor_asset_information.json",
     "expectedStatus": 200
   },
   {
     "context": "028 - Update AAS with submodel references via /shells/{id}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "data": "testdata/registry_sync_put_shell_with_submodels.json",
     "expectedStatus": 204
   },
   {
     "context": "029 - Verify AAS descriptor after shell update with references",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
     "shouldMatch": "expected/registry_sync_aas_descriptor_after_put_shell_with_submodels.json",
     "expectedStatus": 200
   },
@@ -234,7 +234,7 @@
     "context": "030 - Upload JSON environment via /upload",
     "action": "UPLOAD_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/registry_sync_upload_environment.json",
     "headers": {
       "X-Upload-Part-ContentType": "application/json"
@@ -244,14 +244,14 @@
   {
     "context": "031 - Verify uploaded shell exists",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtdXBsb2Fk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtdXBsb2Fk",
     "shouldMatch": "expected/registry_sync_uploaded_shell.json",
     "expectedStatus": 200
   },
   {
     "context": "032 - Verify descriptor for uploaded shell",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtdXBsb2Fk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtdXBsb2Fk",
     "shouldMatch": "expected/registry_sync_uploaded_descriptor.json",
     "expectedStatus": 200
   }

--- a/internal/aasenvironment/integration_tests/upload_harting_it_config.json
+++ b/internal/aasenvironment/integration_tests/upload_harting_it_config.json
@@ -2,14 +2,14 @@
   {
     "context": "001 - Health Check",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "expectedStatus": 200
   },
   {
     "context": "002 - Upload HARTING AASX using backward-compatible namespace adaptation",
     "action": "UPLOAD_AASX_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/HARTING_AAS_09140009950.aasx",
     "expectedStatus": 200
   }

--- a/internal/aasenvironment/integration_tests/upload_it_config.json
+++ b/internal/aasenvironment/integration_tests/upload_it_config.json
@@ -2,14 +2,14 @@
   {
     "context": "001 - Health Check",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "expectedStatus": 200
   },
   {
     "context": "002 - Upload AASX file",
     "action": "UPLOAD_AASX_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/IESEDriveMotorDM3000.aasx",
     "expectedStatus": 200
   },
@@ -17,20 +17,20 @@
     "context": "003 - List AAS after upload",
     "action": "VERIFY_ENDPOINT_SNAPSHOT",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "data": "expected/iese_shells.json",
     "expectedStatus": 200
   },
   {
     "context": "003.1 - List AAS after upload trailing slash",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shells/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/",
     "expectedStatus": 404
   },
   {
     "context": "004 - Verify uploaded file attachments",
     "action": "VERIFY_AASX_ATTACHMENTS",
-    "endpoint": "http://127.0.0.1:6004",
+    "endpoint": "{{BASYX_IT_API_URL}}",
     "headers": {
       "X-Attachments-Expectation": "required"
     },
@@ -39,7 +39,7 @@
   {
     "context": "005 - Verify AAS thumbnails",
     "action": "VERIFY_AASX_THUMBNAIL",
-    "endpoint": "http://127.0.0.1:6004",
+    "endpoint": "{{BASYX_IT_API_URL}}",
     "headers": {
       "X-Thumbnail-Expectation": "required"
     },
@@ -49,28 +49,28 @@
     "context": "006 - List Submodels after upload",
     "action": "VERIFY_ENDPOINT_SNAPSHOT",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "data": "expected/iese_submodels.json",
     "expectedStatus": 200
   },
   {
     "context": "006.1 - List Submodels after upload trailing slash",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodels/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/",
     "expectedStatus": 404
   },
   {
     "context": "007 - List ConceptDescriptions after upload",
     "action": "VERIFY_ENDPOINT_SNAPSHOT",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "data": "expected/iese_conceptdescriptions.json",
     "expectedStatus": 200
   },
   {
     "context": "007.1 - List ConceptDescriptions after upload trailing slash",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/concept-descriptions/",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/",
     "expectedStatus": 404
   }
 ]

--- a/internal/aasenvironment/integration_tests/upload_json_xml_config.json
+++ b/internal/aasenvironment/integration_tests/upload_json_xml_config.json
@@ -2,14 +2,14 @@
   {
     "context": "001 - Health Check",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "expectedStatus": 200
   },
   {
     "context": "002 - Upload JSON environment by content type",
     "action": "UPLOAD_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/environment_minimal.json",
     "headers": {
       "X-Upload-Part-ContentType": "application/json"
@@ -20,7 +20,7 @@
     "context": "003 - Upload XML environment by content type",
     "action": "UPLOAD_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/environment_minimal.xml",
     "headers": {
       "X-Upload-Part-ContentType": "application/xml"
@@ -31,7 +31,7 @@
     "context": "004 - MIME wins over misleading extension",
     "action": "UPLOAD_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/environment_minimal.json",
     "headers": {
       "X-Upload-Part-ContentType": "application/json",
@@ -44,7 +44,7 @@
     "context": "005 - Reject unsupported media type",
     "action": "UPLOAD_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/environment_minimal.json",
     "headers": {
       "X-Upload-Part-ContentType": "text/plain"
@@ -55,7 +55,7 @@
     "context": "006 - Reject malformed JSON body",
     "action": "UPLOAD_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/environment_malformed.json",
     "headers": {
       "X-Upload-Part-ContentType": "application/json"
@@ -66,7 +66,7 @@
     "context": "007 - Reject malformed XML body",
     "action": "UPLOAD_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/environment_malformed.xml",
     "headers": {
       "X-Upload-Part-ContentType": "application/xml"
@@ -77,7 +77,7 @@
     "context": "008 - Infer JSON without MIME and filename",
     "action": "UPLOAD_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/environment_minimal.json",
     "headers": {
       "X-Upload-Part-ContentType": "application/octet-stream",

--- a/internal/aasenvironment/integration_tests/upload_productionplan_it_config.json
+++ b/internal/aasenvironment/integration_tests/upload_productionplan_it_config.json
@@ -2,14 +2,14 @@
   {
     "context": "001 - Health Check",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "expectedStatus": 200
   },
   {
     "context": "002 - Upload ProductionPlan AASX file",
     "action": "UPLOAD_AASX_MULTIPART",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "testdata/ProductionPlanSFKL.aasx",
     "expectedStatus": 200
   },
@@ -17,20 +17,20 @@
     "context": "003 - List AAS after ProductionPlan upload",
     "action": "VERIFY_ENDPOINT_SNAPSHOT",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "data": "expected/productionplan_shells.json",
     "expectedStatus": 200
   },
   {
     "context": "003.1 - List AAS after ProductionPlan upload trailing slash",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shells/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/",
     "expectedStatus": 404
   },
   {
     "context": "004 - Verify uploaded file attachments",
     "action": "VERIFY_AASX_ATTACHMENTS",
-    "endpoint": "http://127.0.0.1:6004",
+    "endpoint": "{{BASYX_IT_API_URL}}",
     "headers": {
       "X-Attachments-Expectation": "absent"
     },
@@ -39,7 +39,7 @@
   {
     "context": "005 - Verify AAS thumbnails",
     "action": "VERIFY_AASX_THUMBNAIL",
-    "endpoint": "http://127.0.0.1:6004",
+    "endpoint": "{{BASYX_IT_API_URL}}",
     "headers": {
       "X-Thumbnail-Expectation": "absent"
     },
@@ -49,28 +49,28 @@
     "context": "006 - List Submodels after ProductionPlan upload",
     "action": "VERIFY_ENDPOINT_SNAPSHOT",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "data": "expected/productionplan_submodels.json",
     "expectedStatus": 200
   },
   {
     "context": "006.1 - List Submodels after ProductionPlan upload trailing slash",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodels/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/",
     "expectedStatus": 404
   },
   {
     "context": "007 - List ConceptDescriptions after ProductionPlan upload",
     "action": "VERIFY_ENDPOINT_SNAPSHOT",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "data": "expected/productionplan_conceptdescriptions.json",
     "expectedStatus": 200
   },
   {
     "context": "007.1 - List ConceptDescriptions after ProductionPlan upload trailing slash",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/concept-descriptions/",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/",
     "expectedStatus": 404
   }
 ]

--- a/internal/aasenvironment/marker_access_integration_tests/expected/dtr_admin.json
+++ b/internal/aasenvironment/marker_access_integration_tests/expected/dtr_admin.json
@@ -49,7 +49,7 @@
             {
               "interface": "SUBMODEL-3.0",
               "protocolInformation": {
-                "href": "http://localhost:5005/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
+                "href": "{{BASYX_MARKER_SM_LOCALHOST_URL}}/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
                 "endpointProtocol": "HTTP"
               }
             }
@@ -73,7 +73,7 @@
             {
               "interface": "SUBMODEL-3.0",
               "protocolInformation": {
-                "href": "http://localhost:5005/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6c2VyaWFsLXBhcnQtdHlwaXphdGlvbg",
+                "href": "{{BASYX_MARKER_SM_LOCALHOST_URL}}/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6c2VyaWFsLXBhcnQtdHlwaXphdGlvbg",
                 "endpointProtocol": "HTTP"
               }
             }

--- a/internal/aasenvironment/marker_access_integration_tests/expected/dtr_bpn1.json
+++ b/internal/aasenvironment/marker_access_integration_tests/expected/dtr_bpn1.json
@@ -45,7 +45,7 @@
             {
               "interface": "SUBMODEL-3.0",
               "protocolInformation": {
-                "href": "http://localhost:5005/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
+                "href": "{{BASYX_MARKER_SM_LOCALHOST_URL}}/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
                 "endpointProtocol": "HTTP"
               }
             }
@@ -69,7 +69,7 @@
             {
               "interface": "SUBMODEL-3.0",
               "protocolInformation": {
-                "href": "http://localhost:5005/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6c2VyaWFsLXBhcnQtdHlwaXphdGlvbg",
+                "href": "{{BASYX_MARKER_SM_LOCALHOST_URL}}/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6c2VyaWFsLXBhcnQtdHlwaXphdGlvbg",
                 "endpointProtocol": "HTTP"
               }
             }

--- a/internal/aasenvironment/marker_access_integration_tests/expected/dtr_bpn2.json
+++ b/internal/aasenvironment/marker_access_integration_tests/expected/dtr_bpn2.json
@@ -45,7 +45,7 @@
             {
               "interface": "SUBMODEL-3.0",
               "protocolInformation": {
-                "href": "http://localhost:5005/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
+                "href": "{{BASYX_MARKER_SM_LOCALHOST_URL}}/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
                 "endpointProtocol": "HTTP"
               }
             }
@@ -69,7 +69,7 @@
             {
               "interface": "SUBMODEL-3.0",
               "protocolInformation": {
-                "href": "http://localhost:5005/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6c2VyaWFsLXBhcnQtdHlwaXphdGlvbg",
+                "href": "{{BASYX_MARKER_SM_LOCALHOST_URL}}/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6c2VyaWFsLXBhcnQtdHlwaXphdGlvbg",
                 "endpointProtocol": "HTTP"
               }
             }

--- a/internal/aasenvironment/marker_access_integration_tests/expected/dtr_public.json
+++ b/internal/aasenvironment/marker_access_integration_tests/expected/dtr_public.json
@@ -9,7 +9,7 @@
             {
               "interface": "SUBMODEL-3.0",
               "protocolInformation": {
-                "href": "http://localhost:5005/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
+                "href": "{{BASYX_MARKER_SM_LOCALHOST_URL}}/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
                 "endpointProtocol": "HTTP"
               }
             }

--- a/internal/aasenvironment/marker_access_integration_tests/expected/dtr_unrelated.json
+++ b/internal/aasenvironment/marker_access_integration_tests/expected/dtr_unrelated.json
@@ -24,7 +24,7 @@
             {
               "interface": "SUBMODEL-3.0",
               "protocolInformation": {
-                "href": "http://localhost:5005/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
+                "href": "{{BASYX_MARKER_SM_LOCALHOST_URL}}/submodels/dXJuOmV4YW1wbGU6c3VibW9kZWw6bmFtZXBsYXRl",
                 "endpointProtocol": "HTTP"
               }
             }

--- a/internal/aasenvironment/marker_access_integration_tests/it_config.json
+++ b/internal/aasenvironment/marker_access_integration_tests/it_config.json
@@ -2,40 +2,40 @@
   {
     "context": "Post shell descriptor as admin",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:5004/api/v3/shell-descriptors",
-    "data": "../../../examples/BaSyxMarkerAccessExample/data/shell-descriptor.json",
+    "endpoint": "{{BASYX_MARKER_DTR_URL}}/api/v3/shell-descriptors",
+    "data": "{{BASYX_MARKER_DATA_DIR}}/shell-descriptor.json",
     "expectedStatus": 201,
     "token": { "user": "admin", "password": "pwd" }
   },
   {
     "context": "Post public submodel as admin",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "data": "../../../examples/BaSyxMarkerAccessExample/data/public-submodel.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "data": "{{BASYX_MARKER_DATA_DIR}}/public-submodel.json",
     "expectedStatus": 201,
     "token": { "user": "admin", "password": "pwd" }
   },
   {
     "context": "Post restricted submodel as admin",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "data": "../../../examples/BaSyxMarkerAccessExample/data/restricted-submodel.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "data": "{{BASYX_MARKER_DATA_DIR}}/restricted-submodel.json",
     "expectedStatus": 201,
     "token": { "user": "admin", "password": "pwd" }
   },
   {
     "context": "DTR admin sees everything",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5004/api/v3/shell-descriptors",
-    "shouldMatch": "expected/dtr_admin.json",
+    "endpoint": "{{BASYX_MARKER_DTR_URL}}/api/v3/shell-descriptors",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/dtr_admin.json",
     "expectedStatus": 200,
     "token": { "user": "admin", "password": "pwd" }
   },
   {
     "context": "DTR admin remains unrestricted with unrelated BPN header",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5004/api/v3/shell-descriptors",
-    "shouldMatch": "expected/dtr_admin.json",
+    "endpoint": "{{BASYX_MARKER_DTR_URL}}/api/v3/shell-descriptors",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/dtr_admin.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_999" },
     "token": { "user": "admin", "password": "pwd" }
@@ -43,31 +43,31 @@
   {
     "context": "DTR anonymous sees public data",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5004/api/v3/shell-descriptors",
-    "shouldMatch": "expected/dtr_public.json",
+    "endpoint": "{{BASYX_MARKER_DTR_URL}}/api/v3/shell-descriptors",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/dtr_public.json",
     "expectedStatus": 200
   },
   {
     "context": "DTR regular token sees public data",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5004/api/v3/shell-descriptors",
-    "shouldMatch": "expected/dtr_public.json",
+    "endpoint": "{{BASYX_MARKER_DTR_URL}}/api/v3/shell-descriptors",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/dtr_public.json",
     "expectedStatus": 200,
     "token": { "user": "usera", "password": "pwd" }
   },
   {
     "context": "DTR BPN company 1 sees own markers",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5004/api/v3/shell-descriptors",
-    "shouldMatch": "expected/dtr_bpn1.json",
+    "endpoint": "{{BASYX_MARKER_DTR_URL}}/api/v3/shell-descriptors",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/dtr_bpn1.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_001" }
   },
   {
     "context": "DTR regular token with BPN company 1 sees own markers",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5004/api/v3/shell-descriptors",
-    "shouldMatch": "expected/dtr_bpn1.json",
+    "endpoint": "{{BASYX_MARKER_DTR_URL}}/api/v3/shell-descriptors",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/dtr_bpn1.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_001" },
     "token": { "user": "usera", "password": "pwd" }
@@ -75,32 +75,32 @@
   {
     "context": "DTR BPN company 2 sees own markers",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5004/api/v3/shell-descriptors",
-    "shouldMatch": "expected/dtr_bpn2.json",
+    "endpoint": "{{BASYX_MARKER_DTR_URL}}/api/v3/shell-descriptors",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/dtr_bpn2.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_002" }
   },
   {
     "context": "DTR unrelated BPN sees public data",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5004/api/v3/shell-descriptors",
-    "shouldMatch": "expected/dtr_unrelated.json",
+    "endpoint": "{{BASYX_MARKER_DTR_URL}}/api/v3/shell-descriptors",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/dtr_unrelated.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_999" }
   },
   {
     "context": "SM repository admin sees everything",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "shouldMatch": "expected/sm_admin.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/sm_admin.json",
     "expectedStatus": 200,
     "token": { "user": "admin", "password": "pwd" }
   },
   {
     "context": "SM repository admin remains unrestricted with unrelated BPN header",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "shouldMatch": "expected/sm_admin.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/sm_admin.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_999" },
     "token": { "user": "admin", "password": "pwd" }
@@ -108,31 +108,31 @@
   {
     "context": "SM repository anonymous sees public data",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "shouldMatch": "expected/sm_public.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/sm_public.json",
     "expectedStatus": 200
   },
   {
     "context": "SM repository regular token sees public data",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "shouldMatch": "expected/sm_public.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/sm_public.json",
     "expectedStatus": 200,
     "token": { "user": "usera", "password": "pwd" }
   },
   {
     "context": "SM repository BPN company 1 sees own markers",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "shouldMatch": "expected/sm_bpn1.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/sm_bpn1.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_001" }
   },
   {
     "context": "SM repository regular token with BPN company 1 sees own markers",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "shouldMatch": "expected/sm_bpn1.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/sm_bpn1.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_001" },
     "token": { "user": "usera", "password": "pwd" }
@@ -140,16 +140,16 @@
   {
     "context": "SM repository BPN company 2 sees own markers",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "shouldMatch": "expected/sm_bpn2.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/sm_bpn2.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_002" }
   },
   {
     "context": "SM repository unrelated BPN sees public data",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:5005/submodels",
-    "shouldMatch": "expected/sm_unrelated.json",
+    "endpoint": "{{BASYX_MARKER_SM_URL}}/submodels",
+    "shouldMatch": "{{BASYX_MARKER_EXPECTED_DIR}}/sm_unrelated.json",
     "expectedStatus": 200,
     "headers": { "Edc-Bpn": "BPN_COMPANY_999" }
   }

--- a/internal/aasenvironment/marker_access_integration_tests/marker_access_integration_test.go
+++ b/internal/aasenvironment/marker_access_integration_tests/marker_access_integration_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 	smSecurityEnv := testenv.PrepareSecurityEnvOrExit(filepath.Join(markerExamplePath, "security", "smrepo"), markerFixtureRewrites)
 	dataDir := testenv.PrepareSecurityEnvOrExit(filepath.Join(markerExamplePath, "data"), markerFixtureRewrites)
 	expectedDir := testenv.PrepareSecurityEnvOrExit("expected", markerFixtureRewrites)
-	infraDir, infraFile, err := prepareMarkerFile(filepath.Join(markerExamplePath, "basyx-infra.yml"), "basyx-infra.yml", markerFixtureRewrites)
+	infraDir, infraFile, err := prepareMarkerFile(filepath.Join(markerExamplePath, "basyx-infra.yml"), "basyx-infra.yml", markerFixtureRewrites, nil)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
 		_ = os.RemoveAll(dtrSecurityEnv)
@@ -66,7 +66,13 @@ func TestMain(m *testing.M) {
 		_ = os.RemoveAll(expectedDir)
 		os.Exit(1)
 	}
-	composeDir, composeFile, err := prepareMarkerFile(filepath.Join(markerExamplePath, "docker-compose.yml"), "docker-compose.yml", markerComposeReplacements(runtime, dtrSecurityEnv, smSecurityEnv, infraFile))
+	composeReplacements, requiredComposeSnippets := markerComposeReplacements(runtime, dtrSecurityEnv, smSecurityEnv, infraFile)
+	composeDir, composeFile, err := prepareMarkerFile(
+		filepath.Join(markerExamplePath, "docker-compose.yml"),
+		"docker-compose.yml",
+		composeReplacements,
+		requiredComposeSnippets,
+	)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
 		_ = os.RemoveAll(dtrSecurityEnv)
@@ -116,27 +122,49 @@ func markerReplacements(runtime *testenv.ComposeRuntime) map[string]string {
 	}
 }
 
-func markerComposeReplacements(runtime *testenv.ComposeRuntime, dtrSecurityEnv string, smSecurityEnv string, infraFile string) map[string]string {
+func markerComposeReplacements(
+	runtime *testenv.ComposeRuntime,
+	dtrSecurityEnv string,
+	smSecurityEnv string,
+	infraFile string,
+) (map[string]string, []string) {
 	absoluteExamplePath, err := filepath.Abs(markerExamplePath)
 	if err != nil {
 		absoluteExamplePath = markerExamplePath
 	}
 	repositoryRoot := filepath.Clean(filepath.Join(absoluteExamplePath, "..", ".."))
 	replacements := markerReplacements(runtime)
-	replacements["    container_name: marker-access-aas-web-ui\n"] = ""
-	replacements["context: ../.."] = fmt.Sprintf("context: %q", repositoryRoot)
-	replacements["- ./security/dtr:/security:ro"] = "- " + dtrSecurityEnv + ":/security:ro"
-	replacements["- ./security/smrepo:/security:ro"] = "- " + smSecurityEnv + ":/security:ro"
-	replacements["- ./basyx-infra.yml:/basyx-infra.yml:ro"] = "- " + infraFile + ":/basyx-infra.yml:ro"
-	replacements["- ./keycloak/realm:/opt/keycloak/data/import:ro"] = "- " + filepath.Join(absoluteExamplePath, "keycloak", "realm") + ":/opt/keycloak/data/import:ro"
-	replacements[`- "5004:5004"`] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("dtr"))
-	replacements[`- "5005:5004"`] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("sm"))
-	replacements[`- "3000:3000"`] = fmt.Sprintf(`- "127.0.0.1:%d:3000"`, runtime.Port("ui"))
-	replacements[`- "8080:8080"`] = fmt.Sprintf(`- "0.0.0.0:%d:8080"`, runtime.Port("keycloak"))
-	return replacements
+	required := []string{
+		"    container_name: marker-access-aas-web-ui\n",
+		"context: ../..",
+		"- ./security/dtr:/security:ro",
+		"- ./security/smrepo:/security:ro",
+		"- ./basyx-infra.yml:/basyx-infra.yml:ro",
+		"- ./keycloak/realm:/opt/keycloak/data/import:ro",
+		`- "5004:5004"`,
+		`- "5005:5004"`,
+		`- "3000:3000"`,
+		`- "8080:8080"`,
+	}
+	replacements[required[0]] = ""
+	replacements[required[1]] = fmt.Sprintf("context: %q", repositoryRoot)
+	replacements[required[2]] = "- " + dtrSecurityEnv + ":/security:ro"
+	replacements[required[3]] = "- " + smSecurityEnv + ":/security:ro"
+	replacements[required[4]] = "- " + infraFile + ":/basyx-infra.yml:ro"
+	replacements[required[5]] = "- " + filepath.Join(absoluteExamplePath, "keycloak", "realm") + ":/opt/keycloak/data/import:ro"
+	replacements[required[6]] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("dtr"))
+	replacements[required[7]] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("sm"))
+	replacements[required[8]] = fmt.Sprintf(`- "127.0.0.1:%d:3000"`, runtime.Port("ui"))
+	replacements[required[9]] = fmt.Sprintf(`- "0.0.0.0:%d:8080"`, runtime.Port("keycloak"))
+	return replacements, required
 }
 
-func prepareMarkerFile(sourcePath string, targetName string, replacements map[string]string) (string, string, error) {
+func prepareMarkerFile(
+	sourcePath string,
+	targetName string,
+	replacements map[string]string,
+	requiredSnippets []string,
+) (string, string, error) {
 	info, err := os.Stat(sourcePath)
 	if err != nil {
 		return "", "", fmt.Errorf("AASEMV-MARKER-FILESTAT: %w", err)
@@ -147,11 +175,14 @@ func prepareMarkerFile(sourcePath string, targetName string, replacements map[st
 		return "", "", fmt.Errorf("AASEMV-MARKER-FILEREAD: %w", err)
 	}
 	content := string(data)
+	if missing := missingMarkerSnippets(content, requiredSnippets); len(missing) > 0 {
+		return "", "", fmt.Errorf("AASEMV-MARKER-FILEREPLACE missing required snippets in %s: %s", sourcePath, strings.Join(missing, ", "))
+	}
 	for oldValue, newValue := range replacements {
 		content = strings.ReplaceAll(content, oldValue, newValue)
 	}
 
-	targetDir, err := os.MkdirTemp(".", ".basyx-marker-file-*")
+	targetDir, err := os.MkdirTemp("", "basyx-marker-file-*")
 	if err != nil {
 		return "", "", fmt.Errorf("AASEMV-MARKER-FILEDIR: %w", err)
 	}
@@ -171,4 +202,14 @@ func prepareMarkerFile(sourcePath string, targetName string, replacements map[st
 		return "", "", fmt.Errorf("AASEMV-MARKER-FILEWRITE: %w", err)
 	}
 	return targetDir, targetPath, nil
+}
+
+func missingMarkerSnippets(content string, requiredSnippets []string) []string {
+	missing := make([]string, 0)
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(content, snippet) {
+			missing = append(missing, snippet)
+		}
+	}
+	return missing
 }

--- a/internal/aasenvironment/marker_access_integration_tests/marker_access_integration_test.go
+++ b/internal/aasenvironment/marker_access_integration_tests/marker_access_integration_test.go
@@ -7,31 +7,168 @@
 package markeraccessintegrationtests
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 )
 
+const markerExamplePath = "../../../examples/BaSyxMarkerAccessExample"
+
+var (
+	markerDTRBaseURL      = testenv.LocalURLFromEnv("BASYX_MARKER_DTR_PORT", 5004) + "/api/v3"
+	markerSMBaseURL       = testenv.LocalURLFromEnv("BASYX_MARKER_SM_PORT", 5005)
+	markerKeycloakToken   = testenv.LocalhostURLFromEnv("BASYX_MARKER_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+	markerDataDir         = filepath.Join(markerExamplePath, "data")
+	markerExpectedDir     = "expected"
+	markerTemplateValues  = map[string]string{}
+	markerFixtureRewrites = map[string]string{}
+)
+
 func TestMarkerAccessIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		ConfigPath: "it_config.json",
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			markerKeycloakToken,
 			"basyx-ui",
 			10*time.Second,
 		),
+		TemplateValues: markerTemplateValues,
 	})
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
-		ComposeFile:     "../../../examples/BaSyxMarkerAccessExample/docker-compose.yml",
+	runtime := testenv.NewComposeRuntimeOrExit("aasenvironment-marker-access", []testenv.PortBinding{
+		{Name: "dtr", EnvVar: "BASYX_MARKER_DTR_PORT"},
+		{Name: "sm", EnvVar: "BASYX_MARKER_SM_PORT"},
+		{Name: "ui", EnvVar: "BASYX_MARKER_UI_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_MARKER_KEYCLOAK_PORT"},
+	})
+	markerDTRBaseURL = runtime.LocalURL("dtr") + "/api/v3"
+	markerSMBaseURL = runtime.LocalURL("sm")
+	markerKeycloakToken = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	markerFixtureRewrites = markerReplacements(runtime)
+
+	dtrSecurityEnv := testenv.PrepareSecurityEnvOrExit(filepath.Join(markerExamplePath, "security", "dtr"), markerFixtureRewrites)
+	smSecurityEnv := testenv.PrepareSecurityEnvOrExit(filepath.Join(markerExamplePath, "security", "smrepo"), markerFixtureRewrites)
+	dataDir := testenv.PrepareSecurityEnvOrExit(filepath.Join(markerExamplePath, "data"), markerFixtureRewrites)
+	expectedDir := testenv.PrepareSecurityEnvOrExit("expected", markerFixtureRewrites)
+	infraDir, infraFile, err := prepareMarkerFile(filepath.Join(markerExamplePath, "basyx-infra.yml"), "basyx-infra.yml", markerFixtureRewrites)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
+		_ = os.RemoveAll(dtrSecurityEnv)
+		_ = os.RemoveAll(smSecurityEnv)
+		_ = os.RemoveAll(dataDir)
+		_ = os.RemoveAll(expectedDir)
+		os.Exit(1)
+	}
+	composeDir, composeFile, err := prepareMarkerFile(filepath.Join(markerExamplePath, "docker-compose.yml"), "docker-compose.yml", markerComposeReplacements(runtime, dtrSecurityEnv, smSecurityEnv, infraFile))
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
+		_ = os.RemoveAll(dtrSecurityEnv)
+		_ = os.RemoveAll(smSecurityEnv)
+		_ = os.RemoveAll(dataDir)
+		_ = os.RemoveAll(expectedDir)
+		_ = os.RemoveAll(infraDir)
+		os.Exit(1)
+	}
+
+	markerDataDir = dataDir
+	markerExpectedDir = expectedDir
+	markerTemplateValues = map[string]string{
+		"BASYX_MARKER_DATA_DIR":     markerDataDir,
+		"BASYX_MARKER_EXPECTED_DIR": markerExpectedDir,
+	}
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+		ComposeFile:     composeFile,
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.Env(),
 		PreDownBeforeUp: true,
-		HealthURL:       "http://127.0.0.1:5004/api/v3/health",
+		HealthURL:       markerDTRBaseURL + "/health",
 		WaitForReady: func() error {
-			return testenv.WaitHealthyURL("http://127.0.0.1:5005/health", 2*time.Minute)
+			return testenv.WaitHealthyURL(markerSMBaseURL+"/health", 2*time.Minute)
 		},
-	}))
+	})
+
+	_ = os.RemoveAll(dtrSecurityEnv)
+	_ = os.RemoveAll(smSecurityEnv)
+	_ = os.RemoveAll(dataDir)
+	_ = os.RemoveAll(expectedDir)
+	_ = os.RemoveAll(infraDir)
+	_ = os.RemoveAll(composeDir)
+	os.Exit(code)
+}
+
+func markerReplacements(runtime *testenv.ComposeRuntime) map[string]string {
+	keycloakURL := fmt.Sprintf("http://keycloak.localhost:%d", runtime.Port("keycloak"))
+	return map[string]string{
+		"http://localhost:5004":             runtime.LocalhostURL("dtr"),
+		"http://127.0.0.1:5004":             runtime.LocalURL("dtr"),
+		"http://localhost:5005":             runtime.LocalhostURL("sm"),
+		"http://127.0.0.1:5005":             runtime.LocalURL("sm"),
+		"http://keycloak.localhost:8080":    keycloakURL,
+		"{{BASYX_MARKER_SM_LOCALHOST_URL}}": runtime.LocalhostURL("sm"),
+	}
+}
+
+func markerComposeReplacements(runtime *testenv.ComposeRuntime, dtrSecurityEnv string, smSecurityEnv string, infraFile string) map[string]string {
+	absoluteExamplePath, err := filepath.Abs(markerExamplePath)
+	if err != nil {
+		absoluteExamplePath = markerExamplePath
+	}
+	repositoryRoot := filepath.Clean(filepath.Join(absoluteExamplePath, "..", ".."))
+	replacements := markerReplacements(runtime)
+	replacements["    container_name: marker-access-aas-web-ui\n"] = ""
+	replacements["context: ../.."] = fmt.Sprintf("context: %q", repositoryRoot)
+	replacements["- ./security/dtr:/security:ro"] = "- " + dtrSecurityEnv + ":/security:ro"
+	replacements["- ./security/smrepo:/security:ro"] = "- " + smSecurityEnv + ":/security:ro"
+	replacements["- ./basyx-infra.yml:/basyx-infra.yml:ro"] = "- " + infraFile + ":/basyx-infra.yml:ro"
+	replacements["- ./keycloak/realm:/opt/keycloak/data/import:ro"] = "- " + filepath.Join(absoluteExamplePath, "keycloak", "realm") + ":/opt/keycloak/data/import:ro"
+	replacements[`- "5004:5004"`] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("dtr"))
+	replacements[`- "5005:5004"`] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("sm"))
+	replacements[`- "3000:3000"`] = fmt.Sprintf(`- "127.0.0.1:%d:3000"`, runtime.Port("ui"))
+	replacements[`- "8080:8080"`] = fmt.Sprintf(`- "0.0.0.0:%d:8080"`, runtime.Port("keycloak"))
+	return replacements
+}
+
+func prepareMarkerFile(sourcePath string, targetName string, replacements map[string]string) (string, string, error) {
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return "", "", fmt.Errorf("AASEMV-MARKER-FILESTAT: %w", err)
+	}
+	//nolint:gosec // The marker test reads a fixed fixture path assembled in TestMain.
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return "", "", fmt.Errorf("AASEMV-MARKER-FILEREAD: %w", err)
+	}
+	content := string(data)
+	for oldValue, newValue := range replacements {
+		content = strings.ReplaceAll(content, oldValue, newValue)
+	}
+
+	targetDir, err := os.MkdirTemp(".", ".basyx-marker-file-*")
+	if err != nil {
+		return "", "", fmt.Errorf("AASEMV-MARKER-FILEDIR: %w", err)
+	}
+	targetDir, err = filepath.Abs(targetDir)
+	if err != nil {
+		_ = os.RemoveAll(targetDir)
+		return "", "", fmt.Errorf("AASEMV-MARKER-FILEABS: %w", err)
+	}
+	//nolint:gosec // Docker containers run as non-root users and need to read mounted fixture directories.
+	if err = os.Chmod(targetDir, 0o755); err != nil {
+		_ = os.RemoveAll(targetDir)
+		return "", "", fmt.Errorf("AASEMV-MARKER-FILECHMOD: %w", err)
+	}
+	targetPath := filepath.Join(targetDir, targetName)
+	if err = os.WriteFile(targetPath, []byte(content), info.Mode().Perm()); err != nil {
+		_ = os.RemoveAll(targetDir)
+		return "", "", fmt.Errorf("AASEMV-MARKER-FILEWRITE: %w", err)
+	}
+	return targetDir, targetPath, nil
 }

--- a/internal/aasenvironment/migration_integration_tests/aasenvironment_migration_integration_test.go
+++ b/internal/aasenvironment/migration_integration_tests/aasenvironment_migration_integration_test.go
@@ -48,13 +48,15 @@ import (
 
 const (
 	migrationComposeFile = "./docker_compose/docker_compose.yml"
-	migrationBaseURL     = "http://127.0.0.1:6034"
-	migrationDSN         = "host=127.0.0.1 port=6434 user=admin password=admin123 dbname=basyxMigrationTestDB sslmode=disable"
 )
 
 var (
-	composeBinary string
-	composePrefix []string
+	migrationBaseURL  = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6034)
+	migrationDSN      = testenv.PostgresKeywordDSNFromEnv("BASYX_IT_DB_PORT", 6434, "basyxMigrationTestDB")
+	composeBinary     string
+	composePrefix     []string
+	composeProject    string
+	composeRuntimeEnv []string
 )
 
 type migrationFixture struct {
@@ -64,6 +66,15 @@ type migrationFixture struct {
 }
 
 func TestMain(m *testing.M) {
+	runtime := testenv.NewComposeRuntimeOrExit("aasenvironment-migration", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+	})
+	migrationBaseURL = runtime.LocalURL("api")
+	migrationDSN = runtime.PostgresKeywordDSN("db", "basyxMigrationTestDB")
+	composeProject = runtime.ProjectName
+	composeRuntimeEnv = runtime.Env()
+
 	var err error
 	composeBinary, composePrefix, err = testenv.FindCompose()
 	if err != nil {
@@ -71,20 +82,20 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	_ = runCompose("down", "--volumes", "--remove-orphans")
+	_ = runCompose("down", "-v", "--remove-orphans")
 	if err = runCompose("up", "-d", "migration_db", "old_configuration", "old_aas_environment"); err != nil {
 		fmt.Fprintf(os.Stderr, "AASEMV-MIGRATION-STARTOLD: %v\n", err)
-		_ = runCompose("down", "--volumes", "--remove-orphans")
+		_ = runCompose("down", "-v", "--remove-orphans")
 		os.Exit(1)
 	}
 	if err = testenv.WaitHealthyURL(migrationBaseURL+"/health", 5*time.Minute); err != nil {
 		fmt.Fprintf(os.Stderr, "AASEMV-MIGRATION-HEALTHOLD: %v\n", err)
-		_ = runCompose("down", "--volumes", "--remove-orphans")
+		_ = runCompose("down", "-v", "--remove-orphans")
 		os.Exit(1)
 	}
 
 	exitCode := m.Run()
-	if err = runCompose("down", "--volumes", "--remove-orphans"); err != nil && exitCode == 0 {
+	if err = runCompose("down", "-v", "--remove-orphans"); err != nil && exitCode == 0 {
 		fmt.Fprintf(os.Stderr, "AASEMV-MIGRATION-CLEANUP: %v\n", err)
 		exitCode = 1
 	}
@@ -124,9 +135,13 @@ func runCompose(args ...string) error {
 
 	commandArgs := append([]string{}, composePrefix...)
 	commandArgs = append(commandArgs, "-f", migrationComposeFile)
+	if composeProject != "" {
+		commandArgs = append(commandArgs, "-p", composeProject)
+	}
 	commandArgs = append(commandArgs, args...)
 
 	cmd := exec.CommandContext(ctx, composeBinary, commandArgs...)
+	cmd.Env = append(os.Environ(), composeRuntimeEnv...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/aasenvironment/migration_integration_tests/docker_compose/docker_compose.yml
+++ b/internal/aasenvironment/migration_integration_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   migration_db:
     image: postgres:18
-    container_name: aasenvironment_migration_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxMigrationTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6434:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6434}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxMigrationTestDB"]
       interval: 2s
@@ -40,7 +39,7 @@ services:
       GENERAL_AASREGISTRYINTEGRATION: "false"
       GENERAL_SUBMODELREGISTRYINTEGRATION: "false"
     ports:
-      - "6034:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6034}:5004"
     depends_on:
       old_configuration:
         condition: service_completed_successfully
@@ -67,7 +66,7 @@ services:
       GENERAL_AASREGISTRYINTEGRATION: "false"
       GENERAL_SUBMODELREGISTRYINTEGRATION: "false"
     ports:
-      - "6034:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6034}:5004"
     depends_on:
       new_configuration:
         condition: service_completed_successfully

--- a/internal/aasenvironment/preconfiguration_integration_tests/aasenvironment_preconfiguration_integration_test.go
+++ b/internal/aasenvironment/preconfiguration_integration_tests/aasenvironment_preconfiguration_integration_test.go
@@ -40,16 +40,25 @@ import (
 
 const (
 	preconfigurationComposeFilePath = "./docker_compose/docker_compose.yml"
-	preconfigurationBaseURL         = "http://127.0.0.1:6014"
 	observerStatusFilePath          = "./docker_compose/observer/health_observer_status.txt"
 )
+
+var preconfigurationBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6014)
 
 func TestMain(m *testing.M) {
 	_ = os.MkdirAll("./docker_compose/observer", 0o750)
 	_ = os.Remove(observerStatusFilePath)
 
+	runtime := testenv.NewComposeRuntimeOrExit("aasenvironment-preconfiguration", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+	})
+	preconfigurationBaseURL = runtime.LocalURL("api")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     preconfigurationComposeFilePath,
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.Env(),
 		PreDownBeforeUp: true,
 	}))
 }

--- a/internal/aasenvironment/preconfiguration_integration_tests/docker_compose/docker_compose.yml
+++ b/internal/aasenvironment/preconfiguration_integration_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db_preconfig_it:
     image: postgres:18
-    container_name: postgres_db_preconfig_it
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6433:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6433}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -37,7 +36,7 @@ services:
       - ../../integration_tests/testdata:/app/preconfiguration:ro
       - ../../../submodelrepository/integration_tests/docker_compose/rsa-key.pem:/app/rsa-key.pem:ro
     ports:
-      - "6014:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6014}:5004"
     extra_hosts:
       - "localhost:host-gateway"
     depends_on:
@@ -97,7 +96,6 @@ services:
         fi
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasenvironment/security_tests/aasenvironment_security_integration_test.go
+++ b/internal/aasenvironment/security_tests/aasenvironment_security_integration_test.go
@@ -45,8 +45,9 @@ import (
 )
 
 const actionUploadMultipart = "UPLOAD_MULTIPART"
-const testBaseURL = "http://localhost:6004"
-const testKeycloakTokenURL = "http://localhost:18080/realms/basyx/protocol/openid-connect/token"
+
+var testBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+var testKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 18080) + "/realms/basyx/protocol/openid-connect/token"
 
 func TestIntegration(t *testing.T) {
 	tokenProvider := testenv.NewPasswordGrantTokenProvider(
@@ -528,10 +529,25 @@ func runMultipartUploadAction(t *testing.T, step testenv.JSONSuiteStep, tokenPro
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("aasenvironment-security-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	testBaseURL = runtime.LocalhostURL("api")
+	testKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:18080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     "docker_compose/docker_compose.yml",
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
 		PreDownBeforeUp: true,
-		HealthURL:       "http://localhost:6004/health",
+		HealthURL:       testBaseURL + "/health",
 		HealthTimeout:   3 * time.Minute,
-	}))
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/aasenvironment/security_tests/docker_compose/docker_compose.yml
+++ b/internal/aasenvironment/security_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db:
     image: postgres:18
-    container_name: aasenvironment_security_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-environment-security:
-    container_name: aas-environment-security
     build:
       context: ../../../..
       dockerfile: ./cmd/aasenvironmentservice/Dockerfile
@@ -39,29 +37,28 @@ services:
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
       - JWS_PRIVATEKEYPATH=/app/rsa-key.pem
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
       - ../../../submodelrepository/integration_tests/docker_compose/rsa-key.pem:/app/rsa-key.pem:ro
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: aasenvironment_security_keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "18080"
-      KC_HOSTNAME_URL: "http://localhost:18080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-18080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-18080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -73,13 +70,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 18080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-18080}:8080"
     volumes:
       - ../../../aasregistry/security_tests/docker_compose/keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: aasenvironment_security_keycloak_healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -91,7 +87,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasenvironment/security_tests/it_config.json
+++ b/internal/aasenvironment/security_tests/it_config.json
@@ -4,7 +4,7 @@
     "action": "UPLOAD_MULTIPART",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "../integration_tests/testdata/IESEDriveMotorDM3000.aasx",
     "expectedStatus": 403
   },
@@ -13,7 +13,7 @@
     "action": "UPLOAD_MULTIPART",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/upload/",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload/",
     "data": "../integration_tests/testdata/IESEDriveMotorDM3000.aasx",
     "expectedStatus": 404
   },
@@ -22,7 +22,7 @@
     "action": "UPLOAD_MULTIPART",
     "token": { "user": "usera", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "../integration_tests/testdata/IESEDriveMotorDM3000.aasx",
     "expectedStatus": 200
   },
@@ -31,7 +31,7 @@
     "action": "UPLOAD_MULTIPART",
     "token": { "user": "usera", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/upload",
+    "endpoint": "{{BASYX_IT_API_URL}}/upload",
     "data": "../integration_tests/testdata/IESEDriveMotorDM3000.aasx",
     "expectedStatus": 403
   }

--- a/internal/aasenvironment/security_tests/serialization_it_config.json
+++ b/internal/aasenvironment/security_tests/serialization_it_config.json
@@ -3,14 +3,14 @@
 		"context": "GET serialization - viewer-only user allowed",
 		"token": { "user": "usera", "password": "pwd" },
 		"method": "GET",
-		"endpoint": "http://localhost:6004/serialization",
+		"endpoint": "{{BASYX_IT_API_URL}}/serialization",
 		"expectedStatus": 200
 	},
 	{
 		"context": "GET serialization - editor-only user denied",
 		"token": { "user": "userx", "password": "pwd" },
 		"method": "GET",
-		"endpoint": "http://localhost:6004/serialization",
+		"endpoint": "{{BASYX_IT_API_URL}}/serialization",
 		"expectedStatus": 403
 	}
 ]

--- a/internal/aasregistry/benchmark_results/docker_compose/docker_compose.yml
+++ b/internal/aasregistry/benchmark_results/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: postgres_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "5432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-5432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -30,13 +29,12 @@ services:
       - POSTGRES_MAXIDLECONNECTIONS=500
       - POSTGRES_CONNMAXLIFETIMEMINUTES=5
     ports:
-      - "5004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-5004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasregistry/integration_tests/aasregistry_bulk_integration_test.go
+++ b/internal/aasregistry/integration_tests/aasregistry_bulk_integration_test.go
@@ -43,8 +43,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const aasRegistryBaseURL = "http://127.0.0.1:6004"
-
 var aasNoRedirectClient = &http.Client{
 	Timeout: 10 * time.Second,
 	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {

--- a/internal/aasregistry/integration_tests/aasregistry_integration_test.go
+++ b/internal/aasregistry/integration_tests/aasregistry_integration_test.go
@@ -43,21 +43,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const defaultAASRegistryIntegrationTestDSN = "postgres://admin:admin123@127.0.0.1:6432/basyxTestDB?sslmode=disable"
-
+var aasRegistryBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
 var aasRegistryIntegrationTestDSN = getAASRegistryIntegrationTestDSN()
 
 func getAASRegistryIntegrationTestDSN() string {
 	if dsn := os.Getenv("AASREGISTRY_INTEGRATION_TEST_DSN"); dsn != "" {
 		return dsn
 	}
-	return defaultAASRegistryIntegrationTestDSN
+	return testenv.PostgresURLFromEnv("BASYX_IT_DB_PORT", 6432, "basyxTestDB")
 }
 
 func deleteAllAASDescriptors(t *testing.T, runner *testenv.JSONSuiteRunner, stepNumber int) {
 	response, err := runner.RunStep(testenv.JSONSuiteStep{
 		Method:         http.MethodGet,
-		Endpoint:       "http://127.0.0.1:6004/shell-descriptors",
+		Endpoint:       aasRegistryBaseURL + "/shell-descriptors",
 		ExpectedStatus: http.StatusOK,
 	}, stepNumber)
 	require.NoError(t, err)
@@ -73,7 +72,7 @@ func deleteAllAASDescriptors(t *testing.T, runner *testenv.JSONSuiteRunner, step
 		enc := base64.RawURLEncoding.EncodeToString([]byte(item.ID))
 		_, err := runner.RunStep(testenv.JSONSuiteStep{
 			Method:         http.MethodDelete,
-			Endpoint:       fmt.Sprintf("http://127.0.0.1:6004/shell-descriptors/%s", enc),
+			Endpoint:       fmt.Sprintf("%s/shell-descriptors/%s", aasRegistryBaseURL, enc),
 			ExpectedStatus: http.StatusNoContent,
 		}, stepNumber)
 		require.NoError(t, err)
@@ -215,7 +214,7 @@ func assertLocationHeaderMatches(t *testing.T, expectedLocation string, actualLo
 }
 
 func TestLocationHeadersForCreateEndpointsAASRegistry(t *testing.T) {
-	baseURL := "http://127.0.0.1:6004"
+	baseURL := aasRegistryBaseURL
 
 	t.Run("PostAssetAdministrationShellDescriptorSetsLocation", func(t *testing.T) {
 		aasID := fmt.Sprintf("https://example.com/ids/aas/location-post-%d", time.Now().UnixNano())
@@ -326,8 +325,17 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
+	runtime := testenv.NewComposeRuntimeOrExit("aasregistry-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+	})
+	aasRegistryBaseURL = runtime.LocalURL("api")
+	aasRegistryIntegrationTestDSN = runtime.PostgresURL("db", "basyxTestDB")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker_compose.yml",
-		HealthURL:   "http://localhost:6004/health",
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.Env(),
+		HealthURL:   aasRegistryBaseURL + "/health",
 	}))
 }

--- a/internal/aasregistry/integration_tests/aasregistry_integration_test.go
+++ b/internal/aasregistry/integration_tests/aasregistry_integration_test.go
@@ -322,6 +322,9 @@ func TestIntegration(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	if os.Getenv("BASYX_EXTERNAL_COMPOSE") == "1" {
+		testenv.SetEnvDefaultsOrExit(map[string]string{
+			"BASYX_IT_API_URL": aasRegistryBaseURL,
+		})
 		os.Exit(m.Run())
 	}
 

--- a/internal/aasregistry/integration_tests/docker_compose/docker_compose.yml
+++ b/internal/aasregistry/integration_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db-it:
     image: postgres:18
-    container_name: postgres_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-registry-it:
-    container_name: aas-registry-it
     build:
       context: ../../../..
       dockerfile: ./cmd/aasregistryservice/Dockerfile
@@ -34,7 +32,7 @@ services:
       - BASYX_HISTORY_FULL_SNAPSHOT_INTERVAL=3
       - ABAC_ENABLED=false
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
@@ -44,7 +42,6 @@ services:
       - "localhost:host-gateway"
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasregistry/integration_tests/it_config.json
+++ b/internal/aasregistry/integration_tests/it_config.json
@@ -2,199 +2,199 @@
   {
     "context": "001 - Health Check - GET /health",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "shouldMatch": "expected/expectedHealthEndpoint.json",
     "expectedStatus": 200
   },
   {
     "context": "002 - List AAS Descriptors (Empty) - GET /shell-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "002.1 - List AAS Descriptors - GET /shell-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "expectedStatus": 200
   },
   {
     "context": "002.2 - Create AAS Descriptor (Malformed) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_malformed.json",
     "expectedStatus": 400
   },
   {
     "context": "002.3 - Replace AAS Descriptor - PUT /shell-descriptors",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_2.json",
     "expectedStatus": 405
   },
   {
     "context": "002.4 - Delete AAS Descriptor - DELETE /shell-descriptors",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "expectedStatus": 405
   },
   {
     "context": "002.5 - List AAS Descriptors - GET /shell-descriptors/ route not found",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "002.6 - Create AAS Descriptor - POST /shell-descriptors/ route not found",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "data": "postBody/simple_ass_descriptor_malformed.json",
     "expectedStatus": 404
   },
   {
     "context": "002.7 - Replace AAS Descriptor - PUT /shell-descriptors/ route not found",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "data": "postBody/simple_ass_descriptor_2.json",
     "expectedStatus": 404
   },
   {
     "context": "002.8 - Delete AAS Descriptor - DELETE /shell-descriptors/ route not found",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "003 - Get AAS Descriptor by ID (Not Found) - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
     "expectedStatus": 404
   },
   {
     "context": "004 - List Submodel Descriptors (AAS Not Found) - GET /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "expectedStatus": 404
   },
   {
     "context": "004.1 - List Submodel Descriptors (AAS Not Found) - GET /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "expectedStatus": 404
   },
   {
     "context": "004.2 - Create Submodel Descriptor (AAS Not Found) - POST /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_1.json",
     "expectedStatus": 404
   },
   {
     "context": "004.3 - Replace Submodel Descriptor Collection - PUT /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 405
   },
   {
     "context": "004.4 - Delete Submodel Descriptor Collection - DELETE /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "expectedStatus": 405
   },
   {
     "context": "004.5 - List Submodel Descriptors - GET /shell-descriptors/{aasId}/submodel-descriptors/ route not found",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "004.6 - Create Submodel Descriptor - POST /shell-descriptors/{aasId}/submodel-descriptors/ route not found",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
     "data": "postBody/simple_submodel_descriptor_1.json",
     "expectedStatus": 404
   },
   {
     "context": "004.7 - Replace Submodel Descriptor Collection - PUT /shell-descriptors/{aasId}/submodel-descriptors/ route not found",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
     "data": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 404
   },
   {
     "context": "004.8 - Delete Submodel Descriptor Collection - DELETE /shell-descriptors/{aasId}/submodel-descriptors/ route not found",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "005 - Replace Submodel Descriptor (AAS Not Found) - PUT /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAy",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAy",
     "data": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 404
   },
   {
     "context": "006 - Delete Submodel Descriptor (AAS Not Found) - DELETE /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
     "expectedStatus": 404
   },
   {
     "context": "007 - Create Submodel Descriptor (AAS Not Found) - POST /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_1.json",
     "expectedStatus": 404
   },
   {
     "context": "008 - Create AAS Descriptor (Missing Identifier) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_malformed.json",
     "expectedStatus": 400
   },
   {
     "context": "009 - Create AAS Descriptor (Invalid AssetKind) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_malformed_2.json",
     "expectedStatus": 400
   },
   {
     "context": "010 - Create AAS Descriptor (Invalid Key) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_malformed_3.json",
     "expectedStatus": 400
   },
   {
     "context": "011 - Create AAS Descriptor (Wrong Extension Value Type) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_malformed_4.json",
     "expectedStatus": 400
   },
   {
     "context": "012 - Create AAS Descriptor (Missing Keys in Reference) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_malformed_5.json",
     "expectedStatus": 400
   },
   {
     "context": "013 - Create AAS Descriptor (Empty Keys in Reference) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_malformed_6.json",
     "expectedStatus": 400
   },
   {
     "context": "014 - Create AAS Descriptor #1 (Simple) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_1.json",
     "shouldMatch": "postBody/simple_ass_descriptor_1.json",
     "expectedStatus": 201
@@ -202,7 +202,7 @@
   {
     "context": "015 - Create AAS Descriptor #2 (Simple) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_2.json",
     "shouldMatch": "postBody/simple_ass_descriptor_2.json",
     "expectedStatus": 201
@@ -210,7 +210,7 @@
   {
     "context": "016 - Create AAS Descriptor #3 (Simple) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_3.json",
     "shouldMatch": "postBody/simple_ass_descriptor_3.json",
     "expectedStatus": 201
@@ -218,7 +218,7 @@
   {
     "context": "017 - Create AAS Descriptor #4 (Simple) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_4.json",
     "shouldMatch": "postBody/simple_ass_descriptor_4.json",
     "expectedStatus": 201
@@ -226,122 +226,122 @@
   {
     "context": "018 - Create AAS Descriptor Duplicate (Conflict) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_1.json",
     "expectedStatus": 409
   },
   {
     "context": "019 - List AAS Descriptors (Paged) - GET /shell-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/simple_ass_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "020 - Delete Submodel Descriptor (Not Found) - DELETE /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
     "expectedStatus": 404
   },
   {
     "context": "021 - List AAS Descriptors (Invalid assetKind Param) - GET /shell-descriptors?assetKind=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors?assetKind=OMEGALUL",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?assetKind=OMEGALUL",
     "expectedStatus": 400
   },
   {
     "context": "022 - List AAS Descriptors (limit=2) - GET /shell-descriptors?limit=2",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors?limit=2",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?limit=2",
     "shouldMatch": "expected/simple_ass_paged_result_limit2.json",
     "expectedStatus": 200
   },
   {
     "context": "023 - List AAS Descriptors (limit=2, cursor=...) - GET /shell-descriptors?limit=2&cursor=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors?limit=2&cursor=aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8zNGh6ZWF3",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?limit=2&cursor=aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8zNGh6ZWF3",
     "shouldMatch": "expected/simple_ass_paged_result_limit2cursor.json",
     "expectedStatus": 200
   },
   {
     "context": "024 - List AAS Descriptors (Bad Cursor) - GET /shell-descriptors?cursor=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors?cursor=HELLOWRONGENCODEDURL",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?cursor=HELLOWRONGENCODEDURL",
     "expectedStatus": 400
   },
   {
     "context": "024.1 - List AAS Descriptors (Nonexistent Cursor) - GET /shell-descriptors?cursor=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors?cursor=ZG9lcy1ub3QtZXhpc3Q",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?cursor=ZG9lcy1ub3QtZXhpc3Q",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "025 - List AAS Descriptors (Filter assetKind=Type) - GET /shell-descriptors?assetKind=Type",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors?assetKind=Type",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?assetKind=Type",
     "shouldMatch": "expected/simple_ass_paged_result_filter_assetKind.json",
     "expectedStatus": 200
   },
   {
     "context": "026 - List AAS Descriptors (Filter assetType=betachad) - GET /shell-descriptors?assetType=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors?assetType=YmV0YWNoYWQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?assetType=YmV0YWNoYWQ",
     "shouldMatch": "expected/simple_ass_paged_result_filter_assetType.json",
     "expectedStatus": 200
   },
   {
     "context": "027 - Replace AAS Descriptor (ID Mismatch) - PUT /shell-descriptors/{aasId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
     "expectedStatus": 400
   },
   {
     "context": "028 - Get AAS Descriptor by ID - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
     "shouldMatch": "postBody/simple_ass_descriptor_1.json",
     "expectedStatus": 200
   },
   {
     "context": "029 - Replace AAS Descriptor (204 No Content) - PUT /shell-descriptors/{aasId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
     "data": "postBody/simple_ass_descriptor_5.json",
     "expectedStatus": 204
   },
   {
     "context": "030 - List Submodel Descriptors (Initially Empty) - GET /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "031 - Get AAS Descriptor by ID (Updated) - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
     "shouldMatch": "postBody/simple_ass_descriptor_5.json",
     "expectedStatus": 200
   },
   {
     "context": "032 - Replace AAS Descriptor (Complex) - PUT /shell-descriptors/{aasId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
     "data": "postBody/complex_aas_descriptor_1.json",
     "expectedStatus": 204
   },
   {
     "context": "033 - Get AAS Descriptor by ID (Complex) - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
     "shouldMatch": "postBody/complex_aas_descriptor_1.json",
     "expectedStatus": 200
   },
   {
     "context": "034 - Create Submodel Descriptor #1 - POST /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_1.json",
     "shouldMatch": "postBody/simple_submodel_descriptor_1.json",
     "expectedStatus": 201
@@ -349,35 +349,35 @@
   {
     "context": "035 - Create Submodel Descriptor Duplicate (Conflict) - POST /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_1.json",
     "expectedStatus": 409
   },
   {
     "context": "036 - List Submodel Descriptors (After Create) - GET /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "shouldMatch": "expected/submodel_paged.json",
     "expectedStatus": 200
   },
   {
     "context": "037 - Get Submodel Descriptor by ID - GET /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
     "shouldMatch": "postBody/simple_submodel_descriptor_1.json",
     "expectedStatus": 200
   },
   {
     "context": "038 - Replace Submodel Descriptor (Wrong ID) - PUT /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
     "data": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 400
   },
   {
     "context": "039 - Create Submodel Descriptor #2 - POST /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_2.json",
     "shouldMatch": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 201
@@ -385,34 +385,34 @@
   {
     "context": "040 - List Submodel Descriptors (limit=2) - GET /shell-descriptors/{aasId}/submodel-descriptors?limit=2",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors?limit=2",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors?limit=2",
     "shouldMatch": "expected/submodel_paged_with_limit.json",
     "expectedStatus": 200
   },
   {
     "context": "041 - List Submodel Descriptors (cursor=...) - GET /shell-descriptors/{aasId}/submodel-descriptors?cursor=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors?cursor=dXJuOmV4YW1wbGU6c206MDAx",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors?cursor=dXJuOmV4YW1wbGU6c206MDAx",
     "shouldMatch": "expected/submodel_paged_with_cursor.json",
     "expectedStatus": 200
   },
   {
     "context": "042 - List Submodel Descriptors (Bad Cursor) - GET /shell-descriptors/{aasId}/submodel-descriptors?cursor=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors?cursor=HELLOWRONGENCODEDURL",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors?cursor=HELLOWRONGENCODEDURL",
     "expectedStatus": 400
   },
   {
     "context": "042.1 - List Submodel Descriptors (Nonexistent Cursor) - GET /shell-descriptors/{aasId}/submodel-descriptors?cursor=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors?cursor=dXJuOmV4YW1wbGU6c206OTk5",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors?cursor=dXJuOmV4YW1wbGU6c206OTk5",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "043 - Create Submodel Descriptor #3 - POST /shell-descriptors/{aasId}/submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_3.json",
     "shouldMatch": "postBody/simple_submodel_descriptor_3.json",
     "expectedStatus": 201
@@ -420,46 +420,46 @@
   {
     "context": "044 - Delete Submodel Descriptor #1 - DELETE /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
     "expectedStatus": 204
   },
   {
     "context": "045 - List AAS Descriptors (Final Complex Paged) - GET /shell-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/final_complex_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "046 - Delete AAS Descriptor - DELETE /shell-descriptors/{aasId}",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
     "expectedStatus": 204
   },
   {
     "context": "047 - Get Deleted AAS Descriptor (Not Found) - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy8yMjMzNQ",
     "expectedStatus": 404
   },
   {
     "context": "048 - PUT as Create (Missing Endpoint in Submodel, Expect 400) - PUT /shell-descriptors/{aasId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9mYWN0b3Jpbw",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9mYWN0b3Jpbw",
     "data": "postBody/simple_ass_descriptor_malformed_7.json",
     "expectedStatus": 400
   },
   {
     "context": "049 - PUT as Create (Empty Endpoint List, Expect 400) - PUT /shell-descriptors/{aasId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9mYWN0b3Jpbw",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9mYWN0b3Jpbw",
     "data": "postBody/simple_ass_descriptor_malformed_9.json",
     "expectedStatus": 400
   },
   {
     "context": "050 - PUT as Create (Created 201) - PUT /shell-descriptors/{aasId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9mYWN0b3Jpbw",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9mYWN0b3Jpbw",
     "data": "postBody/simple_ass_descriptor_6.json",
     "shouldMatch": "postBody/simple_ass_descriptor_6.json",
     "expectedStatus": 201
@@ -467,21 +467,21 @@
   {
     "context": "051 - Get Small AAS Descriptor - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9mYWN0b3Jpbw",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9mYWN0b3Jpbw",
     "shouldMatch": "postBody/simple_ass_descriptor_6.json",
     "expectedStatus": 200
   },
   {
     "context": "052 - List AAS Descriptors (Final Paged Result) - GET /shell-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/final_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "053 - PUT AAS Descriptor (Create Martin, 201) - PUT /shell-descriptors/{aasId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
     "data": "postBody/simple_ass_descriptor_7.json",
     "shouldMatch": "expected/expected_ass_descriptor_7.json",
     "expectedStatus": 201
@@ -489,34 +489,34 @@
   {
     "context": "054 - PUT AAS Descriptor (Idempotent Update, 204) - PUT /shell-descriptors/{aasId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
     "data": "postBody/simple_ass_descriptor_7.json",
     "expectedStatus": 204
   },
   {
     "context": "055 - GET AAS Descriptor (Martin) - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
     "shouldMatch": "expected/expected_ass_descriptor_7.json",
     "expectedStatus": 200
   },
   {
     "context": "056 - PUT Submodel in AAS (Wrong ID, 400) - PUT /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9zYXRpc2ZhY3Rvcnk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9zYXRpc2ZhY3Rvcnk",
     "data": "postBody/simple_submodel_descriptor_4.json",
     "expectedStatus": 400
   },
   {
     "context": "057 - GET Submodel (Not Found) - GET /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/bWFydGluaXN0Y29vbA",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/bWFydGluaXN0Y29vbA",
     "expectedStatus": 404
   },
   {
     "context": "058 - PUT Submodel (Create via PUT, 201) - PUT /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy93cm9uZ2lk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy93cm9uZ2lk",
     "data": "postBody/simple_submodel_descriptor_4.json",
     "shouldMatch": "expected/submodel_descriptor_simplified.json",
     "expectedStatus": 201
@@ -524,40 +524,40 @@
   {
     "context": "059 - GET AAS Descriptor (With New Submodel) - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
     "shouldMatch": "expected/simple_aas_with_sub_via_put.json",
     "expectedStatus": 200
   },
   {
     "context": "060 - PUT Submodel (Modify via PUT, 204) - PUT /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy93cm9uZ2lk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy93cm9uZ2lk",
     "data": "postBody/simple_submodel_descriptor_4_different.json",
     "expectedStatus": 204
   },
   {
     "context": "061 - Delete Submodel (Not Existing, 404) - DELETE /shell-descriptors/{aasId}/submodel-descriptors/{subId}",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/bWFydGluaXN0ZGVyYWxsZXJjb29sc3Rl",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4/submodel-descriptors/bWFydGluaXN0ZGVyYWxsZXJjb29sc3Rl",
     "expectedStatus": 404
   },
   {
     "context": "062 - GET AAS Descriptor (With Changed Submodel) - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW4",
     "shouldMatch": "expected/simple_aas_with_sub_via_put_changed.json",
     "expectedStatus": 200
   },
   {
     "context": "063 - GET AAS Descriptor (Bad Encoded URL, 400) - GET /shell-descriptors/{badId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/HELLOWRONGENCODEDURL",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/HELLOWRONGENCODEDURL",
     "expectedStatus": 400
   },
   {
     "context": "066 - Create AAS Descriptor (AssetKind=Role) - POST /shell-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_ass_descriptor_8.json",
     "shouldMatch": "postBody/simple_ass_descriptor_8.json",
     "expectedStatus": 201
@@ -565,7 +565,7 @@
   {
     "context": "067 - Get AAS Descriptor (AssetKind=Role) - GET /shell-descriptors/{aasId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW5pc3Rjb29s",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvaWRzL2Fhcy9tYXJ0aW5pc3Rjb29s",
     "shouldMatch": "postBody/simple_ass_descriptor_8.json",
     "expectedStatus": 200
   },
@@ -576,7 +576,7 @@
   {
     "context": "065 - Verify AAS Descriptors Empty - GET /shell-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   },
@@ -587,13 +587,13 @@
   {
     "context": "069 - GET Non Existing Endpoint (404) - GET /does-not-exist",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/does-not-exist",
+    "endpoint": "{{BASYX_IT_API_URL}}/does-not-exist",
     "expectedStatus": 404
   },
   {
     "context": "070 - PATCH Health Endpoint (405) - PATCH /health",
     "method": "PATCH",
-    "endpoint": "http://127.0.0.1:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "expectedStatus": 405
   }
 ]

--- a/internal/aasregistry/query_integration_tests/aasregistry_query_integration_test.go
+++ b/internal/aasregistry/query_integration_tests/aasregistry_query_integration_test.go
@@ -36,11 +36,14 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 )
 
+var queryBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6005)
+var queryKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8081) + "/realms/basyx/protocol/openid-connect/token"
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8081/realms/basyx/protocol/openid-connect/token",
+			queryKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -48,8 +51,23 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("aasregistry-query-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	queryBaseURL = runtime.LocalhostURL("api")
+	queryKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8081": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker_compose.yml",
-		HealthURL:   "http://localhost:6005/health",
-	}))
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
+		HealthURL:   queryBaseURL + "/health",
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/aasregistry/query_integration_tests/docker_compose/docker_compose.yml
+++ b/internal/aasregistry/query_integration_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db-query:
     image: postgres:18
-    container_name: postgres_query_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "6433:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6433}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-registry-query:
-    container_name: aas-registry-query
     build:
       context: ../../../..
       dockerfile: ./cmd/aasregistryservice/Dockerfile
@@ -34,7 +32,7 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6005:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6005}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
@@ -43,21 +41,20 @@ services:
       keycloak-query-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak-query:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak-query
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db-query:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8081"
-      KC_HOSTNAME_URL: "http://localhost:8081"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8081}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8081}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -69,13 +66,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - "8081:8080"
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8081}:8080"
     volumes:
       - ../../security_filter_tests/docker_compose/keycloak/realm:/opt/keycloak/data/import
 
   keycloak-query-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak-query-healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -87,7 +83,6 @@ services:
       - keycloak-query
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasregistry/query_integration_tests/it_config.json
+++ b/internal/aasregistry/query_integration_tests/it_config.json
@@ -2,14 +2,14 @@
   {
     "context": "GET Description - Anonymous - ALLOWED",
     "method": "GET",
-    "endpoint": "http://localhost:6005/description",
+    "endpoint": "{{BASYX_IT_API_URL}}/description",
     "expectedStatus": 200
   },
   {
     "context": "POST Descriptor A - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_A.json",
     "expectedStatus": 201
   },
@@ -17,7 +17,7 @@
     "context": "POST Descriptor B - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_B.json",
     "expectedStatus": 201
   },
@@ -25,7 +25,7 @@
     "context": "POST Descriptor C - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_C.json",
     "expectedStatus": 201
   },
@@ -33,7 +33,7 @@
     "context": "POST Descriptor D - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_D.json",
     "expectedStatus": 201
   },
@@ -41,7 +41,7 @@
     "context": "POST Query - Viewer - FILTERED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/query/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shell-descriptors",
     "data": "postBody/query_shells_with_filters.json",
     "shouldMatch": "expected/query_viewer.json",
     "expectedStatus": 200
@@ -50,7 +50,7 @@
     "context": "POST Query - Editor - TIGHTER",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/query/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shell-descriptors",
     "data": "postBody/query_shells_userx_tighter.json",
     "shouldMatch": "expected/query_userx_tighter.json",
     "expectedStatus": 200
@@ -59,7 +59,7 @@
     "context": "POST Query - Admin - FULL",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/query/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shell-descriptors",
     "data": "postBody/query_shells_with_filters.json",
     "shouldMatch": "expected/query_admin.json",
     "expectedStatus": 200

--- a/internal/aasregistry/security_filter_tests/aasregistry_security_filter_integration_test.go
+++ b/internal/aasregistry/security_filter_tests/aasregistry_security_filter_integration_test.go
@@ -36,11 +36,14 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 )
 
+var securityBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+var securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -48,8 +51,23 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("aasregistry-security-filter-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker_compose.yml",
-		HealthURL:   "http://localhost:6004/health",
-	}))
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
+		HealthURL:   securityBaseURL + "/health",
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/aasregistry/security_filter_tests/docker_compose/docker_compose.yml
+++ b/internal/aasregistry/security_filter_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: postgres_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-registry-security:
-    container_name: aas-registry-security
     build:
       context: ../../../..
       dockerfile: ./cmd/aasregistryservice/Dockerfile
@@ -34,28 +32,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -67,13 +64,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak-healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -85,7 +81,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasregistry/security_filter_tests/it_config.json
+++ b/internal/aasregistry/security_filter_tests/it_config.json
@@ -3,7 +3,7 @@
     "context": "POST Descriptor A - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_A.json",
     "expectedStatus": 201
   },
@@ -11,7 +11,7 @@
     "context": "POST Descriptor B - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_B.json",
     "expectedStatus": 201
   },
@@ -19,7 +19,7 @@
     "context": "POST Descriptor C - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_C.json",
     "expectedStatus": 201
   },
@@ -27,7 +27,7 @@
     "context": "GET Descriptor A - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
     "shouldMatch": "expected/expectedShellAUserA.json",
     "expectedStatus": 200
   },
@@ -35,7 +35,7 @@
     "context": "GET Descriptor B - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
     "shouldMatch": "expected/expectedShellBUserA.json",
     "expectedStatus": 200
   },
@@ -43,7 +43,7 @@
     "context": "GET Descriptor C - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
     "shouldMatch": "expected/expectedShellCUserA.json",
     "expectedStatus": 200
   },
@@ -51,7 +51,7 @@
     "context": "GET ALL Descriptor - User A - FILTERED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedShellUserA.json",
     "expectedStatus": 200
   },
@@ -59,7 +59,7 @@
     "context": "POST SMDESC - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/aasdesc_with_smdesc.json",
     "expectedStatus": 201
   },
@@ -67,7 +67,7 @@
     "context": "GET ALL Descriptor - User X - FILTERED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors",
     "shouldMatch": "expected/expectedShellUserX.json",
     "expectedStatus": 200
   },
@@ -75,14 +75,14 @@
     "context": "GET 1 Descriptor - User X - denied",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
     "expectedStatus": 404
   },
   {
     "context": "GET 1 Descriptor - User X - FILTERED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "shouldMatch": "expected/singlesm.json",
     "expectedStatus": 200
   },
@@ -90,14 +90,14 @@
     "context": "DELETE Descriptor - User X - denied",
     "token": { "user": "userx", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
     "expectedStatus": 404
   },
   {
     "context": "GET ALL - ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/allShellsAdmin.json",
     "expectedStatus": 200
   },
@@ -105,14 +105,14 @@
     "context": "DELETE Descriptor - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "expectedStatus": 204
   },
   {
     "context": "GET 1 Descriptor - User X - removed",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "expectedStatus": 404
   },
 
@@ -120,7 +120,7 @@
     "context": "POST Descriptor - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors",
     "data": "postBody/singlesm.json",
     "shouldMatch": "expected/singlesm.json",
     "expectedStatus": 201
@@ -129,7 +129,7 @@
     "context": "GET 1 Descriptor - User X - FILTERED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "shouldMatch": "expected/singlesm.json",
     "expectedStatus": 200
   },
@@ -139,7 +139,7 @@
     "context": "PUT Descriptor - User X - denied",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
     "data": "postBody/singlesmDenied.json",
     "expectedStatus": 403
   },
@@ -147,7 +147,7 @@
     "context": "PUT Descriptor - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "data": "postBody/singlesm.json",
     "expectedStatus": 204
   },
@@ -155,7 +155,7 @@
     "context": "GET 1 Descriptor - User X - FILTERED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "shouldMatch": "expected/singlesm.json",
     "expectedStatus": 200
   },
@@ -166,7 +166,7 @@
     "context": "POST Descriptor - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors",
     "data": "postBody/singlesm.json",
     "expectedStatus": 409
   },
@@ -174,7 +174,7 @@
     "context": "GET 1 Descriptor - User X - FILTERED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "shouldMatch": "expected/singlesm.json",
     "expectedStatus": 200
   },
@@ -182,7 +182,7 @@
     "context": "DELETE Descriptor - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "expectedStatus": 204
   },
 
@@ -190,7 +190,7 @@
     "context": "PUT Descriptor - User X - denied",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
     "data": "postBody/singlesmDenied.json",
     "expectedStatus": 403
   },
@@ -198,7 +198,7 @@
     "context": "PUT Descriptor - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "data": "postBody/singlesm.json",
     "shouldMatch": "expected/singlesm.json",
     "expectedStatus": 201
@@ -207,7 +207,7 @@
     "context": "GET 1 Descriptor - User X - FILTERED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "shouldMatch": "expected/singlesm.json",
     "expectedStatus": 200
   },
@@ -216,14 +216,14 @@
     "context": "DELETE Descriptor - ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
     "expectedStatus": 204
   },
   {
     "context": "POST Descriptor - User X - denied",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9JQ0hNQUdQSVpaQVNPR0VSTkU/submodel-descriptors",
     "data": "postBody/singlesmDenied.json",
     "expectedStatus": 403
   }

--- a/internal/aasregistry/security_index_tests/aasregistry_security_index_integration_test.go
+++ b/internal/aasregistry/security_index_tests/aasregistry_security_index_integration_test.go
@@ -36,11 +36,14 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 )
 
+var securityBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+var securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -48,8 +51,23 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("aasregistry-security-index-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker_compose.yml",
-		HealthURL:   "http://localhost:6004/test/health",
-	}))
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
+		HealthURL:   securityBaseURL + "/test/health",
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/aasregistry/security_index_tests/docker_compose/docker_compose.yml
+++ b/internal/aasregistry/security_index_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: postgres_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-registry-security:
-    container_name: aas-registry-security
     build:
       context: ../../../..
       dockerfile: ./cmd/aasregistryservice/Dockerfile
@@ -35,28 +33,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -68,13 +65,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak-healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -86,7 +82,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasregistry/security_index_tests/it_config.json
+++ b/internal/aasregistry/security_index_tests/it_config.json
@@ -3,7 +3,7 @@
     "context": "POST Descriptor A - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/test/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors",
     "data": "postBody/simple_aas_A.json",
     "expectedStatus": 201
   },
@@ -11,7 +11,7 @@
     "context": "POST Descriptor B - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/test/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors",
     "data": "postBody/simple_aas_B.json",
     "expectedStatus": 201
   },
@@ -19,7 +19,7 @@
     "context": "POST Descriptor C - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/test/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors",
     "data": "postBody/simple_aas_C.json",
     "expectedStatus": 201
   },
@@ -27,7 +27,7 @@
     "context": "GET Descriptor A - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
     "shouldMatch": "postBody/simple_aas_A.json",
     "expectedStatus": 200
   },
@@ -35,7 +35,7 @@
     "context": "GET Descriptor B - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
     "shouldMatch": "postBody/simple_aas_B.json",
     "expectedStatus": 200
   },
@@ -43,7 +43,7 @@
     "context": "GET Descriptor C - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
     "shouldMatch": "postBody/simple_aas_C.json",
     "expectedStatus": 200
   },
@@ -51,34 +51,34 @@
     "context": "GET ALL Descriptor - Admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors",
     "shouldMatch": "expected/expectedShellAdmin.json",
     "expectedStatus": 200
   },
   {
     "context": "GET Descriptor A - Anonym - ALLOWED",
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
     "shouldMatch": "expected/expectedShellAAnonym.json",
     "expectedStatus": 200
   },
   {
     "context": "GET Descriptor B - Anonym - ALLOWED",
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor C - Anonym - ALLOWED",
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor A - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
     "shouldMatch": "expected/expectedShellAUserA.json",
     "expectedStatus": 200
   },
@@ -86,7 +86,7 @@
     "context": "GET Descriptor B - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
     "shouldMatch": "expected/expectedShellBUserA.json",
     "expectedStatus": 200
   },
@@ -94,7 +94,7 @@
     "context": "GET Descriptor C - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
     "shouldMatch": "expected/expectedShellCUserA.json",
     "expectedStatus": 200
   },
@@ -102,7 +102,7 @@
     "context": "GET ALL Descriptor - User A - FILTERED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/test/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/test/shell-descriptors",
     "shouldMatch": "expected/expectedShellUserA.json",
     "expectedStatus": 200
   }

--- a/internal/aasregistry/security_match_tests/aasregistry_security_match_integration_test.go
+++ b/internal/aasregistry/security_match_tests/aasregistry_security_match_integration_test.go
@@ -36,11 +36,14 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 )
 
+var securityBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+var securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -48,8 +51,23 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("aasregistry-security-match-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker_compose.yml",
-		HealthURL:   "http://localhost:6004/health",
-	}))
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
+		HealthURL:   securityBaseURL + "/health",
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/aasregistry/security_match_tests/docker_compose/docker_compose.yml
+++ b/internal/aasregistry/security_match_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: postgres_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-registry-security:
-    container_name: aas-registry-security
     build:
       context: ../../../..
       dockerfile: ./cmd/aasregistryservice/Dockerfile
@@ -34,28 +32,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -67,13 +64,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak-healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -85,7 +81,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasregistry/security_match_tests/it_config.json
+++ b/internal/aasregistry/security_match_tests/it_config.json
@@ -3,7 +3,7 @@
     "context": "POST Descriptor A - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_A.json",
     "expectedStatus": 201
   },
@@ -11,7 +11,7 @@
     "context": "POST Descriptor B - Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_B.json",
     "expectedStatus": 201
   },
@@ -19,14 +19,14 @@
     "context": "GET Descriptor A - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor B - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
     "shouldMatch": "expected/expectedShellBUserA.json",
     "expectedStatus": 200
   },
@@ -34,7 +34,7 @@
     "context": "GET ALL Descriptor - User A - FILTERED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedShellUserA.json",
     "expectedStatus": 200
   }

--- a/internal/aasregistry/security_oidc_tests/aasregistry_security_oidc_integration_test.go
+++ b/internal/aasregistry/security_oidc_tests/aasregistry_security_oidc_integration_test.go
@@ -46,11 +46,14 @@ import (
 const (
 	oidcTestAudience  = "basyx-api"
 	oidcTestKeyID     = "basyx-oidc-e2e-key"
-	scpRegistryURL    = "http://localhost:6104"
-	rolesRegistryURL  = "http://localhost:6204"
 	securityEnvVar    = "OIDC_TEST_SECURITY_ENV"
 	composeConfigPath = "docker_compose/docker_compose.yml"
 	readinessTimeout  = 5 * time.Minute
+)
+
+var (
+	scpRegistryURL   = testenv.LocalhostURLFromEnv("BASYX_IT_SCP_API_PORT", 6104)
+	rolesRegistryURL = testenv.LocalhostURLFromEnv("BASYX_IT_ROLES_API_PORT", 6204)
 )
 
 type testIssuer struct {
@@ -113,6 +116,13 @@ func TestOIDCSignedJWTProviders(t *testing.T) {
 var oidcIssuer *testIssuer
 
 func TestMain(m *testing.M) {
+	runtime := testenv.NewComposeRuntimeOrExit("aasregistry-security-oidc", []testenv.PortBinding{
+		{Name: "scp-api", EnvVar: "BASYX_IT_SCP_API_PORT"},
+		{Name: "roles-api", EnvVar: "BASYX_IT_ROLES_API_PORT"},
+	})
+	scpRegistryURL = runtime.LocalhostURL("scp-api")
+	rolesRegistryURL = runtime.LocalhostURL("roles-api")
+
 	issuer, err := startTestIssuer()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "COMMON-OIDC-E2E-STARTISSUER failed to start OIDC issuer: %v\n", err)
@@ -135,6 +145,8 @@ func TestMain(m *testing.M) {
 
 	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     composeConfigPath,
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.EnvWith(securityEnvVar + "=" + securityEnv),
 		PreDownBeforeUp: true,
 		DownArgs:        []string{"down", "--remove-orphans"},
 		WaitForReady: func() error {

--- a/internal/aasregistry/security_oidc_tests/docker_compose/docker_compose.yml
+++ b/internal/aasregistry/security_oidc_tests/docker_compose/docker_compose.yml
@@ -1,7 +1,6 @@
 services:
   db-scp:
     image: postgres:18
-    container_name: postgres_oidc_scp_test
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
@@ -15,7 +14,6 @@ services:
 
   db-roles:
     image: postgres:18
-    container_name: postgres_oidc_roles_test
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
@@ -28,7 +26,6 @@ services:
       retries: 5
 
   basyx-configuration-scp:
-    container_name: basyx_configuration_oidc_scp_test
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile
@@ -46,7 +43,6 @@ services:
         condition: service_healthy
 
   basyx-configuration-roles:
-    container_name: basyx_configuration_oidc_roles_test
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile
@@ -64,7 +60,6 @@ services:
         condition: service_healthy
 
   aas-registry-scp:
-    container_name: aas_registry_oidc_scp_test
     build:
       context: ../../../..
       dockerfile: ./cmd/aasregistryservice/Dockerfile
@@ -82,7 +77,7 @@ services:
       - ABAC_MODELPATH=/security_env/scp-access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/scp-trustlist.json
     ports:
-      - "6104:5004"
+      - "127.0.0.1:${BASYX_IT_SCP_API_PORT:-6104}:5004"
     depends_on:
       basyx-configuration-scp:
         condition: service_completed_successfully
@@ -92,7 +87,6 @@ services:
       - "localhost:host-gateway"
 
   aas-registry-roles:
-    container_name: aas_registry_oidc_roles_test
     build:
       context: ../../../..
       dockerfile: ./cmd/aasregistryservice/Dockerfile
@@ -110,7 +104,7 @@ services:
       - ABAC_MODELPATH=/security_env/roles-access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/roles-trustlist.json
     ports:
-      - "6204:5004"
+      - "127.0.0.1:${BASYX_IT_ROLES_API_PORT:-6204}:5004"
     depends_on:
       basyx-configuration-roles:
         condition: service_completed_successfully

--- a/internal/aasregistry/security_operator_tests/aasregistry_security_operator_integration_test.go
+++ b/internal/aasregistry/security_operator_tests/aasregistry_security_operator_integration_test.go
@@ -36,11 +36,14 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 )
 
+var securityBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+var securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -48,8 +51,23 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("aasregistry-security-operator-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker_compose.yml",
-		HealthURL:   "http://localhost:6004/health",
-	}))
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
+		HealthURL:   securityBaseURL + "/health",
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/aasregistry/security_operator_tests/docker_compose/docker_compose.yml
+++ b/internal/aasregistry/security_operator_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: postgres_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "5432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-5432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-registry-security:
-    container_name: aas-registry-security
     build:
       context: ../../../..
       dockerfile: ./cmd/aasregistryservice/Dockerfile
@@ -35,28 +33,27 @@ services:
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
       - GENERAL_ENABLEIMPLICITCASTS=true
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -68,13 +65,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak-healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -86,7 +82,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasregistry/security_operator_tests/it_config.json
+++ b/internal/aasregistry/security_operator_tests/it_config.json
@@ -3,7 +3,7 @@
     "context": "Health endpoint - anonymous allowed",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "shouldMatch": "expected/expectedHealthEndpoint.json",
     "expectedStatus": 200
   },
@@ -11,7 +11,7 @@
     "context": "POST viewer descriptor - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/viewer_descriptor.json",
     "shouldMatch": "postBody/viewer_descriptor.json",
     "expectedStatus": 201
@@ -20,7 +20,7 @@
     "context": "POST regex descriptor - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/regex_descriptor.json",
     "shouldMatch": "postBody/regex_descriptor.json",
     "expectedStatus": 201
@@ -29,7 +29,7 @@
     "context": "POST regex descriptor 2 - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/regex_descriptor2.json",
     "shouldMatch": "postBody/regex_descriptor2.json",
     "expectedStatus": 201
@@ -38,7 +38,7 @@
     "context": "POST public descriptor - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/public_descriptor.json",
     "shouldMatch": "postBody/public_descriptor.json",
     "expectedStatus": 201
@@ -47,7 +47,7 @@
     "context": "GET viewer descriptor - viewer allowed via $starts-with",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczp2aWV3ZXItYXNzZXQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczp2aWV3ZXItYXNzZXQ",
     "shouldMatch": "postBody/viewer_descriptor.json",
     "expectedStatus": 200
   },
@@ -55,14 +55,14 @@
     "context": "GET viewer descriptor - editor denied (prefix rule)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczp2aWV3ZXItYXNzZXQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczp2aWV3ZXItYXNzZXQ",
     "expectedStatus": 404
   },
   {
     "context": "GET regex descriptor - editor allowed via $regex",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczpyZWdleC00Mg",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczpyZWdleC00Mg",
     "shouldMatch": "postBody/regex_descriptor.json",
     "expectedStatus": 200
   },
@@ -70,14 +70,14 @@
     "context": "GET regex descriptor - editor denied (regex rule not matched)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczpyZWdpbWF4LTQy",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczpyZWdpbWF4LTQy",
     "expectedStatus": 404
   },
   {
     "context": "GET public descriptor - anonymous allowed via $ends-with",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczpkZW1vOnB1YmxpYw",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczpkZW1vOnB1YmxpYw",
     "shouldMatch": "postBody/public_descriptor.json",
     "expectedStatus": 200
   },
@@ -85,14 +85,14 @@
     "context": "GET viewer descriptor - anonymous denied",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczp2aWV3ZXItYXNzZXQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczp2aWV3ZXItYXNzZXQ",
     "expectedStatus": 404
   },
   {
     "context": "GET all descriptor - editor ",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedEditorResult.json",
     "expectedStatus": 200
   },
@@ -100,14 +100,14 @@
     "context": "GET all descriptor - viewer ",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedViewerResult.json",
     "expectedStatus": 200
   },
   {
     "context": "GET all descriptor - anon ",
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedAnonResult.json",
     "expectedStatus": 200
   },
@@ -115,7 +115,7 @@
     "context": "POST time allow descriptor - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/time_allow_descriptor.json",
     "shouldMatch": "postBody/time_allow_descriptor.json",
     "expectedStatus": 201
@@ -124,7 +124,7 @@
     "context": "POST time deny descriptor - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/time_deny_descriptor.json",
     "shouldMatch": "postBody/time_deny_descriptor.json",
     "expectedStatus": 201
@@ -133,7 +133,7 @@
     "context": "GET time allow descriptor - viewer allowed via datetime compare",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczp0aW1lLWFsbG93",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczp0aW1lLWFsbG93",
     "shouldMatch": "postBody/time_allow_descriptor.json",
     "expectedStatus": 200
   },
@@ -141,14 +141,14 @@
     "context": "GET time deny descriptor - viewer denied via datetime compare",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczp0aW1lLWRlbnk=",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczp0aW1lLWRlbnk=",
     "expectedStatus": 404
   },
   {
     "context": "POST time field allow descriptor - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/time_field_allow_descriptor.json",
     "shouldMatch": "postBody/time_field_allow_descriptor.json",
     "expectedStatus": 201
@@ -157,7 +157,7 @@
     "context": "POST time field deny descriptor - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/time_field_deny_descriptor.json",
     "shouldMatch": "postBody/time_field_deny_descriptor.json",
     "expectedStatus": 201
@@ -166,7 +166,7 @@
     "context": "GET time field allow descriptor - viewer allowed via field datetime compare",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczpkdC1maWVsZC1hbGxvdw",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczpkdC1maWVsZC1hbGxvdw",
     "shouldMatch": "postBody/time_field_allow_descriptor.json",
     "expectedStatus": 200
   },
@@ -174,14 +174,14 @@
     "context": "GET time field deny descriptor - viewer denied via field datetime compare",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczpkdC1maWVsZC1kZW55",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczpkdC1maWVsZC1kZW55",
     "expectedStatus": 404
   },
   {
     "context": "GET ALL time field allow descriptors - viewer ",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedTimeResult.json",
     "expectedStatus": 200
   },
@@ -189,7 +189,7 @@
     "context": "POST mixed cast allow descriptor - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/mixed_cast_allow_descriptor.json",
     "shouldMatch": "postBody/mixed_cast_allow_descriptor.json",
     "expectedStatus": 201
@@ -198,7 +198,7 @@
     "context": "POST mixed cast deny descriptor - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/mixed_cast_deny_descriptor.json",
     "shouldMatch": "postBody/mixed_cast_deny_descriptor.json",
     "expectedStatus": 201
@@ -207,7 +207,7 @@
     "context": "GET mixed cast allow descriptor - editor with clearance allowed via casts",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWFsbG93",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWFsbG93",
     "shouldMatch": "postBody/mixed_cast_allow_descriptor.json",
     "expectedStatus": 200
   },
@@ -215,14 +215,14 @@
     "context": "GET mixed cast deny descriptor - editor with clearance denied via casts",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWRlbnk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWRlbnk",
     "expectedStatus": 404
   },
   {
     "context": "POST mixed cast allow descriptor 2 - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/mixed_cast_allow_descriptor2.json",
     "shouldMatch": "postBody/mixed_cast_allow_descriptor2.json",
     "expectedStatus": 201
@@ -231,7 +231,7 @@
     "context": "POST mixed cast allow descriptor 3 - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/mixed_cast_allow_descriptor3.json",
     "shouldMatch": "postBody/mixed_cast_allow_descriptor3.json",
     "expectedStatus": 201
@@ -240,7 +240,7 @@
     "context": "POST mixed cast deny descriptor 3 - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/mixed_cast_deny_descriptor3.json",
     "shouldMatch": "postBody/mixed_cast_deny_descriptor3.json",
     "expectedStatus": 201
@@ -249,7 +249,7 @@
     "context": "POST mixed cast deny descriptor 4 - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/mixed_cast_deny_descriptor4.json",
     "shouldMatch": "postBody/mixed_cast_deny_descriptor4.json",
     "expectedStatus": 201
@@ -258,7 +258,7 @@
     "context": "POST mixed cast deny descriptor 5 - admin creates fixture",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/mixed_cast_deny_descriptor5.json",
     "shouldMatch": "postBody/mixed_cast_deny_descriptor5.json",
     "expectedStatus": 201
@@ -267,7 +267,7 @@
     "context": "GET mixed cast allow descriptor 2 - editor with clearance allowed via casts",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWFsbG93Mg",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWFsbG93Mg",
     "shouldMatch": "postBody/mixed_cast_allow_descriptor2.json",
     "expectedStatus": 200
   },
@@ -275,7 +275,7 @@
     "context": "GET mixed cast allow descriptor 3 - editor with clearance allowed via casts",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWFsbG93Mw",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWFsbG93Mw",
     "shouldMatch": "postBody/mixed_cast_allow_descriptor3.json",
     "expectedStatus": 200
   },
@@ -283,28 +283,28 @@
     "context": "GET mixed cast deny descriptor 3 - editor with clearance denied via casts",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWRlbnkz",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWRlbnkz",
     "expectedStatus": 404
   },
   {
     "context": "GET mixed cast deny descriptor 4 - editor with clearance denied via casts",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWRlbnk0",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWRlbnk0",
     "expectedStatus": 404
   },
   {
     "context": "GET mixed cast deny descriptor 5 - editor with clearance denied via casts",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWRlbnk1",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/dXJuOmFhczptaXhlZC1jYXN0LWRlbnk1",
     "expectedStatus": 404
   },
   {
     "context": "GET ALL mixed cast allow descriptors - editor with clearance",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedMixedCastResult.json",
     "expectedStatus": 200
   }

--- a/internal/aasregistry/security_tests/aasregistry_security_integration_test.go
+++ b/internal/aasregistry/security_tests/aasregistry_security_integration_test.go
@@ -40,11 +40,14 @@ import (
 
 const actionAssertRecentChangeIDs = "ASSERT_RECENT_CHANGE_IDS"
 
+var securityBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+var securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -97,8 +100,23 @@ func extractRecentChangeIDs(t *testing.T, responseBody string) []string {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("aasregistry-security-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker_compose.yml",
-		HealthURL:   "http://localhost:6004/health",
-	}))
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
+		HealthURL:   securityBaseURL + "/health",
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/aasregistry/security_tests/docker_compose/docker_compose.yml
+++ b/internal/aasregistry/security_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: postgres_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-registry-security:
-    container_name: aas-registry-security
     build:
       context: ../../../..
       dockerfile: ./cmd/aasregistryservice/Dockerfile
@@ -35,28 +33,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -68,13 +65,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak-healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -86,7 +82,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasregistry/security_tests/it_config.json
+++ b/internal/aasregistry/security_tests/it_config.json
@@ -3,7 +3,7 @@
     "context": "Health endpoint - anonymous allowed",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "shouldMatch": "expected/expectedHealthEndpoint.json",
     "expectedStatus": 200
   },
@@ -11,7 +11,7 @@
     "context": "POST Descriptor A - User ANONONYM - DENIED",
     "token": null,
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_A.json",
     "expectedStatus": 403
   },
@@ -19,7 +19,7 @@
     "context": "POST Descriptor B - User ANONONYM - DENIED",
     "token": null,
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_B.json",
     "expectedStatus": 403
   },
@@ -27,7 +27,7 @@
     "context": "POST Descriptor C - User ANONONYM - DENIED",
     "token": null,
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_C.json",
     "expectedStatus": 403
   },
@@ -35,7 +35,7 @@
     "context": "POST Descriptor D - User ANONONYM - DENIED",
     "token": null,
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_D.json",
     "expectedStatus": 403
   },
@@ -43,7 +43,7 @@
     "context": "POST Descriptor X - User ANONONYM - DENIED",
     "token": null,
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_X.json",
     "expectedStatus": 403
   },
@@ -51,7 +51,7 @@
     "context": "POST Descriptor A - User A - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_A.json",
     "shouldMatch": "postBody/simple_aas_A.json",
     "expectedStatus": 201
@@ -60,7 +60,7 @@
     "context": "POST Descriptor B - User A - DENIED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_B.json",
     "expectedStatus": 403
   },
@@ -69,7 +69,7 @@
     "action": "ASSERT_BULK_FAILURE",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/bulk/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/bulk/shell-descriptors",
     "data": "postBody/bulk_create_aas_b.json",
     "expectedStatus": 202,
     "expectedBulkFailureStatus": 403,
@@ -80,7 +80,7 @@
     "context": "POST Descriptor C - User A - DENIED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_C.json",
     "expectedStatus": 403
   },
@@ -88,7 +88,7 @@
     "context": "POST Descriptor D - User A - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_D.json",
     "shouldMatch": "postBody/simple_aas_D.json",
     "expectedStatus": 201
@@ -97,7 +97,7 @@
     "context": "POST Descriptor X - User A - DENIED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_X.json",
     "expectedStatus": 403
   },
@@ -105,7 +105,7 @@
     "context": "POST Descriptor A - User B - ALLOWED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_A.json",
     "expectedStatus": 409
   },
@@ -113,7 +113,7 @@
     "context": "POST Descriptor B - User B - ALLOWED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_B.json",
     "shouldMatch": "postBody/simple_aas_B.json",
     "expectedStatus": 201
@@ -122,7 +122,7 @@
     "context": "POST Descriptor C - User B - ALLOWED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_C.json",
     "shouldMatch": "postBody/simple_aas_C.json",
     "expectedStatus": 201
@@ -131,7 +131,7 @@
     "context": "POST Descriptor D - User B - ALLOWED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_D.json",
     "expectedStatus": 409
   },
@@ -139,7 +139,7 @@
     "context": "POST Descriptor X - User B - DENIED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_X.json",
     "expectedStatus": 403
   },
@@ -147,7 +147,7 @@
     "context": "POST Descriptor A - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_A.json",
     "expectedStatus": 409
   },
@@ -155,7 +155,7 @@
     "context": "POST Descriptor B - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_B.json",
     "expectedStatus": 409
   },
@@ -163,7 +163,7 @@
     "context": "POST Descriptor C - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_C.json",
     "expectedStatus": 409
   },
@@ -171,7 +171,7 @@
     "context": "POST Descriptor D - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_D.json",
     "expectedStatus": 409
   },
@@ -179,7 +179,7 @@
     "context": "POST Descriptor X - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/simple_aas_X.json",
     "shouldMatch": "postBody/simple_aas_X.json",
     "expectedStatus": 201
@@ -188,7 +188,7 @@
     "context": "GET Descriptor A - User ANONONYM - ALLOWED",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
     "shouldMatch": "postBody/simple_aas_A.json",
     "expectedStatus": 200
   },
@@ -196,42 +196,42 @@
     "context": "GET Descriptor A trailing slash - User ANONONYM - NOT FOUND",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B/",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor B - User ANONONYM - DENIED",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor C - User ANONONYM - DENIED",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor D - User ANONONYM - DENIED",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9E",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9E",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor X - User ANONONYM - DENIED",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor A - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
     "shouldMatch": "postBody/simple_aas_A.json",
     "expectedStatus": 200
   },
@@ -239,7 +239,7 @@
     "context": "GET Descriptor B - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
     "shouldMatch": "postBody/simple_aas_B.json",
     "expectedStatus": 200
   },
@@ -247,28 +247,28 @@
     "context": "GET Descriptor C - User A - DENIED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor D - User A - DENIED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9E",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9E",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor X - User A - DENIED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor A - User B - ALLOWED",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
     "shouldMatch": "postBody/simple_aas_A.json",
     "expectedStatus": 200
   },
@@ -276,7 +276,7 @@
     "context": "GET Descriptor B - User B - ALLOWED",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
     "shouldMatch": "postBody/simple_aas_B.json",
     "expectedStatus": 200
   },
@@ -284,7 +284,7 @@
     "context": "GET Descriptor C - User B - ALLOWED",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
     "shouldMatch": "postBody/simple_aas_C.json",
     "expectedStatus": 200
   },
@@ -292,7 +292,7 @@
     "context": "GET Descriptor D - User B - ALLOWED",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9E",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9E",
     "shouldMatch": "postBody/simple_aas_D.json",
     "expectedStatus": 200
   },
@@ -300,14 +300,14 @@
     "context": "GET Descriptor X - User B - DENIED",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y",
     "expectedStatus": 404
   },
   {
     "context": "GET Descriptor A - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9B",
     "shouldMatch": "postBody/simple_aas_A.json",
     "expectedStatus": 200
   },
@@ -315,7 +315,7 @@
     "context": "GET Descriptor B - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9C",
     "shouldMatch": "postBody/simple_aas_B.json",
     "expectedStatus": 200
   },
@@ -323,7 +323,7 @@
     "context": "GET Descriptor C - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9D",
     "shouldMatch": "postBody/simple_aas_C.json",
     "expectedStatus": 200
   },
@@ -331,7 +331,7 @@
     "context": "GET Descriptor D - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9E",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9E",
     "shouldMatch": "postBody/simple_aas_D.json",
     "expectedStatus": 200
   },
@@ -339,7 +339,7 @@
     "context": "GET Descriptor X - User ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y",
     "shouldMatch": "postBody/simple_aas_X.json",
     "expectedStatus": 200
   },
@@ -347,7 +347,7 @@
     "context": "GET ALL Descriptor - User ANONONYM - ALLOWED",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedShellAnonym.json",
     "expectedStatus": 200
   },
@@ -355,7 +355,7 @@
     "context": "GET ALL Descriptor trailing slash - User ANONONYM - NOT FOUND",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "expectedStatus": 404
   },
   {
@@ -363,7 +363,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?limit=20",
     "shouldMatch": "expected/expectedRecentChangesAnonymousDescriptorIDs.json",
     "expectedStatus": 200
   },
@@ -371,14 +371,14 @@
     "context": "GET /shell-descriptors/ - anonymous public filtered - NOT FOUND",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/?limit=20",
     "expectedStatus": 404
   },
   {
     "context": "GET ALL Descriptor - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedShellUserA.json",
     "expectedStatus": 200
   },
@@ -386,7 +386,7 @@
     "context": "GET ALL Descriptor trailing slash - User A - NOT FOUND",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "expectedStatus": 404
   },
   {
@@ -394,7 +394,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?limit=20",
     "shouldMatch": "expected/expectedRecentChangesUserADescriptorIDs.json",
     "expectedStatus": 200
   },
@@ -402,14 +402,14 @@
     "context": "GET /shell-descriptors/ - user A filtered - NOT FOUND",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/?limit=20",
     "expectedStatus": 404
   },
   {
     "context": "GET ALL Descriptor - User B - ALLOWED",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedShellUserB.json",
     "expectedStatus": 200
   },
@@ -417,7 +417,7 @@
     "context": "GET ALL Descriptor trailing slash - User B - NOT FOUND",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "expectedStatus": 404
   },
   {
@@ -425,7 +425,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?limit=20",
     "shouldMatch": "expected/expectedRecentChangesUserBDescriptorIDs.json",
     "expectedStatus": 200
   },
@@ -433,14 +433,14 @@
     "context": "GET /shell-descriptors/ - user B filtered - NOT FOUND",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/?limit=20",
     "expectedStatus": 404
   },
   {
     "context": "GET ALL Descriptor - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedShellUserX.json",
     "expectedStatus": 200
   },
@@ -448,14 +448,14 @@
     "context": "GET ALL Descriptor trailing slash - User X - NOT FOUND",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "GET ALL Descriptor - User Y - ALLOWED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedShellUserY.json",
     "expectedStatus": 200
   },
@@ -463,14 +463,14 @@
     "context": "GET ALL Descriptor trailing slash - User Y - NOT FOUND",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "GET ALL Descriptor - User Admin - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "shouldMatch": "expected/expectedShellAdmin.json",
     "expectedStatus": 200
   },
@@ -478,7 +478,7 @@
     "context": "GET ALL Descriptor trailing slash - User Admin - NOT FOUND",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/",
     "expectedStatus": 404
   },
   {
@@ -486,7 +486,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors?limit=20",
     "shouldMatch": "expected/expectedRecentChangesAdminDescriptorIDs.json",
     "expectedStatus": 200
   },
@@ -494,74 +494,74 @@
     "context": "GET /shell-descriptors/ - admin descriptor object filtered - NOT FOUND",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shell-descriptors/?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/?limit=20",
     "expectedStatus": 404
   },
-  { "context": "POST Submodel A - ANON - DENIED", "token": null, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 403 },
-  { "context": "POST Submodel B - ANON - DENIED", "token": null, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "expectedStatus": 403 },
-  { "context": "POST Submodel C - ANON - DENIED", "token": null, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 403 },
-  { "context": "POST Submodel D - ANON - DENIED", "token": null, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 403 },
-  { "context": "POST Submodel X - ANON - DENIED", "token": null, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
+  { "context": "POST Submodel A - ANON - DENIED", "token": null, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 403 },
+  { "context": "POST Submodel B - ANON - DENIED", "token": null, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "expectedStatus": 403 },
+  { "context": "POST Submodel C - ANON - DENIED", "token": null, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 403 },
+  { "context": "POST Submodel D - ANON - DENIED", "token": null, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 403 },
+  { "context": "POST Submodel X - ANON - DENIED", "token": null, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
 
-  { "context": "POST Submodel A - User X - ALLOWED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "shouldMatch": "postBody/simple_smd_a.json", "expectedStatus": 201 },
-  { "context": "POST Submodel B - User X - DENIED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "expectedStatus": 403 },
-  { "context": "POST Submodel C - User X - DENIED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 403 },
-  { "context": "POST Submodel D - User X - ALLOWED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "shouldMatch": "postBody/simple_smd_d.json", "expectedStatus": 201 },
-  { "context": "POST Submodel X - User X - DENIED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
+  { "context": "POST Submodel A - User X - ALLOWED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "shouldMatch": "postBody/simple_smd_a.json", "expectedStatus": 201 },
+  { "context": "POST Submodel B - User X - DENIED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "expectedStatus": 403 },
+  { "context": "POST Submodel C - User X - DENIED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 403 },
+  { "context": "POST Submodel D - User X - ALLOWED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "shouldMatch": "postBody/simple_smd_d.json", "expectedStatus": 201 },
+  { "context": "POST Submodel X - User X - DENIED", "token": { "user": "userx", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
 
-  { "context": "POST Submodel A - User Y - CONFLICT", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
-  { "context": "POST Submodel B - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "shouldMatch": "postBody/simple_smd_b.json", "expectedStatus": 201 },
-  { "context": "POST Submodel C - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "shouldMatch": "postBody/simple_smd_c.json", "expectedStatus": 201 },
-  { "context": "POST Submodel D - User Y - DENIED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
-  { "context": "POST Submodel X - User Y - DENIED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
+  { "context": "POST Submodel A - User Y - CONFLICT", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
+  { "context": "POST Submodel B - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "shouldMatch": "postBody/simple_smd_b.json", "expectedStatus": 201 },
+  { "context": "POST Submodel C - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "shouldMatch": "postBody/simple_smd_c.json", "expectedStatus": 201 },
+  { "context": "POST Submodel D - User Y - DENIED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
+  { "context": "POST Submodel X - User Y - DENIED", "token": { "user": "usery", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "expectedStatus": 403 },
 
-  { "context": "POST Submodel A - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
-  { "context": "POST Submodel B - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "expectedStatus": 409 },
-  { "context": "POST Submodel C - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 409 },
-  { "context": "POST Submodel D - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
-  { "context": "POST Submodel X - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "shouldMatch": "postBody/simple_smd_x.json", "expectedStatus": 201 },
+  { "context": "POST Submodel A - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_a.json", "expectedStatus": 409 },
+  { "context": "POST Submodel B - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_b.json", "expectedStatus": 409 },
+  { "context": "POST Submodel C - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_c.json", "expectedStatus": 409 },
+  { "context": "POST Submodel D - ADMIN - CONFLICT", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_d.json", "expectedStatus": 409 },
+  { "context": "POST Submodel X - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "POST", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "data": "postBody/simple_smd_x.json", "shouldMatch": "postBody/simple_smd_x.json", "expectedStatus": 201 },
 
-  { "context": "GET Submodel A - ANON - ALLOWED", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE", "shouldMatch": "expected/expected_smd_a.json", "expectedStatus": 200 },
-  { "context": "GET Submodel A trailing slash - ANON - NOT FOUND", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE/", "expectedStatus": 404 },
-  { "context": "GET Submodel B - ANON - DENIED", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI", "expectedStatus": 404 },
-  { "context": "GET Submodel C - ANON - DENIED", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM", "expectedStatus": 404 },
-  { "context": "GET Submodel D - ANON - DENIED", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ", "expectedStatus": 404 },
-  { "context": "GET Submodel X - ANON - DENIED", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg", "expectedStatus": 404 },
+  { "context": "GET Submodel A - ANON - ALLOWED", "token": null, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE", "shouldMatch": "expected/expected_smd_a.json", "expectedStatus": 200 },
+  { "context": "GET Submodel A trailing slash - ANON - NOT FOUND", "token": null, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE/", "expectedStatus": 404 },
+  { "context": "GET Submodel B - ANON - DENIED", "token": null, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI", "expectedStatus": 404 },
+  { "context": "GET Submodel C - ANON - DENIED", "token": null, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM", "expectedStatus": 404 },
+  { "context": "GET Submodel D - ANON - DENIED", "token": null, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ", "expectedStatus": 404 },
+  { "context": "GET Submodel X - ANON - DENIED", "token": null, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg", "expectedStatus": 404 },
 
-  { "context": "GET Submodel A - User A - ALLOWED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE", "shouldMatch": "expected/expected_smd_a.json", "expectedStatus": 200 },
-  { "context": "GET Submodel B - User A - ALLOWED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI", "shouldMatch": "expected/expected_smd_b.json", "expectedStatus": 200 },
-  { "context": "GET Submodel C - User A - DENIED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM", "expectedStatus": 404 },
-  { "context": "GET Submodel D - User A - DENIED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ", "expectedStatus": 404 },
-  { "context": "GET Submodel X - User A - DENIED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg", "expectedStatus": 404 },
+  { "context": "GET Submodel A - User A - ALLOWED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE", "shouldMatch": "expected/expected_smd_a.json", "expectedStatus": 200 },
+  { "context": "GET Submodel B - User A - ALLOWED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI", "shouldMatch": "expected/expected_smd_b.json", "expectedStatus": 200 },
+  { "context": "GET Submodel C - User A - DENIED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM", "expectedStatus": 404 },
+  { "context": "GET Submodel D - User A - DENIED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ", "expectedStatus": 404 },
+  { "context": "GET Submodel X - User A - DENIED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg", "expectedStatus": 404 },
 
-  { "context": "GET Submodel A - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE", "shouldMatch": "expected/expected_smd_a.json", "expectedStatus": 200 },
-  { "context": "GET Submodel B - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI", "shouldMatch": "expected/expected_smd_b.json", "expectedStatus": 200 },
-  { "context": "GET Submodel C - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM", "shouldMatch": "expected/expected_smd_c.json", "expectedStatus": 200 },
-  { "context": "GET Submodel D - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ", "shouldMatch": "expected/expected_smd_d.json", "expectedStatus": 200 },
-  { "context": "GET Submodel X - User B - DENIED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg", "expectedStatus": 404 },
+  { "context": "GET Submodel A - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE", "shouldMatch": "expected/expected_smd_a.json", "expectedStatus": 200 },
+  { "context": "GET Submodel B - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI", "shouldMatch": "expected/expected_smd_b.json", "expectedStatus": 200 },
+  { "context": "GET Submodel C - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM", "shouldMatch": "expected/expected_smd_c.json", "expectedStatus": 200 },
+  { "context": "GET Submodel D - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ", "shouldMatch": "expected/expected_smd_d.json", "expectedStatus": 200 },
+  { "context": "GET Submodel X - User B - DENIED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg", "expectedStatus": 404 },
 
-  { "context": "GET Submodel A - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE", "shouldMatch": "expected/expected_smd_a.json", "expectedStatus": 200 },
-  { "context": "GET Submodel B - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI", "shouldMatch": "expected/expected_smd_b.json", "expectedStatus": 200 },
-  { "context": "GET Submodel C - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM", "shouldMatch": "expected/expected_smd_c.json", "expectedStatus": 200 },
-  { "context": "GET Submodel D - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ", "shouldMatch": "expected/expected_smd_d.json", "expectedStatus": 200 },
-  { "context": "GET Submodel X - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg", "shouldMatch": "expected/expected_smd_x.json", "expectedStatus": 200 },
+  { "context": "GET Submodel A - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE", "shouldMatch": "expected/expected_smd_a.json", "expectedStatus": 200 },
+  { "context": "GET Submodel B - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI", "shouldMatch": "expected/expected_smd_b.json", "expectedStatus": 200 },
+  { "context": "GET Submodel C - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM", "shouldMatch": "expected/expected_smd_c.json", "expectedStatus": 200 },
+  { "context": "GET Submodel D - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ", "shouldMatch": "expected/expected_smd_d.json", "expectedStatus": 200 },
+  { "context": "GET Submodel X - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg", "shouldMatch": "expected/expected_smd_x.json", "expectedStatus": 200 },
 
-  { "context": "GET ALL Submodels - ANON - ALLOWED", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDAnon.json", "expectedStatus": 200 },
-  { "context": "GET ALL Submodels trailing slash - ANON - NOT FOUND", "token": null, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/", "expectedStatus": 404 },
-  { "context": "GET ALL Submodels - User A - ALLOWED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDUserA.json", "expectedStatus": 200 },
-  { "context": "GET ALL Submodels - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDUserB.json", "expectedStatus": 200 },
-  { "context": "GET ALL Submodels - User X - ALLOWED", "token": { "user": "userx", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDUserX.json", "expectedStatus": 200 },
-  { "context": "GET ALL Submodels - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDUserY.json", "expectedStatus": 200 },
-  { "context": "GET ALL Submodels - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDAdmin.json", "expectedStatus": 200 },
+  { "context": "GET ALL Submodels - ANON - ALLOWED", "token": null, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDAnon.json", "expectedStatus": 200 },
+  { "context": "GET ALL Submodels trailing slash - ANON - NOT FOUND", "token": null, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/", "expectedStatus": 404 },
+  { "context": "GET ALL Submodels - User A - ALLOWED", "token": { "user": "usera", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDUserA.json", "expectedStatus": 200 },
+  { "context": "GET ALL Submodels - User B - ALLOWED", "token": { "user": "userb", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDUserB.json", "expectedStatus": 200 },
+  { "context": "GET ALL Submodels - User X - ALLOWED", "token": { "user": "userx", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDUserX.json", "expectedStatus": 200 },
+  { "context": "GET ALL Submodels - User Y - ALLOWED", "token": { "user": "usery", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDUserY.json", "expectedStatus": 200 },
+  { "context": "GET ALL Submodels - ADMIN - ALLOWED", "token": { "user": "admin", "password": "pwd" }, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors", "shouldMatch": "expected/expectedSMDAdmin.json", "expectedStatus": 200 },
 
-  { "context": "PUT AAS create - User X allowed via CREATE", "token": { "user": "userx", "password": "pwd" }, "method": "PUT", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9QVVQtWA", "data": "postBody/put_create_aas_userx.json", "expectedStatus": 201 },
-  { "context": "PUT AAS update - User X denied without UPDATE", "token": { "user": "userx", "password": "pwd" }, "method": "PUT", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9QVVQtWA", "data": "postBody/put_update_aas_userx.json", "expectedStatus": 403 },
-  { "context": "PUT AAS update - Admin allowed with UPDATE", "token": { "user": "admin", "password": "pwd" }, "method": "PUT", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9QVVQtWA", "data": "postBody/put_update_aas_userx.json", "expectedStatus": 204 },
+  { "context": "PUT AAS create - User X allowed via CREATE", "token": { "user": "userx", "password": "pwd" }, "method": "PUT", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9QVVQtWA", "data": "postBody/put_create_aas_userx.json", "expectedStatus": 201 },
+  { "context": "PUT AAS update - User X denied without UPDATE", "token": { "user": "userx", "password": "pwd" }, "method": "PUT", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9QVVQtWA", "data": "postBody/put_update_aas_userx.json", "expectedStatus": 403 },
+  { "context": "PUT AAS update - Admin allowed with UPDATE", "token": { "user": "admin", "password": "pwd" }, "method": "PUT", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9QVVQtWA", "data": "postBody/put_update_aas_userx.json", "expectedStatus": 204 },
 
-  { "context": "PUT Submodel create - User X allowed via CREATE", "token": { "user": "userx", "password": "pwd" }, "method": "PUT", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVBVVC1Y", "data": "postBody/put_create_smd_userx.json", "expectedStatus": 201 },
-  { "context": "PUT Submodel update - User X denied without UPDATE", "token": { "user": "userx", "password": "pwd" }, "method": "PUT", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVBVVC1Y", "data": "postBody/put_update_smd_userx.json", "expectedStatus": 403 },
-  { "context": "PUT Submodel update - Admin allowed with UPDATE", "token": { "user": "admin", "password": "pwd" }, "method": "PUT", "endpoint": "http://localhost:6004/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVBVVC1Y", "data": "postBody/put_update_smd_userx.json", "expectedStatus": 204 },
+  { "context": "PUT Submodel create - User X allowed via CREATE", "token": { "user": "userx", "password": "pwd" }, "method": "PUT", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVBVVC1Y", "data": "postBody/put_create_smd_userx.json", "expectedStatus": 201 },
+  { "context": "PUT Submodel update - User X denied without UPDATE", "token": { "user": "userx", "password": "pwd" }, "method": "PUT", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVBVVC1Y", "data": "postBody/put_update_smd_userx.json", "expectedStatus": 403 },
+  { "context": "PUT Submodel update - Admin allowed with UPDATE", "token": { "user": "admin", "password": "pwd" }, "method": "PUT", "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9Y/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVBVVC1Y", "data": "postBody/put_update_smd_userx.json", "expectedStatus": 204 },
 
-  { "context": "GET Non Existing Endpoint - ANON - NOT FOUND", "token": null, "method": "GET", "endpoint": "http://localhost:6004/does-not-exist", "expectedStatus": 404 },
-  { "context": "PATCH Health Endpoint - ANON - NOT FOUND", "token": null, "method": "PATCH", "endpoint": "http://localhost:6004/health", "expectedStatus": 404 }
+  { "context": "GET Non Existing Endpoint - ANON - NOT FOUND", "token": null, "method": "GET", "endpoint": "{{BASYX_IT_API_URL}}/does-not-exist", "expectedStatus": 404 },
+  { "context": "PATCH Health Endpoint - ANON - NOT FOUND", "token": null, "method": "PATCH", "endpoint": "{{BASYX_IT_API_URL}}/health", "expectedStatus": 404 }
 ]

--- a/internal/aasrepository/integration_tests/aasrepository_history_recent_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_history_recent_integration_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 func TestAASRepositoryHistoryRecentChangesAndBatchAssetKind(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/history-batch-%d", time.Now().UnixNano())
 	encodedAASID := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 	globalAssetID := "urn:example:asset:history-batch"
@@ -165,7 +165,7 @@ func TestAASRepositoryHistoryRecentChangesAndBatchAssetKind(t *testing.T) {
 }
 
 func TestAASRepositoryHistoryAllowsAddingIDShortAfterCreate(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/history-add-idshort-%d", time.Now().UnixNano())
 	encodedAASID := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 

--- a/internal/aasrepository/integration_tests/aasrepository_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_integration_test.go
@@ -51,8 +51,9 @@ import (
 )
 
 const actionDeleteAllAAS = "DELETE_ALL_AAS"
-const defaultIntegrationTestDSN = "postgres://admin:admin123@127.0.0.1:6432/basyxTestDB?sslmode=disable"
 
+var aasRepositoryBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
+var aasRepositoryInvalidBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_INVALID_API_PORT", 6006)
 var integrationTestDSN = getIntegrationTestDSN()
 
 func getIntegrationTestDSN() string {
@@ -60,14 +61,14 @@ func getIntegrationTestDSN() string {
 		return dsn
 	}
 
-	return defaultIntegrationTestDSN
+	return testenv.PostgresURLFromEnv("BASYX_IT_DB_PORT", 6432, "basyxTestDB")
 }
 
 func deleteAllAAS(t *testing.T, runner *testenv.JSONSuiteRunner, stepNumber int) {
 	for {
 		response, err := runner.RunStep(testenv.JSONSuiteStep{
 			Method:         http.MethodGet,
-			Endpoint:       "http://127.0.0.1:6004/shells",
+			Endpoint:       aasRepositoryBaseURL + "/shells",
 			ExpectedStatus: http.StatusOK,
 		}, stepNumber)
 		require.NoError(t, err)
@@ -87,7 +88,7 @@ func deleteAllAAS(t *testing.T, runner *testenv.JSONSuiteRunner, stepNumber int)
 			encodedIdentifier := base64.RawURLEncoding.EncodeToString([]byte(item.ID))
 			_, err = runner.RunStep(testenv.JSONSuiteStep{
 				Method:         http.MethodDelete,
-				Endpoint:       fmt.Sprintf("http://127.0.0.1:6004/shells/%s", encodedIdentifier),
+				Endpoint:       fmt.Sprintf("%s/shells/%s", aasRepositoryBaseURL, encodedIdentifier),
 				ExpectedStatus: http.StatusNoContent,
 			}, stepNumber)
 			require.NoError(t, err)
@@ -628,7 +629,7 @@ func shouldMatchImportedDescriptionResponseForAASEnvironment(step testenv.JSONSu
 }
 
 func TestQueryAssetAdministrationShellFalseFragmentFiltersKeepRootAAS(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/query-fragments-%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 
@@ -784,7 +785,7 @@ func requireFirstSpecificAssetID(t *testing.T, shell map[string]any) map[string]
 }
 
 func TestPostAssetAdministrationShellAcceptsNullSubmodels(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/null-submodels-%d", time.Now().UnixNano())
 
 	requestBody := fmt.Sprintf(`{
@@ -818,7 +819,7 @@ func TestPostAssetAdministrationShellAcceptsNullSubmodels(t *testing.T) {
 }
 
 func TestPutSubmodelByIdAasRepositoryReturnsCreatedSubmodelAnd201(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/put-submodel-create-%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 
@@ -846,7 +847,7 @@ func TestPutSubmodelByIdAasRepositoryReturnsCreatedSubmodelAnd201(t *testing.T) 
 }
 
 func TestPutSubmodelByIdAasRepositoryReturnsNoContentOnUpdate(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/put-submodel-update-%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 
@@ -892,7 +893,7 @@ func TestPutSubmodelByIdAasRepositoryReturnsNoContentOnUpdate(t *testing.T) {
 }
 
 func TestLocationHeadersForSubmodelElementCreateEndpointsAasRepository(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/location-headers-submodel-elements-%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 
@@ -955,7 +956,7 @@ func TestLocationHeadersForSubmodelElementCreateEndpointsAasRepository(t *testin
 }
 
 func TestGetSubmodelByIdAasRepositoryReturnsSubmodel(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/get-submodel-%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 
@@ -984,7 +985,7 @@ func TestGetSubmodelByIdAasRepositoryReturnsSubmodel(t *testing.T) {
 }
 
 func TestPostSubmodelReferenceAasRepositoryReturnsConflictOnDuplicate(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/submodel-ref-duplicate-%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 
@@ -1006,7 +1007,7 @@ func TestPostSubmodelReferenceAasRepositoryReturnsConflictOnDuplicate(t *testing
 }
 
 func TestSubmodelSuperPathEndpointsAasRepository(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/superpath-%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 
@@ -1165,7 +1166,7 @@ func findAASSubmodelElementInListOptional(t *testing.T, rawElements []any, idSho
 }
 
 func TestDeleteSubmodelByIdAasRepositoryDeletesSubmodelAndReference(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/delete-submodel-%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 
@@ -1202,7 +1203,7 @@ func TestDeleteSubmodelByIdAasRepositoryDeletesSubmodelAndReference(t *testing.T
 }
 
 func TestDeleteSubmodelByIdAasRepositoryRollsBackReferenceDeleteOnSubmodelDeleteFailure(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/delete-submodel-tx-%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 
@@ -1247,7 +1248,7 @@ func TestDeleteSubmodelByIdAasRepositoryRollsBackReferenceDeleteOnSubmodelDelete
 }
 
 func TestThumbnailAttachmentOperations(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/thumbnail_test_%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 	thumbnailEndpoint := fmt.Sprintf("%s/shells/%s/asset-information/thumbnail", baseURL, aasIdentifier)
@@ -1377,7 +1378,7 @@ func TestThumbnailAttachmentOperations(t *testing.T) {
 }
 
 func TestDeleteAssetAdministrationShellUnlinksThumbnailLargeObject(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/thumbnail_delete_cleanup_%d", time.Now().UnixNano())
 	encodedAASID := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 	aasEndpoint := fmt.Sprintf("%s/shells/%s", baseURL, encodedAASID)
@@ -1399,7 +1400,7 @@ func TestDeleteAssetAdministrationShellUnlinksThumbnailLargeObject(t *testing.T)
 }
 
 func TestPutAssetAdministrationShellUnlinksReplacedThumbnailLargeObject(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/thumbnail_put_cleanup_%d", time.Now().UnixNano())
 	encodedAASID := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 	aasEndpoint := fmt.Sprintf("%s/shells/%s", baseURL, encodedAASID)
@@ -1468,7 +1469,7 @@ func countPostgresLargeObjects(t *testing.T, dsn string) int64 {
 }
 
 func TestContractThumbnailGetReturnsDetectedContentType(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/thumbnail_contract_%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 	thumbnailEndpoint := fmt.Sprintf("%s/shells/%s/asset-information/thumbnail", baseURL, aasIdentifier)
@@ -1494,7 +1495,7 @@ func TestContractThumbnailGetReturnsDetectedContentType(t *testing.T) {
 }
 
 func TestThumbnailUploadUsesDeclaredContentTypeFallback(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := aasRepositoryBaseURL
 	aasID := fmt.Sprintf("https://example.com/ids/aas/thumbnail_declared_fallback_%d", time.Now().UnixNano())
 	aasIdentifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
 	thumbnailEndpoint := fmt.Sprintf("%s/shells/%s/asset-information/thumbnail", baseURL, aasIdentifier)
@@ -1536,7 +1537,7 @@ func TestStandaloneStartupRejectsUnsupportedSubmodelRegistryToggle(t *testing.T)
 		t.Skip("requires bundled integration docker compose setup")
 	}
 
-	assertServiceNeverHealthy(t, "http://localhost:6006/health", 20*time.Second)
+	assertServiceNeverHealthy(t, aasRepositoryInvalidBaseURL+"/health", 20*time.Second)
 }
 
 // TestMain handles setup and teardown
@@ -1545,10 +1546,21 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
+	runtime := testenv.NewComposeRuntimeOrExit("aasrepository-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "invalid-api", EnvVar: "BASYX_IT_INVALID_API_PORT"},
+	})
+	aasRepositoryBaseURL = runtime.LocalURL("api")
+	aasRepositoryInvalidBaseURL = runtime.LocalhostURL("invalid-api")
+	integrationTestDSN = runtime.PostgresURL("db", "basyxTestDB")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     "docker_compose/docker_compose.yml",
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.Env(),
 		PreDownBeforeUp: true,
-		HealthURL:       "http://localhost:6004/health",
+		HealthURL:       aasRepositoryBaseURL + "/health",
 		HealthTimeout:   150 * time.Second,
 	}))
 }

--- a/internal/aasrepository/integration_tests/aasrepository_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_integration_test.go
@@ -1543,6 +1543,10 @@ func TestStandaloneStartupRejectsUnsupportedSubmodelRegistryToggle(t *testing.T)
 // TestMain handles setup and teardown
 func TestMain(m *testing.M) {
 	if os.Getenv("BASYX_EXTERNAL_COMPOSE") == "1" {
+		testenv.SetEnvDefaultsOrExit(map[string]string{
+			"BASYX_IT_API_URL":         aasRepositoryBaseURL,
+			"BASYX_IT_INVALID_API_URL": aasRepositoryInvalidBaseURL,
+		})
 		os.Exit(m.Run())
 	}
 

--- a/internal/aasrepository/integration_tests/docker_compose/docker_compose.yml
+++ b/internal/aasrepository/integration_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db_it:
     image: postgres:18
-    container_name: postgres_db_it
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -33,7 +32,7 @@ services:
       - BASYX_HISTORY_FULL_SNAPSHOT_INTERVAL=3
       - SERVER_STRICTVERIFICATION=off
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
@@ -57,7 +56,7 @@ services:
       - SERVER_STRICTVERIFICATION=false
       - GENERAL_SUBMODELREGISTRYINTEGRATION=true
     ports:
-      - "6006:5004"
+      - "127.0.0.1:${BASYX_IT_INVALID_API_PORT:-6006}:5004"
     command: ["/app/aasrepositoryservice", "-config", "/config/config.yaml"]
     depends_on:
       basyx_configuration:
@@ -66,7 +65,6 @@ services:
         condition: service_healthy
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasrepository/integration_tests/it_config.json
+++ b/internal/aasrepository/integration_tests/it_config.json
@@ -2,78 +2,78 @@
 	{
 		"context": "001.1 - GET /health",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/health",
+		"endpoint": "{{BASYX_IT_API_URL}}/health",
 		"shouldMatch": "expected/expectedHealthEndpoint.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "002.1 - GET /description",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/description",
+		"endpoint": "{{BASYX_IT_API_URL}}/description",
 		"shouldMatch": "expected/expectedDescriptionEndpoint.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "003.1 - GET /shells - collection",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"expectedStatus": 200
 	},
 	{
 		"context": "003.2 - PUT /shells - method not allowed",
 		"method": "PUT",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"expectedStatus": 405
 	},
 	{
 		"context": "003.3 - DELETE /shells - method not allowed",
 		"method": "DELETE",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"expectedStatus": 405
 	},
 	{
 		"context": "003.4 - POST /shells - malformed payload",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/invalid/malformedJson.txt",
 		"expectedStatus": 400
 	},
 	{
 		"context": "003.5 - GET /shells/ - route not found",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/",
 		"expectedStatus": 404
 	},
 	{
 		"context": "003.6 - PUT /shells/ - route not found",
 		"method": "PUT",
-		"endpoint": "http://127.0.0.1:6004/shells/",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/",
 		"expectedStatus": 404
 	},
 	{
 		"context": "003.7 - DELETE /shells/ - route not found",
 		"method": "DELETE",
-		"endpoint": "http://127.0.0.1:6004/shells/",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/",
 		"expectedStatus": 404
 	},
 	{
 		"context": "003.8 - POST /shells/ - route not found",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells/",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/",
 		"data": "bodies/invalid/malformedJson.txt",
 		"expectedStatus": 404
 	},
 	{
 		"context": "004.1 - GET /shells - empty",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"shouldMatch": "expected/expectedEmpty.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.1a - POST /shells - create AAS with globalAssetId only",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellAssetIdsGlobalOnly.json",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellAssetIdsGlobalOnly.json",
 		"expectedStatus": 201
@@ -81,14 +81,14 @@
 	{
 		"context": "004.1b - GET /shells/{aasIdentifier} - globalAssetId only",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2Fzc2V0aWRzX2dsb2JhbF9vbmx5",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2Fzc2V0aWRzX2dsb2JhbF9vbmx5",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellAssetIdsGlobalOnly.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.1c - POST /shells - create AAS with globalAssetId and two specificAssetIds",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellAssetIdsMixedExternalSubjectId.json",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellAssetIdsMixedExternalSubjectId.json",
 		"expectedStatus": 201
@@ -96,21 +96,21 @@
 	{
 		"context": "004.1d - GET /shells/{aasIdentifier} - mixed specificAssetIds with and without externalSubjectId",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2Fzc2V0aWRzX21peGVkX3NwZWNpZmlj",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2Fzc2V0aWRzX21peGVkX3NwZWNpZmlj",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellAssetIdsMixedExternalSubjectId.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.1d.1 - GET /shells - filter by specificAssetId value",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells?assetIds=eyJuYW1lIjoic3BlY2lmaWMtd2l0aG91dC1leHRlcm5hbC1zdWJqZWN0IiwidmFsdWUiOiJ2YWx1ZS13aXRob3V0LWV4dGVybmFsLXN1YmplY3QifQ",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells?assetIds=eyJuYW1lIjoic3BlY2lmaWMtd2l0aG91dC1leHRlcm5hbC1zdWJqZWN0IiwidmFsdWUiOiJ2YWx1ZS13aXRob3V0LWV4dGVybmFsLXN1YmplY3QifQ",
 		"shouldMatch": "expected/expectedAssetAdministrationShellFilterSpecificAssetIds.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.1e - POST /shells - create AAS with specificAssetId with semanticId",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithSemanticId.json",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithSemanticId.json",
 		"expectedStatus": 201
@@ -118,14 +118,14 @@
 	{
 		"context": "004.1f - GET /shells/{aasIdentifier} - specificAssetId with semanticId",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL3dpdGhTZW1hbnRpY0lk",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL3dpdGhTZW1hbnRpY0lk",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithSemanticId.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.1g - POST /shells - create AAS with specificAssetId with supplementalSemanticIds",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithSupplementalSemanticIds.json",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithSupplementalSemanticIds.json",
 		"expectedStatus": 201
@@ -133,14 +133,14 @@
 	{
 		"context": "004.1h - GET /shells/{aasIdentifier} - specificAssetId with supplementalSemanticIds",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL3dpdGhTdXBwbGVtZW50YWxTZW1hbnRpY0lkcw",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL3dpdGhTdXBwbGVtZW50YWxTZW1hbnRpY0lkcw",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithSupplementalSemanticIds.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.1i - POST /shells - create AAS with specificAssetId without semanticId and without externalSubjectId",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithoutExternalSubjectId.json",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithoutExternalSubjectId.json",
 		"expectedStatus": 201
@@ -148,14 +148,14 @@
 	{
 		"context": "004.1j - GET /shells/{aasIdentifier} - specificAssetId without semanticId and without externalSubjectId",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzMwMzlfMjM3N180MTIzXzgxMTU",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzMwMzlfMjM3N180MTIzXzgxMTU",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithoutExternalSubjectId.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.1k - POST /shells - create AAS with specificAssetId without semanticId and with externalSubjectId",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithoutSemanticIdWithExternalSubjectId.json",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithoutSemanticIdWithExternalSubjectId.json",
 		"expectedStatus": 201
@@ -163,14 +163,14 @@
 	{
 		"context": "004.1l - GET /shells/{aasIdentifier} - specificAssetId without semanticId and with externalSubjectId",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL25vU2VtYW50aWNJZFdpdGhFeHRlcm5hbFN1YmplY3Q",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL25vU2VtYW50aWNJZFdpdGhFeHRlcm5hbFN1YmplY3Q",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellSpecificAssetIdWithoutSemanticIdWithExternalSubjectId.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.1m - GET /shells - no error for all assetIds scenarios",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"expectedStatus": 200
 	},
 	{
@@ -180,10 +180,10 @@
 	{
 		"context": "004.2 - POST /shells - create AAS for filter test",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellFilter1.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjE"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjE"
 		},
 		"shouldMatch": "bodies/post/postAssetAdministrationShellFilter1.json",
 		"expectedStatus": 201
@@ -191,10 +191,10 @@
 	{
 		"context": "004.3 - POST /shells - create AAS for filter test",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellFilter2.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjI"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjI"
 		},
 		"shouldMatch": "bodies/post/postAssetAdministrationShellFilter2.json",
 		"expectedStatus": 201
@@ -202,10 +202,10 @@
 	{
 		"context": "004.4 - POST /shells - create AAS for filter test",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellFilter3.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjM"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjM"
 		},
 		"shouldMatch": "bodies/post/postAssetAdministrationShellFilter3.json",
 		"expectedStatus": 201
@@ -213,10 +213,10 @@
 	{
 		"context": "004.5 - POST /shells - create AAS for filter test",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellFilter4.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjQ"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjQ"
 		},
 		"shouldMatch": "bodies/post/postAssetAdministrationShellFilter4.json",
 		"expectedStatus": 201
@@ -224,42 +224,42 @@
 	{
 		"context": "004.6 - GET /shells - filter by assetIds",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells?assetIds=eyJuYW1lIjoiZ2xvYmFsQXNzZXRJZCIsInZhbHVlIjoiYXNzZXRJZFZhbHVlWCJ9",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells?assetIds=eyJuYW1lIjoiZ2xvYmFsQXNzZXRJZCIsInZhbHVlIjoiYXNzZXRJZFZhbHVlWCJ9",
 		"shouldMatch": "expected/expectedAssetAdministrationShellFilterAssetIds.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.7 - GET /shells - filter by idShort",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells?idShort=aasTestB",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells?idShort=aasTestB",
 		"shouldMatch": "expected/expectedAssetAdministrationShellFilterIdShort.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.8 - GET /shells - filter by limit",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells?limit=3",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells?limit=3",
 		"shouldMatch": "expected/expectedAssetAdministrationShellFilterLimit.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.9 - GET /shells - filter by cursor",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells?cursor=aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjQ",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells?cursor=aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2ZpbHRlcjQ",
 		"shouldMatch": "expected/expectedAssetAdministrationShellFilterCursor.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.9.1 - GET /shells - nonexistent cursor",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells?cursor=aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2RvZXMtbm90LWV4aXN0",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells?cursor=aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2RvZXMtbm90LWV4aXN0",
 		"shouldMatch": "expected/expectedEmpty.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.10 - GET /shells - filter by cursor",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells?assetIds=eyJuYW1lIjoiZ2xvYmFsQXNzZXRJZCIsInZhbHVlIjoiYXNzZXRJZFZhbHVlWCJ9&idShort=aasTestC",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells?assetIds=eyJuYW1lIjoiZ2xvYmFsQXNzZXRJZCIsInZhbHVlIjoiYXNzZXRJZFZhbHVlWCJ9&idShort=aasTestC",
 		"shouldMatch": "expected/expectedAssetAdministrationShellFilterAssetIdsAndIdShort.json",
 		"expectedStatus": 200
 	},
@@ -270,10 +270,10 @@
 	{
 		"context": "004.10.1 - POST /shells - create AAS for query fragment filter",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellMinimal.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk"
 		},
 		"shouldMatch": "bodies/post/postAssetAdministrationShellMinimal.json",
 		"expectedStatus": 201
@@ -281,7 +281,7 @@
 	{
 		"context": "004.10.2 - POST /query/shells - false submodels fragment keeps AAS",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/query/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/query/shells",
 		"data": "bodies/query/queryAASSubmodelsFragmentFalse.json",
 		"shouldMatch": "expected/expectedQueryShellsSubmodelsFragmentFalse.json",
 		"expectedStatus": 200
@@ -293,10 +293,10 @@
 	{
 		"context": "004.11 - POST /shells - create AAS",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellComplex.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI"
 		},
 		"shouldMatch": "bodies/post/postAssetAdministrationShellComplex.json",
 		"expectedStatus": 201
@@ -304,10 +304,10 @@
 	{
 		"context": "004.12 - POST /shells - create AAS",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellMinimal.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk"
 		},
 		"shouldMatch": "bodies/post/postAssetAdministrationShellMinimal.json",
 		"expectedStatus": 201
@@ -315,86 +315,86 @@
 	{
 		"context": "004.13 - GET /shells",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"shouldMatch": "expected/expectedGetAllAssetAdministrationShells.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "004.14 - POST /shells - conflict (malformed payload)",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/invalid/malformedJson.txt",
 		"expectedStatus": 400
 	},
 	{
 		"context": "004.15 - POST /shells - conflict (duplicate)",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells",
 		"data": "bodies/post/postAssetAdministrationShellComplex.json",
 		"expectedStatus": 409
 	},
 	{
 		"context": "005.1 - GET /shells/$reference",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/$reference",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/$reference",
 		"shouldMatch": "expected/expectedGetAllAssetAdministrationShellsReference.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "005.2 - GET /shells/$reference - filter by idShort",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/$reference?idShort=testAAS2",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/$reference?idShort=testAAS2",
 		"shouldMatch": "expected/expectedAssetAdministrationShellReferencesFilterIdShort.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "005.3 - GET /shells/$reference - filter by limit",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/$reference?limit=1",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/$reference?limit=1",
 		"shouldMatch": "expected/expectedAssetAdministrationShellReferencesFilterLimit.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "005.4 - GET /shells/$reference - filter by cursor",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/$reference?cursor=aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/$reference?cursor=aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk",
 		"shouldMatch": "expected/expectedAssetAdministrationShellReferencesFilterCursor.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "005.4.1 - GET /shells/$reference - nonexistent cursor",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/$reference?cursor=aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2RvZXMtbm90LWV4aXN0",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/$reference?cursor=aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2RvZXMtbm90LWV4aXN0",
 		"shouldMatch": "expected/expectedEmpty.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "006.1 - GET /shells/{aasIdentifier}",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI",
 		"shouldMatch": "bodies/post/postAssetAdministrationShellComplex.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "006.2 - GET /shells/{aasIdentifier} - conflict (not found)",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo",
 		"expectedStatus": 404
 	},
 	{
 		"context": "006.3 - PUT /shells/{aasIdentifier} - update existing AAS",
 		"method": "PUT",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk",
 		"data": "bodies/put/putAssetAdministrationShellUpdated.json",
 		"expectedStatus": 204
 	},
 	{
 		"context": "006.4 - PUT /shells/{aasIdentifier} - create new AAS",
 		"method": "PUT",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzAwMDBfMTExMV8wMDAwXzExMTE",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzAwMDBfMTExMV8wMDAwXzExMTE",
 		"data": "bodies/put/putAssetAdministrationShellCreated.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzAwMDBfMTExMV8wMDAwXzExMTE"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzAwMDBfMTExMV8wMDAwXzExMTE"
 		},
 		"shouldMatch": "bodies/put/putAssetAdministrationShellCreated.json",
 		"expectedStatus": 201
@@ -402,143 +402,143 @@
 	{
 		"context": "006.5 - DELETE /shells/{aasIdentifier}",
 		"method": "DELETE",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk",
 		"expectedStatus": 204
 	},
 	{
 		"context": "006.6 - DELETE /shells/{aasIdentifier} - conflict (not found)",
 		"method": "DELETE",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDk",
 		"expectedStatus": 404
 	},
 	{
 		"context": "007.1 - GET /shells/{aasIdentifier}/$reference",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/$reference",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/$reference",
 		"shouldMatch": "expected/expectedAssetAdministrationShellReference.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "007.2 - GET /shells/{aasIdentifier}/$reference - conflict (not found)",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo/$reference",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo/$reference",
 		"expectedStatus": 404
 	},
 	{
 		"context": "008.1 - GET /shells/{aasIdentifier}/asset-information",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/asset-information",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/asset-information",
 		"shouldMatch": "expected/expectedAssetAdministrationShellAssetInformation.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "008.2 - GET /shells/{aasIdentifier}/asset-information - conflict (not found)",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo/asset-information",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo/asset-information",
 		"expectedStatus": 404
 	},
 	{
 		"context": "008.3 - PUT /shells/{aasIdentifier}/asset-information",
 		"method": "PUT",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/asset-information",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/asset-information",
 		"data": "bodies/put/putAssetInformationUpdated.json",
 		"expectedStatus": 204
 	},
 	{
 		"context": "008.4 - PUT /shells/{aasIdentifier}/asset-information - conflict (not found)",
 		"method": "PUT",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo/asset-information",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo/asset-information",
 		"data": "bodies/put/putAssetInformationUpdated.json",
 		"expectedStatus": 404
 	},
 	{
 		"context": "008.5 - PUT /shells/{aasIdentifier}/asset-information - conflict (malformed)",
 		"method": "PUT",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/asset-information",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/asset-information",
 		"data": "bodies/invalid/malformedJson.txt",
 		"expectedStatus": 400
 	},
 	{
 		"context": "009.1 - GET /shells/{aasIdentifier}/submodel-refs",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
 		"shouldMatch": "expected/expectedAssetAdministrationShellSubmodelReferences.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "009.2 - GET /shells/{aasIdentifier}/submodel-refs - conflict (not found)",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo/submodel-refs",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzJfbm90X2V4aXN0ZW50DQo/submodel-refs",
 		"expectedStatus": 404
 	},
 	{
 		"context": "009.3 - POST /shells/{aasIdentifier}/submodel-refs - create Submodel reference",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
 		"data": "bodies/post/postSubmodelReferenceMinimal.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs"
 		},
 		"expectedStatus": 201
 	},
 	{
 		"context": "009.4 - POST /shells/{aasIdentifier}/submodel-refs - create Submodel reference for filter test",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
 		"data": "bodies/post/postSubmodelReferenceMinimal2.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs"
 		},
 		"expectedStatus": 201
 	},
 	{
 		"context": "009.5 - POST /shells/{aasIdentifier}/submodel-refs - create Submodel reference for filter test",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
 		"data": "bodies/post/postSubmodelReferenceMinimal3.json",
 		"expectedResponseHeaders": {
-			"Location": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs"
+			"Location": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs"
 		},
 		"expectedStatus": 201
 	},
 	{
 		"context": "009.6 - GET /shells/{aasIdentifier}/submodel-refs - filter by limit",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs?limit=2",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs?limit=2",
 		"shouldMatch": "expected/expectedAssetAdministrationShellSubmodelReferencesFilterLimit.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "009.7 - GET /shells/{aasIdentifier}/submodel-refs - filter by cursor",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs?cursor=NQ",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs?cursor=NQ",
 		"shouldMatch": "expected/expectedAssetAdministrationShellSubmodelReferencesFilterCursor.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "009.7.1 - GET /shells/{aasIdentifier}/submodel-refs - nonexistent cursor",
 		"method": "GET",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs?cursor=OTk5OTk",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs?cursor=OTk5OTk",
 		"shouldMatch": "expected/expectedEmpty.json",
 		"expectedStatus": 200
 	},
 	{
 		"context": "009.8 - POST /shells/{aasIdentifier}/submodel-refs - conflict (malformed)",
 		"method": "POST",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs",
 		"data": "bodies/invalid/malformedJson.txt",
 		"expectedStatus": 400
 	},
 	{
 		"context": "010.1 - DELETE /shells/{aasIdentifier}/submodel-refs/{submodelIdentifier}",
 		"method": "DELETE",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvc20vNDAzMV8zMTIwXzMwNjJfMDI1NQ",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvc20vNDAzMV8zMTIwXzMwNjJfMDI1NQ",
 		"expectedStatus": 204
 	},
 	{
 		"context": "010.2 - DELETE /shells/{aasIdentifier}/submodel-refs/{submodelIdentifier} - conflict (not found)",
 		"method": "DELETE",
-		"endpoint": "http://127.0.0.1:6004/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDlfbm9uX2V4aXN0ZW50",
+		"endpoint": "{{BASYX_IT_API_URL}}/shells/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzM0OTRfMjEyMF8zMDYyXzY1MzI/submodel-refs/aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzLzczMDFfMzE1MF85NDQyXzc4NDlfbm9uX2V4aXN0ZW50",
 		"expectedStatus": 404
 	}
 ]

--- a/internal/aasrepository/security_tests/aasrepository_security_integration_test.go
+++ b/internal/aasrepository/security_tests/aasrepository_security_integration_test.go
@@ -39,11 +39,16 @@ import (
 
 const actionAssertRecentChangeIDs = "ASSERT_RECENT_CHANGE_IDS"
 
+var (
+	securityBaseURL          = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+	securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+)
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -95,10 +100,25 @@ func extractRecentChangeIDs(t *testing.T, responseBody string) []string {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("aasrepository-security", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     "docker_compose/docker_compose.yml",
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
 		PreDownBeforeUp: true,
-		HealthURL:       "http://localhost:6004/health",
+		HealthURL:       securityBaseURL + "/health",
 		HealthTimeout:   180 * time.Second,
-	}))
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/aasrepository/security_tests/docker_compose/docker_compose.yml
+++ b/internal/aasrepository/security_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db:
     image: postgres:18
-    container_name: aasrepo_security_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-repository-security:
-    container_name: aas-repository-security
     build:
       context: ../../../..
       dockerfile: ./cmd/aasrepositoryservice/Dockerfile
@@ -36,28 +34,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: aasrepo_security_keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -69,13 +66,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ../../../aasregistry/security_tests/docker_compose/keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: aasrepo_security_keycloak_healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -87,7 +83,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/aasrepository/security_tests/it_config.json
+++ b/internal/aasrepository/security_tests/it_config.json
@@ -3,14 +3,14 @@
     "context": "Anonymous list denied",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "expectedStatus": 403
   },
   {
     "context": "POST viewer-visible aas - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "data": "bodies/post/viewerAllowed.json",
     "expectedStatus": 201
   },
@@ -18,7 +18,7 @@
     "context": "POST viewer-visible-by-key aas - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "data": "bodies/post/viewerViaKey.json",
     "expectedStatus": 201
   },
@@ -26,7 +26,7 @@
     "context": "POST viewer-hidden aas - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "data": "bodies/post/viewerHidden.json",
     "expectedStatus": 201
   },
@@ -34,7 +34,7 @@
     "context": "POST /query/shells - anonymous denied",
     "token": null,
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shells",
     "data": "bodies/query/queryViewerVisible.json",
     "expectedStatus": 403
   },
@@ -42,7 +42,7 @@
     "context": "POST /query/shells - admin query hidden asset type",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shells",
     "data": "bodies/query/queryAssetTypeHidden.json",
     "shouldMatch": "expected/expectedQueryShellsHiddenAdmin.json",
     "expectedStatus": 200
@@ -51,7 +51,7 @@
     "context": "POST /query/shells - admin filter fragment hidden asset type",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shells",
     "data": "bodies/query/queryFilterAssetTypeHidden.json",
     "shouldMatch": "expected/expectedQueryShellsAssetTypeFragmentHiddenAdmin.json",
     "expectedStatus": 200
@@ -60,7 +60,7 @@
     "context": "POST /query/shells - viewer query narrowed by ABAC",
     "token": { "user": "usera", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shells",
     "data": "bodies/query/queryAssetTypeHidden.json",
     "shouldMatch": "expected/expectedQueryShellsHiddenViewer.json",
     "expectedStatus": 200
@@ -69,7 +69,7 @@
     "context": "POST /query/shells - editor reduced to specific IDENTIFIABLE object",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shells",
     "data": "bodies/query/queryViewerVisible.json",
     "shouldMatch": "expected/expectedShellsReducedEditorSpecificIdentifiable.json",
     "expectedStatus": 200
@@ -78,7 +78,7 @@
     "context": "POST /query/shells - empty query rejected",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shells",
     "data": "bodies/query/queryEmpty.json",
     "expectedStatus": 400
   },
@@ -86,7 +86,7 @@
     "context": "POST /query/shells - malformed query rejected",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/shells",
     "data": "bodies/query/queryMalformed.json",
     "expectedStatus": 400
   },
@@ -94,7 +94,7 @@
     "context": "GET /shells - admin full access",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "shouldMatch": "expected/expectedShellsFullAdmin.json",
     "expectedStatus": 200
   },
@@ -102,14 +102,14 @@
     "context": "GET /shells/ - admin not found",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/",
     "expectedStatus": 404
   },
   {
     "context": "GET /shells - editor reduced to specific IDENTIFIABLE object",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "shouldMatch": "expected/expectedShellsReducedEditorSpecificIdentifiable.json",
     "expectedStatus": 200
   },
@@ -117,7 +117,7 @@
     "context": "GET /shells/$reference - admin full access",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/$reference",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/$reference",
     "shouldMatch": "expected/expectedShellRefsFullAdmin.json",
     "expectedStatus": 200
   },
@@ -125,14 +125,14 @@
     "context": "GET /shells/$reference/ - admin not found",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/$reference/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/$reference/",
     "expectedStatus": 404
   },
   {
     "context": "GET /shells/$reference - editor reduced to specific IDENTIFIABLE object",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/$reference",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/$reference",
     "shouldMatch": "expected/expectedShellRefsReducedEditorSpecificIdentifiable.json",
     "expectedStatus": 200
   },
@@ -141,7 +141,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/$recent-changes?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/$recent-changes?limit=20",
     "shouldMatch": "expected/expectedRecentChangesViewerIDs.json",
     "expectedStatus": 200
   },
@@ -149,7 +149,7 @@
     "context": "GET /shells/$recent-changes/ - viewer not found",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/$recent-changes/?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/$recent-changes/?limit=20",
     "expectedStatus": 404
   },
   {
@@ -157,7 +157,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/$recent-changes?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/$recent-changes?limit=20",
     "shouldMatch": "expected/expectedRecentChangesEditorSpecificIdentifiableIDs.json",
     "expectedStatus": 200
   },
@@ -165,35 +165,35 @@
     "context": "GET viewer-visible aas - viewer",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjphbGxvd2Vk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjphbGxvd2Vk",
     "expectedStatus": 200
   },
   {
     "context": "GET viewer-visible aas trailing slash - viewer not found",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjphbGxvd2Vk/",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjphbGxvd2Vk/",
     "expectedStatus": 404
   },
   {
     "context": "GET viewer-by-key aas - viewer",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjprZXk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjprZXk",
     "expectedStatus": 200
   },
   {
     "context": "GET viewer-hidden aas - viewer receives hidden 404",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjpoaWRkZW4",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjpoaWRkZW4",
     "expectedStatus": 404
   },
   {
     "context": "GET viewer-hidden aas - admin full access",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjpoaWRkZW4",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjpoaWRkZW4",
     "shouldMatch": "bodies/post/viewerHidden.json",
     "expectedStatus": 200
   },
@@ -201,7 +201,7 @@
     "context": "GET viewer-visible aas - editor allowed by specific IDENTIFIABLE object",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjphbGxvd2Vk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjphbGxvd2Vk",
     "shouldMatch": "bodies/post/viewerAllowed.json",
     "expectedStatus": 200
   },
@@ -209,14 +209,14 @@
     "context": "GET viewer-by-key aas - editor denied outside specific IDENTIFIABLE object",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjprZXk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjprZXk",
     "expectedStatus": 403
   },
   {
     "context": "POST editor-allowed aas - editor",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "data": "bodies/post/editorAllowed.json",
     "expectedStatus": 201
   },
@@ -224,7 +224,7 @@
     "context": "POST editor-denied aas - editor",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "data": "bodies/post/editorDeniedPost.json",
     "expectedStatus": 403
   },
@@ -232,7 +232,7 @@
     "context": "POST hidden-existing aas for old-state checks - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells",
     "data": "bodies/post/editorHiddenExisting.json",
     "expectedStatus": 201
   },
@@ -240,7 +240,7 @@
     "context": "PUT invisible existing aas - editor denied by old-state check",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjpoaWRkZW4tZXhpc3Rpbmc",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjpoaWRkZW4tZXhpc3Rpbmc",
     "data": "bodies/put/editorHiddenExistingUpdatedAllowed.json",
     "expectedStatus": 403
   },
@@ -248,7 +248,7 @@
     "context": "PUT visible aas to disallowed state - editor denied by new-state check",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjphbGxvd2Vk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjphbGxvd2Vk",
     "data": "bodies/put/editorAllowedUpdatedDenied.json",
     "expectedStatus": 403
   },
@@ -256,42 +256,42 @@
     "context": "DELETE invisible existing aas - editor denied",
     "token": { "user": "userx", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjpoaWRkZW4tZXhpc3Rpbmc",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjpoaWRkZW4tZXhpc3Rpbmc",
     "expectedStatus": 403
   },
   {
     "context": "DELETE viewer-visible aas - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjphbGxvd2Vk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjphbGxvd2Vk",
     "expectedStatus": 204
   },
   {
     "context": "DELETE viewer-by-key aas - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjprZXk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjprZXk",
     "expectedStatus": 204
   },
   {
     "context": "DELETE viewer-hidden aas - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjpoaWRkZW4",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnZpZXdlcjpoaWRkZW4",
     "expectedStatus": 204
   },
   {
     "context": "DELETE editor-allowed aas - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjphbGxvd2Vk",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjphbGxvd2Vk",
     "expectedStatus": 204
   },
   {
     "context": "DELETE hidden-existing aas - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjpoaWRkZW4tZXhpc3Rpbmc",
+    "endpoint": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOmVkaXRvcjpoaWRkZW4tZXhpc3Rpbmc",
     "expectedStatus": 204
   }
 ]

--- a/internal/aasxfileserver/integration_tests/aasxfileserver_integration_test.go
+++ b/internal/aasxfileserver/integration_tests/aasxfileserver_integration_test.go
@@ -42,15 +42,24 @@ import (
 )
 
 const composeFilePath = "./docker_compose/docker_compose.yml"
-const baseURL = "http://127.0.0.1:6004"
+
+var baseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
 
 func TestMain(m *testing.M) {
 	if os.Getenv("BASYX_EXTERNAL_COMPOSE") == "1" {
 		os.Exit(m.Run())
 	}
 
+	runtime := testenv.NewComposeRuntimeOrExit("aasxfileserver-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+	})
+	baseURL = runtime.LocalURL("api")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     composeFilePath,
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.Env(),
 		PreDownBeforeUp: true,
 		HealthURL:       baseURL + "/health",
 		HealthTimeout:   2 * time.Minute,

--- a/internal/aasxfileserver/integration_tests/docker_compose/docker_compose.yml
+++ b/internal/aasxfileserver/integration_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db_it:
     image: postgres:18
-    container_name: postgres_db_it_aasx
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -30,7 +29,7 @@ services:
       - POSTGRES_MAXIDLECONNECTIONS=500
       - POSTGRES_CONNMAXLIFETIMEMINUTES=5
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
@@ -38,7 +37,6 @@ services:
         condition: service_healthy
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/common/testenv/compose_runtime.go
+++ b/internal/common/testenv/compose_runtime.go
@@ -1,0 +1,329 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+//nolint:revive
+package testenv
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+type PortBinding struct {
+	Name   string
+	EnvVar string
+}
+
+type ComposeRuntime struct {
+	ProjectName string
+	ports       map[string]int
+	env         []string
+}
+
+func NewComposeRuntime(prefix string, ports []PortBinding) (*ComposeRuntime, error) {
+	projectName, err := NewComposeProjectName(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	runtime := &ComposeRuntime{
+		ProjectName: projectName,
+		ports:       make(map[string]int, len(ports)),
+		env:         make([]string, 0, len(ports)),
+	}
+
+	for _, port := range ports {
+		name := strings.TrimSpace(port.Name)
+		envVar := strings.TrimSpace(port.EnvVar)
+		if name == "" || envVar == "" {
+			return nil, fmt.Errorf("TESTENV-COMPOSERT-BADPORT binding name and env var must not be empty")
+		}
+		reservedPort, reserveErr := ReserveLocalPort()
+		if reserveErr != nil {
+			return nil, reserveErr
+		}
+		runtime.ports[name] = reservedPort
+		runtime.env = append(runtime.env, envVar+"="+strconv.Itoa(reservedPort))
+		runtime.env = append(runtime.env, composeURLVars(envVar, reservedPort)...)
+	}
+
+	return runtime, nil
+}
+
+func NewComposeRuntimeOrExit(prefix string, ports []PortBinding) *ComposeRuntime {
+	runtime, err := NewComposeRuntime(prefix, ports)
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := runtime.ApplyToProcess(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	return runtime
+}
+
+func NewComposeProjectName(prefix string) (string, error) {
+	sanitized := sanitizeComposeProjectName(prefix)
+	if sanitized == "" {
+		sanitized = "basyx"
+	}
+
+	random := make([]byte, 4)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("TESTENV-COMPOSERT-RANDOM: %w", err)
+	}
+
+	return fmt.Sprintf("%s-%d-%d-%s", sanitized, os.Getpid(), time.Now().UnixNano(), hex.EncodeToString(random)), nil
+}
+
+func sanitizeComposeProjectName(prefix string) string {
+	var builder strings.Builder
+	lastSeparator := false
+	for _, char := range strings.ToLower(strings.TrimSpace(prefix)) {
+		switch {
+		case char >= 'a' && char <= 'z':
+			builder.WriteRune(char)
+			lastSeparator = false
+		case char >= '0' && char <= '9':
+			builder.WriteRune(char)
+			lastSeparator = false
+		case char == '-' || char == '_' || unicode.IsSpace(char) || char == '/' || char == '.':
+			if builder.Len() > 0 && !lastSeparator {
+				builder.WriteByte('-')
+				lastSeparator = true
+			}
+		}
+	}
+
+	result := strings.Trim(builder.String(), "-_")
+	if result == "" {
+		return ""
+	}
+	if result[0] < 'a' || result[0] > 'z' {
+		result = "basyx-" + result
+	}
+	if len(result) > 40 {
+		result = strings.Trim(result[:40], "-_")
+	}
+	return result
+}
+
+func ReserveLocalPort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("TESTENV-COMPOSERT-RESERVEPORT: %w", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("TESTENV-COMPOSERT-PORTADDR unexpected listener address %T", listener.Addr())
+	}
+	return addr.Port, nil
+}
+
+func (r *ComposeRuntime) Env() []string {
+	if r == nil {
+		return nil
+	}
+	return append([]string{}, r.env...)
+}
+
+func (r *ComposeRuntime) EnvWith(extra ...string) []string {
+	env := r.Env()
+	return append(env, extra...)
+}
+
+func (r *ComposeRuntime) ApplyToProcess() error {
+	if r == nil {
+		return nil
+	}
+	for _, entry := range r.env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if err := os.Setenv(key, value); err != nil {
+			return fmt.Errorf("TESTENV-COMPOSERT-SETENV: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *ComposeRuntime) Port(name string) int {
+	if r == nil {
+		return 0
+	}
+	return r.ports[name]
+}
+
+func (r *ComposeRuntime) LocalURL(name string) string {
+	return fmt.Sprintf("http://127.0.0.1:%d", r.Port(name))
+}
+
+func (r *ComposeRuntime) LocalhostURL(name string) string {
+	return fmt.Sprintf("http://localhost:%d", r.Port(name))
+}
+
+func (r *ComposeRuntime) PostgresURL(name string, dbName string) string {
+	return fmt.Sprintf("postgres://admin:admin123@127.0.0.1:%d/%s?sslmode=disable", r.Port(name), dbName)
+}
+
+func (r *ComposeRuntime) PostgresKeywordDSN(name string, dbName string) string {
+	return fmt.Sprintf("host=127.0.0.1 port=%d user=admin password=admin123 dbname=%s sslmode=disable", r.Port(name), dbName)
+}
+
+func LocalURLFromEnv(envVar string, defaultPort int) string {
+	return fmt.Sprintf("http://127.0.0.1:%d", PortFromEnv(envVar, defaultPort))
+}
+
+func LocalhostURLFromEnv(envVar string, defaultPort int) string {
+	return fmt.Sprintf("http://localhost:%d", PortFromEnv(envVar, defaultPort))
+}
+
+func PostgresURLFromEnv(envVar string, defaultPort int, dbName string) string {
+	return fmt.Sprintf("postgres://admin:admin123@127.0.0.1:%d/%s?sslmode=disable", PortFromEnv(envVar, defaultPort), dbName)
+}
+
+func PostgresKeywordDSNFromEnv(envVar string, defaultPort int, dbName string) string {
+	return fmt.Sprintf("host=127.0.0.1 port=%d user=admin password=admin123 dbname=%s sslmode=disable", PortFromEnv(envVar, defaultPort), dbName)
+}
+
+func PortFromEnv(envVar string, defaultPort int) int {
+	value := strings.TrimSpace(os.Getenv(envVar))
+	if value == "" {
+		return defaultPort
+	}
+	port, err := strconv.Atoi(value)
+	if err != nil || port <= 0 {
+		return defaultPort
+	}
+	return port
+}
+
+func composeURLVars(envVar string, port int) []string {
+	portSuffix := "_PORT"
+	if !strings.HasSuffix(envVar, portSuffix) {
+		return nil
+	}
+	prefix := strings.TrimSuffix(envVar, portSuffix)
+	return []string{
+		prefix + "_URL=http://127.0.0.1:" + strconv.Itoa(port),
+		prefix + "_LOCALHOST_URL=http://localhost:" + strconv.Itoa(port),
+	}
+}
+
+func PrepareSecurityEnv(srcDir string, replacements map[string]string) (string, error) {
+	sourceInfo, err := os.Stat(srcDir)
+	if err != nil {
+		return "", fmt.Errorf("TESTENV-SECURITYENV-STAT: %w", err)
+	}
+	if !sourceInfo.IsDir() {
+		return "", fmt.Errorf("TESTENV-SECURITYENV-NOTDIR %s is not a directory", srcDir)
+	}
+
+	targetDir, err := os.MkdirTemp(".", ".basyx-security-env-*")
+	if err != nil {
+		return "", fmt.Errorf("TESTENV-SECURITYENV-MKDIR: %w", err)
+	}
+	absoluteTargetDir, err := filepath.Abs(targetDir)
+	if err != nil {
+		_ = os.RemoveAll(targetDir)
+		return "", fmt.Errorf("TESTENV-SECURITYENV-ABS: %w", err)
+	}
+	//nolint:gosec // Docker containers run as non-root users and need to read mounted fixture directories.
+	if err := os.Chmod(absoluteTargetDir, 0o755); err != nil {
+		_ = os.RemoveAll(absoluteTargetDir)
+		return "", fmt.Errorf("TESTENV-SECURITYENV-CHMOD: %w", err)
+	}
+
+	if err := copySecurityEnv(srcDir, absoluteTargetDir, replacements); err != nil {
+		_ = os.RemoveAll(absoluteTargetDir)
+		return "", err
+	}
+	return absoluteTargetDir, nil
+}
+
+func PrepareSecurityEnvOrExit(srcDir string, replacements map[string]string) string {
+	targetDir, err := PrepareSecurityEnv(srcDir, replacements)
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	return targetDir
+}
+
+func copySecurityEnv(srcDir string, targetDir string, replacements map[string]string) error {
+	return filepath.WalkDir(srcDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("TESTENV-SECURITYENV-WALK: %w", walkErr)
+		}
+
+		relativePath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return fmt.Errorf("TESTENV-SECURITYENV-REL: %w", err)
+		}
+		if relativePath == "." {
+			return nil
+		}
+
+		targetPath := filepath.Join(targetDir, relativePath)
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("TESTENV-SECURITYENV-INFO: %w", err)
+		}
+
+		if entry.IsDir() {
+			return os.MkdirAll(targetPath, info.Mode().Perm())
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		//nolint:gosec // The caller supplies a test fixture directory; WalkDir bounds reads to that tree.
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("TESTENV-SECURITYENV-READ: %w", err)
+		}
+		content := string(data)
+		for oldValue, newValue := range replacements {
+			content = strings.ReplaceAll(content, oldValue, newValue)
+		}
+		if err := os.WriteFile(targetPath, []byte(content), info.Mode().Perm()); err != nil {
+			return fmt.Errorf("TESTENV-SECURITYENV-WRITE: %w", err)
+		}
+		return nil
+	})
+}

--- a/internal/common/testenv/compose_runtime.go
+++ b/internal/common/testenv/compose_runtime.go
@@ -36,21 +36,33 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 )
 
+const composePortLockStaleAfter = 24 * time.Hour
+
+var reservedPortLocks struct {
+	sync.Mutex
+	locks []*portLock
+}
+
+// PortBinding declares one dynamically allocated host port for a compose test.
 type PortBinding struct {
 	Name   string
 	EnvVar string
 }
 
+// ComposeRuntime carries the per-test compose project name, ports, and env values.
 type ComposeRuntime struct {
 	ProjectName string
 	ports       map[string]int
 	env         []string
+	portLocks   []*portLock
 }
 
+// NewComposeRuntime creates a unique compose project name and locked host ports.
 func NewComposeRuntime(prefix string, ports []PortBinding) (*ComposeRuntime, error) {
 	projectName, err := NewComposeProjectName(prefix)
 	if err != nil {
@@ -63,17 +75,23 @@ func NewComposeRuntime(prefix string, ports []PortBinding) (*ComposeRuntime, err
 		env:         make([]string, 0, len(ports)),
 	}
 
+	usedPorts := make(map[int]struct{}, len(ports))
 	for _, port := range ports {
 		name := strings.TrimSpace(port.Name)
 		envVar := strings.TrimSpace(port.EnvVar)
 		if name == "" || envVar == "" {
+			runtime.Release()
 			return nil, fmt.Errorf("TESTENV-COMPOSERT-BADPORT binding name and env var must not be empty")
 		}
-		reservedPort, reserveErr := ReserveLocalPort()
+		reservedPort, lock, reserveErr := reserveLockedLocalPort(usedPorts)
 		if reserveErr != nil {
+			runtime.Release()
 			return nil, reserveErr
 		}
+		usedPorts[reservedPort] = struct{}{}
 		runtime.ports[name] = reservedPort
+		runtime.portLocks = append(runtime.portLocks, lock)
+		trackReservedPortLock(lock)
 		runtime.env = append(runtime.env, envVar+"="+strconv.Itoa(reservedPort))
 		runtime.env = append(runtime.env, composeURLVars(envVar, reservedPort)...)
 	}
@@ -81,6 +99,7 @@ func NewComposeRuntime(prefix string, ports []PortBinding) (*ComposeRuntime, err
 	return runtime, nil
 }
 
+// NewComposeRuntimeOrExit creates a compose runtime and exits the process on failure.
 func NewComposeRuntimeOrExit(prefix string, ports []PortBinding) *ComposeRuntime {
 	runtime, err := NewComposeRuntime(prefix, ports)
 	if err != nil {
@@ -94,6 +113,18 @@ func NewComposeRuntimeOrExit(prefix string, ports []PortBinding) *ComposeRuntime
 	return runtime
 }
 
+// Release frees host-port allocation locks held by this runtime.
+func (r *ComposeRuntime) Release() {
+	if r == nil {
+		return
+	}
+	for _, lock := range r.portLocks {
+		lock.Release()
+	}
+	r.portLocks = nil
+}
+
+// NewComposeProjectName returns a Docker Compose-compatible project name with a unique suffix.
 func NewComposeProjectName(prefix string) (string, error) {
 	sanitized := sanitizeComposeProjectName(prefix)
 	if sanitized == "" {
@@ -140,7 +171,35 @@ func sanitizeComposeProjectName(prefix string) string {
 	return result
 }
 
+// ReserveLocalPort returns a currently available localhost TCP port and locks it for this process.
 func ReserveLocalPort() (int, error) {
+	port, lock, err := reserveLockedLocalPort(nil)
+	if err != nil {
+		return 0, err
+	}
+
+	trackReservedPortLock(lock)
+	return port, nil
+}
+
+func trackReservedPortLock(lock *portLock) {
+	reservedPortLocks.Lock()
+	reservedPortLocks.locks = append(reservedPortLocks.locks, lock)
+	reservedPortLocks.Unlock()
+}
+
+// ReleaseReservedLocalPorts frees locks created for dynamic local port reservations.
+func ReleaseReservedLocalPorts() {
+	reservedPortLocks.Lock()
+	defer reservedPortLocks.Unlock()
+
+	for _, lock := range reservedPortLocks.locks {
+		lock.Release()
+	}
+	reservedPortLocks.locks = nil
+}
+
+func reserveAvailableLocalPort() (int, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, fmt.Errorf("TESTENV-COMPOSERT-RESERVEPORT: %w", err)
@@ -152,6 +211,80 @@ func ReserveLocalPort() (int, error) {
 		return 0, fmt.Errorf("TESTENV-COMPOSERT-PORTADDR unexpected listener address %T", listener.Addr())
 	}
 	return addr.Port, nil
+}
+
+func reserveLockedLocalPort(usedPorts map[int]struct{}) (int, *portLock, error) {
+	var lastErr error
+	for attempt := 0; attempt < 100; attempt++ {
+		port, err := reserveAvailableLocalPort()
+		if err != nil {
+			return 0, nil, err
+		}
+		if _, alreadyUsed := usedPorts[port]; alreadyUsed {
+			continue
+		}
+
+		lock, err := acquirePortLock(port)
+		if err == nil {
+			return port, lock, nil
+		}
+		lastErr = err
+	}
+
+	if lastErr != nil {
+		return 0, nil, fmt.Errorf("TESTENV-COMPOSERT-LOCKPORT: %w", lastErr)
+	}
+	return 0, nil, fmt.Errorf("TESTENV-COMPOSERT-LOCKPORT could not reserve a unique local port")
+}
+
+type portLock struct {
+	path string
+}
+
+func acquirePortLock(port int) (*portLock, error) {
+	lockRoot := filepath.Join(os.TempDir(), "basyx-compose-port-locks")
+	if err := os.MkdirAll(lockRoot, 0o700); err != nil {
+		return nil, fmt.Errorf("TESTENV-COMPOSERT-LOCKROOT: %w", err)
+	}
+
+	lockPath := filepath.Join(lockRoot, strconv.Itoa(port)+".lock")
+	if err := os.Mkdir(lockPath, 0o700); err != nil {
+		if os.IsExist(err) && removeStalePortLock(lockPath) == nil {
+			if retryErr := os.Mkdir(lockPath, 0o700); retryErr == nil {
+				return writePortLockOwner(lockPath)
+			}
+		}
+		return nil, fmt.Errorf("TESTENV-COMPOSERT-LOCKCREATE: %w", err)
+	}
+	return writePortLockOwner(lockPath)
+}
+
+func removeStalePortLock(lockPath string) error {
+	info, err := os.Stat(lockPath)
+	if err != nil {
+		return err
+	}
+	if time.Since(info.ModTime()) < composePortLockStaleAfter {
+		return fmt.Errorf("TESTENV-COMPOSERT-LOCKACTIVE %s", lockPath)
+	}
+	return os.RemoveAll(lockPath)
+}
+
+func writePortLockOwner(lockPath string) (*portLock, error) {
+	owner := fmt.Sprintf("pid=%d\ncreated=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339Nano))
+	if err := os.WriteFile(filepath.Join(lockPath, "owner"), []byte(owner), 0o600); err != nil {
+		_ = os.RemoveAll(lockPath)
+		return nil, fmt.Errorf("TESTENV-COMPOSERT-LOCKOWNER: %w", err)
+	}
+	return &portLock{path: lockPath}, nil
+}
+
+func (l *portLock) Release() {
+	if l == nil || l.path == "" {
+		return
+	}
+	_ = os.RemoveAll(l.path)
+	l.path = ""
 }
 
 func (r *ComposeRuntime) Env() []string {
@@ -170,16 +303,32 @@ func (r *ComposeRuntime) ApplyToProcess() error {
 	if r == nil {
 		return nil
 	}
-	for _, entry := range r.env {
-		key, value, ok := strings.Cut(entry, "=")
-		if !ok {
+	return applyProcessEnv(r.env)
+}
+
+// SetEnvDefaults sets process env vars only when they are not already present.
+func SetEnvDefaults(values map[string]string) error {
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, exists := os.LookupEnv(key); exists {
 			continue
 		}
 		if err := os.Setenv(key, value); err != nil {
-			return fmt.Errorf("TESTENV-COMPOSERT-SETENV: %w", err)
+			return fmt.Errorf("TESTENV-ENVDEFAULTS-SETENV: %w", err)
 		}
 	}
 	return nil
+}
+
+// SetEnvDefaultsOrExit sets default env vars and exits the process on failure.
+func SetEnvDefaultsOrExit(values map[string]string) {
+	if err := SetEnvDefaults(values); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }
 
 func (r *ComposeRuntime) Port(name string) int {
@@ -254,7 +403,7 @@ func PrepareSecurityEnv(srcDir string, replacements map[string]string) (string, 
 		return "", fmt.Errorf("TESTENV-SECURITYENV-NOTDIR %s is not a directory", srcDir)
 	}
 
-	targetDir, err := os.MkdirTemp(".", ".basyx-security-env-*")
+	targetDir, err := os.MkdirTemp("", "basyx-security-env-*")
 	if err != nil {
 		return "", fmt.Errorf("TESTENV-SECURITYENV-MKDIR: %w", err)
 	}

--- a/internal/common/testenv/compose_testmain.go
+++ b/internal/common/testenv/compose_testmain.go
@@ -36,6 +36,8 @@ import (
 
 type ComposeTestMainOptions struct {
 	ComposeFile string
+	ProjectName string
+	Env         []string
 
 	UpArgs   []string
 	DownArgs []string
@@ -61,7 +63,7 @@ func RunComposeTestMain(m *testing.M, options ComposeTestMainOptions) int {
 	}
 
 	runWithLimit := func(timeout time.Duration, args ...string) error {
-		return runWithTimeout(engine, baseArgs, opts.ComposeFile, timeout, args...)
+		return runWithTimeout(engine, baseArgs, opts.ComposeFile, opts.ProjectName, opts.Env, timeout, args...)
 	}
 
 	if opts.PreDownBeforeUp {
@@ -105,7 +107,7 @@ func RunComposeTestMain(m *testing.M, options ComposeTestMainOptions) int {
 	return code
 }
 
-func runWithTimeout(engine string, baseArgs []string, composeFile string, timeout time.Duration, args ...string) error {
+func runWithTimeout(engine string, baseArgs []string, composeFile string, projectName string, env []string, timeout time.Duration, args ...string) error {
 	ctx := context.Background()
 	cancel := func() {}
 	if timeout > 0 {
@@ -115,21 +117,37 @@ func runWithTimeout(engine string, baseArgs []string, composeFile string, timeou
 	}
 	defer cancel()
 
+	cmdArgs := composeCommandArgs(baseArgs, composeFile, projectName, args...)
+	return RunComposeWithEnv(ctx, engine, env, cmdArgs...)
+}
+
+func composeCommandArgs(baseArgs []string, composeFile string, projectName string, args ...string) []string {
 	cmdArgs := append([]string{}, baseArgs...)
 	cmdArgs = append(cmdArgs, "-f", composeFile)
+	if projectName != "" {
+		cmdArgs = append(cmdArgs, "-p", projectName)
+	}
 	cmdArgs = append(cmdArgs, args...)
-	return RunCompose(ctx, engine, cmdArgs...)
+	return cmdArgs
 }
 
 func normalizeComposeTestMainOptions(options ComposeTestMainOptions) ComposeTestMainOptions {
 	if options.ComposeFile == "" {
 		options.ComposeFile = "docker_compose/docker_compose.yml"
 	}
+	if options.ProjectName == "" {
+		projectName, err := NewComposeProjectName(options.ComposeFile)
+		if err == nil {
+			options.ProjectName = projectName
+		}
+	}
 	if len(options.UpArgs) == 0 {
 		options.UpArgs = []string{"up", "-d", "--build"}
 	}
 	if len(options.DownArgs) == 0 {
-		options.DownArgs = []string{"down"}
+		options.DownArgs = []string{"down", "-v", "--remove-orphans"}
+	} else {
+		options.DownArgs = normalizeComposeDownArgs(options.DownArgs)
 	}
 	if options.UpTimeout <= 0 {
 		options.UpTimeout = 10 * time.Minute
@@ -141,4 +159,29 @@ func normalizeComposeTestMainOptions(options ComposeTestMainOptions) ComposeTest
 		options.HealthTimeout = 2 * time.Minute
 	}
 	return options
+}
+
+func normalizeComposeDownArgs(args []string) []string {
+	normalized := append([]string{}, args...)
+	if len(normalized) == 0 || normalized[0] != "down" {
+		return normalized
+	}
+	if !hasAnyArg(normalized, "-v", "--volumes") {
+		normalized = append(normalized, "-v")
+	}
+	if !hasAnyArg(normalized, "--remove-orphans") {
+		normalized = append(normalized, "--remove-orphans")
+	}
+	return normalized
+}
+
+func hasAnyArg(args []string, candidates ...string) bool {
+	for _, arg := range args {
+		for _, candidate := range candidates {
+			if arg == candidate {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/common/testenv/compose_testmain.go
+++ b/internal/common/testenv/compose_testmain.go
@@ -30,6 +30,8 @@ package testenv
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -55,10 +57,16 @@ type ComposeTestMainOptions struct {
 
 func RunComposeTestMain(m *testing.M, options ComposeTestMainOptions) int {
 	opts := normalizeComposeTestMainOptions(options)
+	if err := applyProcessEnv(opts.Env); err != nil {
+		fmt.Printf("Failed to apply Docker Compose test environment: %v\n", err)
+		ReleaseReservedLocalPorts()
+		return 1
+	}
 
 	engine, baseArgs, err := FindCompose()
 	if err != nil {
 		fmt.Println("compose engine not found:", err)
+		ReleaseReservedLocalPorts()
 		return 1
 	}
 
@@ -73,8 +81,13 @@ func RunComposeTestMain(m *testing.M, options ComposeTestMainOptions) int {
 	fmt.Println("Starting Docker Compose...")
 	if err := runWithLimit(opts.UpTimeout, opts.UpArgs...); err != nil {
 		fmt.Printf("Failed to start Docker Compose: %v\n", err)
+		if !opts.SkipDownAfterTests {
+			_ = runWithLimit(opts.DownTimeout, opts.DownArgs...)
+		}
+		ReleaseReservedLocalPorts()
 		return 1
 	}
+	ReleaseReservedLocalPorts()
 
 	if opts.WaitForReady != nil {
 		if err := opts.WaitForReady(); err != nil {
@@ -105,6 +118,19 @@ func RunComposeTestMain(m *testing.M, options ComposeTestMainOptions) int {
 	}
 
 	return code
+}
+
+func applyProcessEnv(env []string) error {
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			continue
+		}
+		if err := os.Setenv(key, value); err != nil {
+			return fmt.Errorf("TESTENV-COMPOSEMAIN-SETENV: %w", err)
+		}
+	}
+	return nil
 }
 
 func runWithTimeout(engine string, baseArgs []string, composeFile string, projectName string, env []string, timeout time.Duration, args ...string) error {

--- a/internal/common/testenv/compose_testmain_test.go
+++ b/internal/common/testenv/compose_testmain_test.go
@@ -1,0 +1,47 @@
+package testenv
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComposeCommandArgsIncludesProjectName(t *testing.T) {
+	args := composeCommandArgs([]string{"compose"}, "docker_compose/docker_compose.yml", "basyx-it-123", "up", "-d")
+
+	require.Equal(t, []string{
+		"compose",
+		"-f", "docker_compose/docker_compose.yml",
+		"-p", "basyx-it-123",
+		"up", "-d",
+	}, args)
+}
+
+func TestNormalizeComposeTestMainOptionsDefaultsDownCleanup(t *testing.T) {
+	options := normalizeComposeTestMainOptions(ComposeTestMainOptions{})
+
+	require.Equal(t, []string{"down", "-v", "--remove-orphans"}, options.DownArgs)
+	require.NotEmpty(t, options.ProjectName)
+}
+
+func TestNormalizeComposeTestMainOptionsAddsMissingDownCleanupArgs(t *testing.T) {
+	options := normalizeComposeTestMainOptions(ComposeTestMainOptions{
+		DownArgs: []string{"down", "--timeout", "1"},
+	})
+
+	require.Contains(t, options.DownArgs, "-v")
+	require.Contains(t, options.DownArgs, "--remove-orphans")
+}
+
+func TestNewComposeProjectNameIsUniqueAndValid(t *testing.T) {
+	first, err := NewComposeProjectName("Internal/AAS Registry Integration Tests")
+	require.NoError(t, err)
+	second, err := NewComposeProjectName("Internal/AAS Registry Integration Tests")
+	require.NoError(t, err)
+
+	require.NotEqual(t, first, second)
+	require.True(t, first[0] >= 'a' && first[0] <= 'z')
+	require.NotContains(t, first, "/")
+	require.Equal(t, strings.ToLower(first), first)
+}

--- a/internal/common/testenv/compose_testmain_test.go
+++ b/internal/common/testenv/compose_testmain_test.go
@@ -1,6 +1,32 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
 package testenv
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -44,4 +70,57 @@ func TestNewComposeProjectNameIsUniqueAndValid(t *testing.T) {
 	require.True(t, first[0] >= 'a' && first[0] <= 'z')
 	require.NotContains(t, first, "/")
 	require.Equal(t, strings.ToLower(first), first)
+}
+
+func TestReserveLockedLocalPortPreventsDuplicateLock(t *testing.T) {
+	port, lock, err := reserveLockedLocalPort(nil)
+	require.NoError(t, err)
+	t.Cleanup(lock.Release)
+
+	duplicate, err := acquirePortLock(port)
+	if err == nil {
+		duplicate.Release()
+	}
+	require.Error(t, err)
+}
+
+func TestNewComposeRuntimeRegistersLocksForRelease(t *testing.T) {
+	runtime, err := NewComposeRuntime("lock-release", []PortBinding{
+		{Name: "api", EnvVar: "BASYX_TESTENV_LOCK_RELEASE_PORT"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(ReleaseReservedLocalPorts)
+
+	require.Len(t, runtime.portLocks, 1)
+	lockPath := runtime.portLocks[0].path
+	require.DirExists(t, lockPath)
+
+	ReleaseReservedLocalPorts()
+
+	require.NoDirExists(t, lockPath)
+}
+
+func TestApplyProcessEnvSetsValidEntries(t *testing.T) {
+	t.Cleanup(func() { _ = os.Unsetenv("BASYX_TESTENV_PROCESS_ENV") })
+
+	require.NoError(t, applyProcessEnv([]string{
+		"BASYX_TESTENV_PROCESS_ENV=expected",
+		"not-an-env-entry",
+		"=missing-key",
+	}))
+
+	require.Equal(t, "expected", os.Getenv("BASYX_TESTENV_PROCESS_ENV"))
+}
+
+func TestSetEnvDefaultsDoesNotOverrideExistingValues(t *testing.T) {
+	t.Setenv("BASYX_TESTENV_DEFAULT", "existing")
+	t.Cleanup(func() { _ = os.Unsetenv("BASYX_TESTENV_ADDED") })
+
+	require.NoError(t, SetEnvDefaults(map[string]string{
+		"BASYX_TESTENV_DEFAULT": "new",
+		"BASYX_TESTENV_ADDED":   "added",
+	}))
+
+	require.Equal(t, "existing", os.Getenv("BASYX_TESTENV_DEFAULT"))
+	require.Equal(t, "added", os.Getenv("BASYX_TESTENV_ADDED"))
 }

--- a/internal/common/testenv/jsonsuite.go
+++ b/internal/common/testenv/jsonsuite.go
@@ -99,6 +99,8 @@ type JSONSuiteOptions struct {
 
 	EnableRequestLog bool
 	EnableRawDump    bool
+
+	TemplateValues map[string]string
 }
 
 type JSONSuiteRunner struct {
@@ -420,7 +422,7 @@ func RunJSONSuite(t *testing.T, options JSONSuiteOptions) {
 	t.Helper()
 
 	normalized := normalizeJSONSuiteOptions(options)
-	steps, err := loadJSONSuiteConfig(normalized.ConfigPath)
+	steps, err := loadJSONSuiteConfig(normalized.ConfigPath, normalized.TemplateValues)
 	require.NoError(t, err, "Failed to load test config")
 
 	err = os.Mkdir(normalized.LogsDir, 0o755)
@@ -467,7 +469,7 @@ func RunJSONSuite(t *testing.T, options JSONSuiteOptions) {
 }
 
 func (r *JSONSuiteRunner) RunStep(step JSONSuiteStep, stepNumber int) (JSONStepResult, error) {
-	bodyBytes, err := loadStepBody(step)
+	bodyBytes, err := r.loadStepBody(step)
 	if err != nil {
 		return JSONStepResult{}, err
 	}
@@ -505,7 +507,7 @@ func (r *JSONSuiteRunner) RunStep(step JSONSuiteStep, stepNumber int) (JSONStepR
 }
 
 func (r *JSONSuiteRunner) runRawStep(step JSONSuiteStep, stepNumber int) (string, int, error) {
-	bodyBytes, err := loadStepBody(step)
+	bodyBytes, err := r.loadStepBody(step)
 	if err != nil {
 		return "", 0, err
 	}
@@ -605,6 +607,7 @@ func (r *JSONSuiteRunner) compareJSONResponse(t *testing.T, step JSONSuiteStep, 
 
 	expectedRaw, err := os.ReadFile(step.ShouldMatch)
 	require.NoError(t, err, "Failed to read expected response file")
+	expectedRaw = applyJSONSuiteTemplateValues(expectedRaw, r.options.TemplateValues)
 
 	expectedJSON, err := normalizeJSON(expectedRaw)
 	require.NoError(t, err, "Failed to parse expected JSON")
@@ -640,21 +643,49 @@ func normalizeJSONSuiteOptions(options JSONSuiteOptions) JSONSuiteOptions {
 	return options
 }
 
-func loadJSONSuiteConfig(path string) ([]JSONSuiteStep, error) {
-	file, err := os.Open(path)
+func loadJSONSuiteConfig(path string, templateValues map[string]string) ([]JSONSuiteStep, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = file.Close() }()
+	data = applyJSONSuiteTemplateValues(data, templateValues)
 
 	var steps []JSONSuiteStep
-	if err := json.NewDecoder(file).Decode(&steps); err != nil {
+	if err := json.Unmarshal(data, &steps); err != nil {
 		return nil, err
 	}
 	return steps, nil
 }
 
-func loadStepBody(step JSONSuiteStep) ([]byte, error) {
+func applyJSONSuiteTemplateValues(data []byte, templateValues map[string]string) []byte {
+	values := jsonSuiteTemplateValuesFromEnv()
+	for key, value := range templateValues {
+		values[key] = value
+	}
+	if len(values) == 0 {
+		return data
+	}
+
+	result := string(data)
+	for key, value := range values {
+		result = strings.ReplaceAll(result, "{{"+key+"}}", value)
+	}
+	return []byte(result)
+}
+
+func jsonSuiteTemplateValuesFromEnv() map[string]string {
+	values := map[string]string{}
+	for _, entry := range os.Environ() {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || !strings.HasPrefix(key, "BASYX_") {
+			continue
+		}
+		values[key] = value
+	}
+	return values
+}
+
+func (r *JSONSuiteRunner) loadStepBody(step JSONSuiteStep) ([]byte, error) {
 	if step.Data == "" {
 		return nil, nil
 	}
@@ -662,7 +693,7 @@ func loadStepBody(step JSONSuiteStep) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read data file: %w", err)
 	}
-	return data, nil
+	return applyJSONSuiteTemplateValues(data, r.options.TemplateValues), nil
 }
 
 func normalizeJSON(input []byte) (string, error) {

--- a/internal/common/testenv/jsonsuite_test.go
+++ b/internal/common/testenv/jsonsuite_test.go
@@ -26,6 +26,8 @@
 package testenv
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -52,4 +54,59 @@ func TestDefaultCheckDBIsEmptyExcludedTablesIncludesPersistentSchemaTables(t *te
 		_, ok := excluded[table]
 		require.Truef(t, ok, "expected %s to be excluded", table)
 	}
+}
+
+func TestApplyJSONSuiteTemplateValuesPreservesDollarPathTokens(t *testing.T) {
+	input := []byte(`[{"method":"GET","endpoint":"{{BASYX_IT_BASE_URL}}/submodels/$metadata/$path"}]`)
+
+	output := applyJSONSuiteTemplateValues(input, map[string]string{
+		"BASYX_IT_BASE_URL": "http://127.0.0.1:61234",
+	})
+
+	require.JSONEq(t,
+		`[{"method":"GET","endpoint":"http://127.0.0.1:61234/submodels/$metadata/$path"}]`,
+		string(output),
+	)
+}
+
+func TestJSONSuiteRunnerTemplatesBodyAndExpectedFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	bodyPath := filepath.Join(tempDir, "body.json")
+	expectedPath := filepath.Join(tempDir, "expected.json")
+	require.NoError(t, os.WriteFile(bodyPath, []byte(`{"href":"{{BASYX_IT_BASE_URL}}/submodels/$reference"}`), 0o600))
+	require.NoError(t, os.WriteFile(expectedPath, []byte(`{"href":"{{BASYX_IT_BASE_URL}}/submodels/$metadata"}`), 0o600))
+
+	runner := &JSONSuiteRunner{
+		options: JSONSuiteOptions{
+			TemplateValues: map[string]string{
+				"BASYX_IT_BASE_URL": "http://127.0.0.1:61234",
+			},
+		},
+	}
+
+	body, err := runner.loadStepBody(JSONSuiteStep{Data: bodyPath})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"href":"http://127.0.0.1:61234/submodels/$reference"}`, string(body))
+
+	runner.compareJSONResponse(t, JSONSuiteStep{ShouldMatch: expectedPath}, 1, `{"href":"http://127.0.0.1:61234/submodels/$metadata"}`)
+}
+
+func TestPrepareSecurityEnvCopiesAndRewritesIssuer(t *testing.T) {
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sourceDir, "trustlist.json"),
+		[]byte(`[{"issuer":"http://localhost:8080/realms/basyx"}]`),
+		0o600,
+	))
+
+	targetDir, err := PrepareSecurityEnv(sourceDir, map[string]string{
+		"http://localhost:8080": "http://localhost:18080",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(targetDir) })
+
+	//nolint:gosec // The test reads a fixture path created under t.TempDir.
+	rewritten, err := os.ReadFile(filepath.Join(targetDir, "trustlist.json"))
+	require.NoError(t, err)
+	require.JSONEq(t, `[{"issuer":"http://localhost:18080/realms/basyx"}]`, string(rewritten))
 }

--- a/internal/common/testenv/util.go
+++ b/internal/common/testenv/util.go
@@ -59,7 +59,16 @@ func FindCompose() (bin string, args []string, err error) {
 // RunCompose executes a Docker Compose command with the given base command and arguments.
 // Streams stdout and stderr to the current process's output streams.
 func RunCompose(ctx context.Context, base string, args ...string) error {
+	return RunComposeWithEnv(ctx, base, nil, args...)
+}
+
+// RunComposeWithEnv executes a Docker Compose command with additional environment variables.
+// Streams stdout and stderr to the current process's output streams.
+func RunComposeWithEnv(ctx context.Context, base string, env []string, args ...string) error {
 	cmd := exec.CommandContext(ctx, base, args...)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/internal/companylookupservice/integration_tests/companylookupservice_integration_test.go
+++ b/internal/companylookupservice/integration_tests/companylookupservice_integration_test.go
@@ -39,10 +39,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var companyLookupBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
+var companyLookupDSN = testenv.PostgresKeywordDSNFromEnv("BASYX_IT_DB_PORT", 6432, "basyxTestDB")
+
 func deleteAllCompanyDescriptors(t *testing.T, runner *testenv.JSONSuiteRunner, stepNumber int) {
 	response, err := runner.RunStep(testenv.JSONSuiteStep{
 		Method:         http.MethodGet,
-		Endpoint:       "http://127.0.0.1:6004/companies",
+		Endpoint:       companyLookupBaseURL + "/companies",
 		ExpectedStatus: http.StatusOK,
 	}, stepNumber)
 	require.NoError(t, err)
@@ -58,7 +61,7 @@ func deleteAllCompanyDescriptors(t *testing.T, runner *testenv.JSONSuiteRunner, 
 		enc := base64.RawURLEncoding.EncodeToString([]byte(item.Domain))
 		_, err := runner.RunStep(testenv.JSONSuiteStep{
 			Method:         http.MethodDelete,
-			Endpoint:       fmt.Sprintf("http://127.0.0.1:6004/companies/%s", enc),
+			Endpoint:       fmt.Sprintf("%s/companies/%s", companyLookupBaseURL, enc),
 			ExpectedStatus: http.StatusNoContent,
 		}, stepNumber)
 		require.NoError(t, err)
@@ -82,15 +85,24 @@ func TestIntegration(t *testing.T) {
 			},
 			testenv.ActionCheckDBIsEmpty: testenv.NewCheckDBIsEmptyAction(testenv.CheckDBIsEmptyOptions{
 				Driver: "pgx",
-				DSN:    "host=127.0.0.1 port=6432 user=admin password=admin123 dbname=basyxTestDB sslmode=disable",
+				DSN:    companyLookupDSN,
 			}),
 		},
 	})
 }
 
 func TestMain(m *testing.M) {
+	runtime := testenv.NewComposeRuntimeOrExit("company-lookup-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+	})
+	companyLookupBaseURL = runtime.LocalURL("api")
+	companyLookupDSN = runtime.PostgresKeywordDSN("db", "basyxTestDB")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker-compose.yml",
-		HealthURL:   "http://localhost:6004/health",
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.Env(),
+		HealthURL:   companyLookupBaseURL + "/health",
 	}))
 }

--- a/internal/companylookupservice/integration_tests/docker_compose/docker-compose.yml
+++ b/internal/companylookupservice/integration_tests/docker_compose/docker-compose.yml
@@ -1,13 +1,12 @@
 services:
   db_it:
     image: postgres:18
-    container_name: postgres_db_it
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     command: [ "postgres", "-c", "listen_addresses=*" ]
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U admin -d basyxTestDB" ]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   company-lookup-it:
-    container_name: company-lookup-it
     build:
       context: ../../../..
       dockerfile: ./cmd/companylookupservice/Dockerfile
@@ -31,7 +29,7 @@ services:
       - POSTGRES_MAXIDLECONNECTIONS=500
       - POSTGRES_CONNMAXLIFETIMEMINUTES=5
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
@@ -41,7 +39,6 @@ services:
       - "localhost:host-gateway"
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/companylookupservice/integration_tests/it_config.json
+++ b/internal/companylookupservice/integration_tests/it_config.json
@@ -2,71 +2,71 @@
     {
         "context": "001 - Health Check - GET /health",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/health",
+        "endpoint": "{{BASYX_IT_API_URL}}/health",
         "shouldMatch": "expected/expected_health_endpoint.json",
         "expectedStatus": 200
     },
     {
         "context": "002 - List Company Descriptors (Empty) - GET /companies",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "shouldMatch": "expected/empty_paged_result.json",
         "expectedStatus": 200
     },
     {
         "context": "002.1 - List Company Descriptors - GET /companies",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "expectedStatus": 200
     },
     {
         "context": "002.2 - Create Company Descriptor (Malformed) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_missing_domain.json",
         "expectedStatus": 400
     },
     {
         "context": "002.3 - Replace Company Collection - PUT /companies",
         "method": "PUT",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "expectedStatus": 405
     },
     {
         "context": "002.4 - Delete Company Collection - DELETE /companies",
         "method": "DELETE",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "expectedStatus": 405
     },
     {
         "context": "002.5 - List Company Descriptors - GET /companies/ route not found",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies/",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/",
         "expectedStatus": 404
     },
     {
         "context": "002.6 - Create Company Descriptor - POST /companies/ route not found",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies/",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/",
         "data": "postBody/company_descriptor_malformed_missing_domain.json",
         "expectedStatus": 404
     },
     {
         "context": "002.7 - Replace Company Collection - PUT /companies/ route not found",
         "method": "PUT",
-        "endpoint": "http://127.0.0.1:6004/companies/",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/",
         "expectedStatus": 404
     },
     {
         "context": "002.8 - Delete Company Collection - DELETE /companies/ route not found",
         "method": "DELETE",
-        "endpoint": "http://127.0.0.1:6004/companies/",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/",
         "expectedStatus": 404
     },
     {
         "context": "003 - Create Company Descriptor #1 - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_1.json",
         "shouldMatch": "postBody/company_descriptor_1.json",
         "expectedStatus": 201
@@ -74,140 +74,140 @@
     {
         "context": "004 - Create Company Descriptor (Conflict - Duplicate) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_1.json",
         "expectedStatus": 409
     },
     {
         "context": "005 - Create Company Descriptor (Conflict - Missing Identifier) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_missing_domain.json",
         "expectedStatus": 400
     },
     {
         "context": "006 - Create Company Descriptor (Conflict - Empty Domain) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_domain.json",
         "expectedStatus": 400
     },
     {
         "context": "007 - Create Company Descriptor (Conflict - Invalid Domain Syntax) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_invalid_domain_syntax.json",
         "expectedStatus": 400
     },
     {
         "context": "008 - Create Company Descriptor (Conflict - Empty Name) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_name.json",
         "expectedStatus": 400
     },
     {
         "context": "009 - Create Company Descriptor (Conflict - Empty Interface in Endpoint) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_interface_in_endpoint.json",
         "expectedStatus": 400
     },
     {
         "context": "010 - Create Company Descriptor (Conflict - Disallowed AAS-Interfaces in Endpoint) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_disallowed_aas_interfaces_in_endpoint.json",
         "expectedStatus": 400
     },
     {
         "context": "011 - Create Company Descriptor (Conflict - Only Non-AAS-Interfaces in Endpoint) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_only_non_aas_interfaces_in_endpoint.json",
         "expectedStatus": 400
     },
     {
         "context": "012 - Create Company Descriptor (Conflict - Empty Protocol Information in Endpoint) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_protocol_information_in_endpoint.json",
         "expectedStatus": 400
     },
     {
         "context": "013 - Create Company Descriptor (Conflict - Empty HREF in Protocol Information) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_href_in_protocol_information.json",
         "expectedStatus": 400
     },
     {
         "context": "014 - Create Company Descriptor (Conflict - Empty Creator in Administrative Information) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_creator_in_administrative_information.json",
         "expectedStatus": 400
     },
     {
         "context": "015 - Create Company Descriptor (Conflict - Missing Keys in Reference) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_missing_keys_in_reference.json",
         "expectedStatus": 400
     },
     {
         "context": "016 - Create Company Descriptor (Conflict - Empty Keys in Reference) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_keys_in_reference.json",
         "expectedStatus": 400
     },
     {
         "context": "017 - Create Company Descriptor (Conflict - Empty Type in Key) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_type_in_key.json",
         "expectedStatus": 400
     },
     {
         "context": "018 - Create Company Descriptor (Conflict - Empty Value in Key) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_value_in_key.json",
         "expectedStatus": 400
     },
     {
         "context": "019 - Create Company Descriptor (Conflict - Empty Language in Description) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_language_in_description.json",
         "expectedStatus": 400
     },
     {
         "context": "020 - Create Company Descriptor (Conflict - Empty Text in Description) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_text_in_description.json",
         "expectedStatus": 400
     },
     {
         "context": "021 - Create Company Descriptor (Conflict - Empty Language in DisplayName) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_language_in_displayname.json",
         "expectedStatus": 400
     },
     {
         "context": "022 - Create Company Descriptor (Conflict - Empty Text in DisplayName) - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_malformed_empty_text_in_displayname.json",
         "expectedStatus": 400
     },
     {
         "context": "023 - Create Company Descriptor #2 - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_2.json",
         "shouldMatch": "postBody/company_descriptor_2.json",
         "expectedStatus": 201
@@ -215,7 +215,7 @@
     {
         "context": "024 - Create Company Descriptor #3 - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_3.json",
         "shouldMatch": "postBody/company_descriptor_3.json",
         "expectedStatus": 201
@@ -223,7 +223,7 @@
     {
         "context": "025 - Create Company Descriptor #4 - POST /companies",
         "method": "POST",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "data": "postBody/company_descriptor_4.json",
         "shouldMatch": "postBody/company_descriptor_4.json",
         "expectedStatus": 201
@@ -231,139 +231,139 @@
     {
         "context": "026 - Get Company Descriptor by Domain - GET /companies/{domain}",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies/aWVzZS5mcmF1bmhvZmVyLmRl",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/aWVzZS5mcmF1bmhvZmVyLmRl",
         "shouldMatch": "postBody/company_descriptor_1.json",
         "expectedStatus": 200
     },
     {
         "context": "027 - Get Company Descriptor by Domain (Conflict - Not Found) - GET /companies/{domain}",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies/bm90LmV4aXN0ZW50LmRl",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/bm90LmV4aXN0ZW50LmRl",
         "expectedStatus": 404
     },
     {
         "context": "028 - Get Company Descriptor by Domain (Conflict - Invalid Domain Syntax) - GET /companies/{domain}",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies/aW52YWxpZF9kb21haW4uZGU",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/aW52YWxpZF9kb21haW4uZGU",
         "expectedStatus": 400
     },
     { 
         "context": "029 - List Company Descriptors - GET /companies",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "shouldMatch": "expected/company_descriptors_1-4.json",
         "expectedStatus": 200
     },
     {
         "context": "030 - List Company Descriptors (Limit) - GET /companies?limit=2",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?limit=2",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?limit=2",
         "shouldMatch": "expected/company_descriptors_1-2.json",
         "expectedStatus": 200
     },
     {
         "context": "031 - List Company Descriptors (Limit + Cursor) - GET /companies?limit=1&cursor=...",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?limit=1&cursor=ZXguY29tLjMuZGU",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?limit=1&cursor=ZXguY29tLjMuZGU",
         "shouldMatch": "expected/company_descriptor_cursor_limit.json",
         "expectedStatus": 200
     },
     {
         "context": "032 - List Company Descriptors (Nonexistent Cursor) - GET /companies?cursor=...",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?limit=1&cursor=enp6enp6",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?limit=1&cursor=enp6enp6",
         "shouldMatch": "expected/empty_paged_result.json",
         "expectedStatus": 200
     },
     {
         "context": "033 - List Company Descriptors (Conflict - Invalid Cursor (Not Base64)) - GET /companies?cursor=...",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?cursor=$HR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvcm9yL2Q0ZS10ZW5hbnQtMC1hYXMtZGlzY292ZXJ5",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?cursor=$HR0cHM6Ly9pZXNlLmZyYXVuaG9mZXIuZGUvcm9yL2Q0ZS10ZW5hbnQtMC1hYXMtZGlzY292ZXJ5",
         "expectedStatus": 400
     },
     {
         "context": "034 - List Company Descriptors (Conflict - Invalid Cursor (Non-UTF8 Bytes)) - GET /companies?cursor=...",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?cursor=aaa",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?cursor=aaa",
         "expectedStatus": 400
     },
     {
         "context": "035 - List Company Descriptors (Filter Name) - GET /companies?name=Fraunhofer IESE",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?name=RnJhdW5ob2ZlciBJRVNF",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?name=RnJhdW5ob2ZlciBJRVNF",
         "shouldMatch": "expected/company_descriptors_filter_name.json",
         "expectedStatus": 200
     },
     {
         "context": "036 - List Company Descriptors (Filter Name Case-Insensitive) - GET /companies?name=fraunhofer iese",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?name=ZnJhdW5ob2ZlciBpZXNl",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?name=ZnJhdW5ob2ZlciBpZXNl",
         "shouldMatch": "expected/company_descriptors_filter_name.json",
         "expectedStatus": 200
     },
     {
         "context": "037 - List Company Descriptors (Filter Name Via Name Options) - GET /companies?name=ExCompany",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?name=RXhDb21wYW55",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?name=RXhDb21wYW55",
         "shouldMatch": "expected/company_descriptors_filter_name_options.json",
         "expectedStatus": 200
     },
     {
         "context": "038 - List Company Descriptors (Filter Name Via Name Options Case-Insensitive) - GET /companies?name=EXCOMPANY",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?name=RVhDT01QQU5Z",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?name=RVhDT01QQU5Z",
         "shouldMatch": "expected/company_descriptors_filter_name_options.json",
         "expectedStatus": 200
     },
     {
         "context": "039 - List Company Descriptors (Filter Name - No Match) - GET /companies?name=NonExistentCompanyName",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?name=Tm9uRXhpc3RlbnRDb21wYW55TmFtZQ",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?name=Tm9uRXhpc3RlbnRDb21wYW55TmFtZQ",
         "shouldMatch": "expected/empty_paged_result.json",
         "expectedStatus": 200
     },
     {
         "context": "040 - List Company Descriptors (Conflict - Invalid Name (Not Base64Url Encoded)) - GET /companies?name=...",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?name=$mFsd29ybWQ",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?name=$mFsd29ybWQ",
         "expectedStatus": 400
     },
     {
         "context": "041 - List Company Descriptors (Filter AssetId) - GET /companies?assetId=https://i.iese.fraunhofer.de/assetId/assets/4711",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?assetId=aHR0cHM6Ly9pLmllc2UuZnJhdW5ob2Zlci5kZS9hc3NldElkL2Fzc2V0cy80NzEx",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?assetId=aHR0cHM6Ly9pLmllc2UuZnJhdW5ob2Zlci5kZS9hc3NldElkL2Fzc2V0cy80NzEx",
         "shouldMatch": "expected/company_descriptors_filter_asset_id.json",
         "expectedStatus": 200
     },
     {
         "context": "042 - List Company Descriptors (Filter AssetId - No Match)",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies?assetId=aHR0cHM6Ly9pLmllc2UuZGUvYXNzZXRJZC9hc3NldHMvMjQ2OA",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies?assetId=aHR0cHM6Ly9pLmllc2UuZGUvYXNzZXRJZC9hc3NldHMvMjQ2OA",
         "shouldMatch": "expected/empty_paged_result.json",
         "expectedStatus": 200
     },
     {
         "context": "043 - Delete Company Descriptor by Domain - DELETE /companies/{domain}",
         "method": "DELETE",
-        "endpoint": "http://127.0.0.1:6004/companies/ZXguY29tLjIuZGU",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/ZXguY29tLjIuZGU",
         "expectedStatus": 204
     },
     {
         "context": "044 - Delete Company Descriptor by Domain (Conflict - Invalid Domain Syntax) - DELETE /companies/{domain}",
         "method": "DELETE",
-        "endpoint": "http://127.0.0.1:6004/companies/aW52YWxpZF9kb21haW4uZGU",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/aW52YWxpZF9kb21haW4uZGU",
         "expectedStatus": 400
     },
     {
         "context": "045 - Delete Company Descriptor by Domain (Conflict - Not Found) - DELETE /companies/{domain}",
         "method": "DELETE",
-        "endpoint": "http://127.0.0.1:6004/companies/ZXguY29tLjIuZGU",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/ZXguY29tLjIuZGU",
         "expectedStatus": 404
     },
     {
         "context": "046 - Update Company Descriptor using PUT - PUT /companies/{domain}",
         "method": "PUT",
-        "endpoint": "http://127.0.0.1:6004/companies/ZXguY29tLjEuZGU",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/ZXguY29tLjEuZGU",
         "data": "postBody/company_descriptor_5.json",
         "shouldMatch": "postBody/company_descriptor_5.json",
         "expectedStatus": 200
@@ -371,28 +371,28 @@
     {
         "context": "047 - Get Company Descriptor by Domain - GET /companies/{domain}",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies/ZXguY29tLjEuZGU",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/ZXguY29tLjEuZGU",
         "shouldMatch": "postBody/company_descriptor_5.json",
         "expectedStatus": 200
     },
     {
         "context": "048 - Update Company Descriptor using PUT (Conflict - Domain Mismatch) - PUT /companies/{domain}",
         "method": "PUT",
-        "endpoint": "http://127.0.0.1:6004/companies/ZXguY29tLjEuZGUubm90",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/ZXguY29tLjEuZGUubm90",
         "data": "postBody/company_descriptor_5.json",
         "expectedStatus": 400
     },
     {
         "context": "049 - Update Company Descriptor using PUT (Conflict - Invalid Domain Syntax) - PUT /companies/{domain}",
         "method": "PUT",
-        "endpoint": "http://127.0.0.1:6004/companies/aW52YWxpZF9kb21haW4uZGU",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/aW52YWxpZF9kb21haW4uZGU",
         "data": "postBody/company_descriptor_5.json",
         "expectedStatus": 400
     },
     {
         "context": "050 - Update Company Descriptor using PUT (Conflict - Nonexistent Domain) - PUT /companies/{domain}",
         "method": "PUT",
-        "endpoint": "http://127.0.0.1:6004/companies/ZXguY29tLjQuZGU",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies/ZXguY29tLjQuZGU",
         "data": "postBody/company_descriptor_6.json",
         "expectedStatus": 404
     },
@@ -403,7 +403,7 @@
     {
         "context": "052 - Verify that Cleanup has worked - GET /companies",
         "method": "GET",
-        "endpoint": "http://127.0.0.1:6004/companies",
+        "endpoint": "{{BASYX_IT_API_URL}}/companies",
         "shouldMatch": "expected/empty_paged_result.json",
         "expectedStatus": 200
     },

--- a/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_integration_test.go
+++ b/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_integration_test.go
@@ -343,6 +343,9 @@ func TestContractGetAllConceptDescriptionsAllowsNullableIDShort(t *testing.T) {
 // TestMain handles setup and teardown
 func TestMain(m *testing.M) {
 	if os.Getenv("BASYX_EXTERNAL_COMPOSE") == "1" {
+		testenv.SetEnvDefaultsOrExit(map[string]string{
+			"BASYX_IT_API_URL": conceptDescriptionRepositoryBaseURL,
+		})
 		os.Exit(m.Run())
 	}
 

--- a/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_integration_test.go
+++ b/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_integration_test.go
@@ -41,16 +41,14 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 )
 
-// #nosec G101 -- integration test DSN matches the local Docker Compose database credentials.
-const defaultConceptDescriptionRepositoryIntegrationTestDSN = "postgres://admin:admin123@127.0.0.1:6432/basyxTestDB?sslmode=disable"
-
+var conceptDescriptionRepositoryBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
 var conceptDescriptionRepositoryIntegrationTestDSN = getConceptDescriptionRepositoryIntegrationTestDSN()
 
 func getConceptDescriptionRepositoryIntegrationTestDSN() string {
 	if dsn := os.Getenv("CONCEPTDESCRIPTIONREPOSITORY_INTEGRATION_TEST_DSN"); dsn != "" {
 		return dsn
 	}
-	return defaultConceptDescriptionRepositoryIntegrationTestDSN
+	return testenv.PostgresURLFromEnv("BASYX_IT_DB_PORT", 6432, "basyxTestDB")
 }
 
 func requestJSON(method string, endpoint string, payload any) (int, []byte, error) {
@@ -143,7 +141,7 @@ func assertLocationHeaderMatches(t *testing.T, expectedLocation string, actualLo
 }
 
 func TestLocationHeadersForCreateEndpointsConceptDescriptionRepository(t *testing.T) {
-	baseURL := "http://127.0.0.1:6004"
+	baseURL := conceptDescriptionRepositoryBaseURL
 	endpoint := baseURL + "/concept-descriptions"
 
 	t.Run("PostConceptDescriptionSetsLocation", func(t *testing.T) {
@@ -224,7 +222,7 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestQueryConceptDescriptionFalseIDShortFragmentKeepsConceptDescription(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := conceptDescriptionRepositoryBaseURL
 	endpoint := baseURL + "/concept-descriptions"
 	conceptDescriptionID := fmt.Sprintf("https://example.com/ids/cd/query-fragment-%d", time.Now().UnixNano())
 	t.Cleanup(func() { cleanupConceptDescription(t, endpoint, conceptDescriptionID) })
@@ -291,7 +289,7 @@ func TestQueryConceptDescriptionFalseIDShortFragmentKeepsConceptDescription(t *t
 }
 
 func TestContractGetAllConceptDescriptionsAllowsNullableIDShort(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := conceptDescriptionRepositoryBaseURL
 	conceptDescriptionID := fmt.Sprintf("https://example.com/ids/cd/contract-null-idshort-%d", time.Now().UnixNano())
 
 	statusCode, responseBody, err := requestJSON(http.MethodPost, baseURL+"/concept-descriptions", map[string]any{
@@ -348,11 +346,20 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
+	runtime := testenv.NewComposeRuntimeOrExit("conceptdescriptionrepository-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+	})
+	conceptDescriptionRepositoryBaseURL = runtime.LocalURL("api")
+	conceptDescriptionRepositoryIntegrationTestDSN = runtime.PostgresURL("db", "basyxTestDB")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     "docker_compose/docker_compose.yml",
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.Env(),
 		UpArgs:          []string{"up", "-d", "--build", "--remove-orphans"},
 		PreDownBeforeUp: true,
-		HealthURL:       "http://localhost:6004/health",
+		HealthURL:       conceptDescriptionRepositoryBaseURL + "/health",
 		HealthTimeout:   150 * time.Second,
 	}))
 }

--- a/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_recent_changes_integration_test.go
+++ b/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_recent_changes_integration_test.go
@@ -42,7 +42,7 @@ import (
 
 func TestConceptDescriptionRepositoryRecentChanges(t *testing.T) {
 	changedAfter := time.Now().Add(-1 * time.Minute).UTC().Format(time.RFC3339Nano)
-	baseURL := "http://localhost:6004"
+	baseURL := conceptDescriptionRepositoryBaseURL
 	conceptDescriptionID := fmt.Sprintf("urn:example:cd:recent:%d", time.Now().UnixNano())
 	encodedID := base64.RawURLEncoding.EncodeToString([]byte(conceptDescriptionID))
 	t.Cleanup(func() {

--- a/internal/conceptdescriptionrepository/integration_tests/docker_compose/docker_compose.yml
+++ b/internal/conceptdescriptionrepository/integration_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db_it:
     image: postgres:18
-    container_name: postgres_db_it
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -32,7 +31,7 @@ services:
       - BASYX_HISTORY_MODE=api
       - BASYX_HISTORY_FULL_SNAPSHOT_INTERVAL=3
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
@@ -40,7 +39,6 @@ services:
         condition: service_healthy
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/conceptdescriptionrepository/integration_tests/it_config.json
+++ b/internal/conceptdescriptionrepository/integration_tests/it_config.json
@@ -2,63 +2,63 @@
     {
         "context": "000 - Description endpoint",
         "method": "GET",
-        "endpoint": "http://localhost:6004/description",
+        "endpoint": "{{BASYX_IT_API_URL}}/description",
         "expectedStatus": 200
     },
     {
         "context": "001 - Get All Concept Descriptions (Empty)",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsEmpty.json"
     },
     {
         "context": "001.1 - Get All Concept Descriptions",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
         "expectedStatus": 200
     },
     {
         "context": "001.2 - Update Concept Descriptions Collection",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
         "expectedStatus": 405
     },
     {
         "context": "001.3 - Delete Concept Descriptions Collection",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
         "expectedStatus": 405
     },
     {
         "context": "001.4 - Get All Concept Descriptions Trailing Slash",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions/",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/",
         "expectedStatus": 404
     },
     {
         "context": "001.5 - Update Concept Descriptions Collection Trailing Slash",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/concept-descriptions/",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/",
         "expectedStatus": 404
     },
     {
         "context": "001.6 - Delete Concept Descriptions Collection Trailing Slash",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/concept-descriptions/",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/",
         "expectedStatus": 404
     },
     {
         "context": "001.7 - Create Concept Description Trailing Slash",
         "method": "POST",
-        "endpoint": "http://localhost:6004/concept-descriptions/",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/",
         "expectedStatus": 404,
         "data": "bodies/ConceptDescriptionA.json"
     },
     {
         "context": "002 - Create Concept Description A",
         "method": "POST",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
         "expectedStatus": 201,
         "data": "bodies/ConceptDescriptionA.json",
         "shouldMatch": "bodies/ConceptDescriptionA.json"
@@ -66,14 +66,14 @@
     {
         "context": "003 - Get Concept Description A by ID",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
         "expectedStatus": 200,
         "shouldMatch": "bodies/ConceptDescriptionA.json"
     },
     {
         "context": "004 - Create Concept Description B",
         "method": "POST",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
         "expectedStatus": 201,
         "data": "bodies/ConceptDescriptionB.json",
         "shouldMatch": "bodies/ConceptDescriptionB.json"
@@ -81,100 +81,100 @@
     {
         "context": "005 - Get All Concept Descriptions (Limit 1 - Page 1)",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions?limit=1",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions?limit=1",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsLimit1Page1.json"
     },
     {
         "context": "006 - Get All Concept Descriptions (Limit 1 - Page 2 via Cursor)",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions?limit=1&cursor=dXJuOmV4YW1wbGU6Y2Q6Yjoy",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions?limit=1&cursor=dXJuOmV4YW1wbGU6Y2Q6Yjoy",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsLimit1Page2.json"
     },
     {
         "context": "006.1 - Get All Concept Descriptions (Nonexistent Cursor)",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions?limit=1&cursor=dXJuOmV4YW1wbGU6Y2Q6OTk5",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions?limit=1&cursor=dXJuOmV4YW1wbGU6Y2Q6OTk5",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsEmpty.json"
     },
     {
         "context": "007 - Update Concept Description B via PUT",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yjoy",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yjoy",
         "expectedStatus": 204,
         "data": "bodies/ConceptDescriptionBUpdated.json"
     },
     {
         "context": "008 - Get Updated Concept Description B by ID",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yjoy",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yjoy",
         "expectedStatus": 200,
         "shouldMatch": "bodies/ConceptDescriptionBUpdated.json"
     },
     {
         "context": "009 - Delete Concept Description A",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
         "expectedStatus": 204
     },
     {
         "context": "010 - Get Concept Description A by ID (Not Found)",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
         "expectedStatus": 404
     },
     {
         "context": "010.1 - Delete Concept Description A by ID (Not Found)",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6YTox",
         "expectedStatus": 404
     },
     {
         "context": "011 - Get All Concept Descriptions After Delete A",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsAfterDeleteA.json"
     },
     {
         "context": "012 - Delete Concept Description B",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yjoy",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yjoy",
         "expectedStatus": 204
     },
     {
         "context": "013 - Get All Concept Descriptions (Empty Again)",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsEmpty.json"
     },
     {
         "context": "013.1 - Create Concept Description C via PUT",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yzoz",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yzoz",
         "expectedStatus": 201,
         "data": "bodies/ConceptDescriptionC.json"
     },
     {
         "context": "013.2 - Get Concept Description C by ID",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yzoz",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yzoz",
         "expectedStatus": 200,
         "shouldMatch": "bodies/ConceptDescriptionC.json"
     },
     {
         "context": "013.3 - Delete Concept Description C",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yzoz",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6Yzoz",
         "expectedStatus": 204
     },
     {
         "context": "014 - Create Concept Description Full",
         "method": "POST",
-        "endpoint": "http://localhost:6004/concept-descriptions",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
         "expectedStatus": 201,
         "data": "bodies/ConceptDescriptionFull.json",
         "shouldMatch": "bodies/ConceptDescriptionFull.json"
@@ -182,28 +182,28 @@
     {
         "context": "015 - Get Concept Descriptions by idShort",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions?idShort=Temperature",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions?idShort=Temperature",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsFilteredFull.json"
     },
     {
         "context": "016 - Get Concept Descriptions by isCaseOf",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions?isCaseOf=0173-1%2302-AAO677%23002",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions?isCaseOf=0173-1%2302-AAO677%23002",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsFilteredFull.json"
     },
     {
         "context": "017 - Get Concept Descriptions by dataSpecificationRef",
         "method": "GET",
-        "endpoint": "http://localhost:6004/concept-descriptions?dataSpecificationRef=https%3A%2F%2Fadmin-shell.io%2Faas%2F3%2F0%2FDataSpecificationIEC61360",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions?dataSpecificationRef=https%3A%2F%2Fadmin-shell.io%2Faas%2F3%2F0%2FDataSpecificationIEC61360",
         "expectedStatus": 200,
         "shouldMatch": "expected/GetAllConceptDescriptionsFilteredFull.json"
     },
     {
         "context": "018 - Delete Concept Description Full",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y29uY2VwdC1kZXNjcmlwdGlvbjp0ZW1wZXJhdHVyZTox",
+        "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y29uY2VwdC1kZXNjcmlwdGlvbjp0ZW1wZXJhdHVyZTox",
         "expectedStatus": 204
     }
 ]

--- a/internal/conceptdescriptionrepository/security_tests/conceptdescriptionrepository_security_integration_test.go
+++ b/internal/conceptdescriptionrepository/security_tests/conceptdescriptionrepository_security_integration_test.go
@@ -39,11 +39,16 @@ import (
 
 const actionAssertRecentChangeIDs = "ASSERT_RECENT_CHANGE_IDS"
 
+var (
+	securityBaseURL          = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+	securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+)
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -95,10 +100,25 @@ func extractRecentChangeIDs(t *testing.T, responseBody string) []string {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("conceptdescriptionrepository-security", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     "docker_compose/docker_compose.yml",
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
 		PreDownBeforeUp: true,
-		HealthURL:       "http://localhost:6004/health",
+		HealthURL:       securityBaseURL + "/health",
 		HealthTimeout:   150 * time.Second,
-	}))
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/conceptdescriptionrepository/security_tests/docker_compose/docker_compose.yml
+++ b/internal/conceptdescriptionrepository/security_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db:
     image: postgres:18
-    container_name: cdrepo_security_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   concept-description-repository-security:
-    container_name: concept-description-repository-security
     build:
       context: ../../../..
       dockerfile: ./cmd/conceptdescriptionrepositoryservice/Dockerfile
@@ -35,28 +33,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: cdrepo_security_keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -68,13 +65,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ../../../aasregistry/security_tests/docker_compose/keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: cdrepo_security_keycloak_healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -86,7 +82,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/conceptdescriptionrepository/security_tests/it_config.json
+++ b/internal/conceptdescriptionrepository/security_tests/it_config.json
@@ -3,21 +3,21 @@
     "context": "Anonymous description allowed",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/description",
+    "endpoint": "{{BASYX_IT_API_URL}}/description",
     "expectedStatus": 200
   },
   {
     "context": "Anonymous list denied",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "expectedStatus": 403
   },
   {
     "context": "POST viewer-visible concept description - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "data": "postBody/cdViewerAllowed.json",
     "shouldMatch": "postBody/cdViewerAllowed.json",
     "expectedStatus": 201
@@ -26,7 +26,7 @@
     "context": "POST viewer-hidden concept description - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "data": "postBody/cdViewerHidden.json",
     "shouldMatch": "postBody/cdViewerHidden.json",
     "expectedStatus": 201
@@ -35,7 +35,7 @@
     "context": "POST /query/concept-descriptions - anonymous denied",
     "token": null,
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/concept-descriptions",
     "data": "postBody/queryViewerAllowed.json",
     "expectedStatus": 403
   },
@@ -43,7 +43,7 @@
     "context": "POST /query/concept-descriptions - admin query hidden idShort",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/concept-descriptions",
     "data": "postBody/queryViewerHidden.json",
     "shouldMatch": "expected/expectedQueryHiddenAdmin.json",
     "expectedStatus": 200
@@ -52,7 +52,7 @@
     "context": "POST /query/concept-descriptions - admin filter fragment hidden idShort",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/concept-descriptions",
     "data": "postBody/queryFilterViewerHidden.json",
     "shouldMatch": "expected/expectedQueryIDShortFragmentHiddenAdmin.json",
     "expectedStatus": 200
@@ -61,7 +61,7 @@
     "context": "POST /query/concept-descriptions - viewer query allowed idShort",
     "token": { "user": "usera", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/concept-descriptions",
     "data": "postBody/queryViewerAllowed.json",
     "shouldMatch": "expected/expectedViewerList.json",
     "expectedStatus": 200
@@ -70,7 +70,7 @@
     "context": "POST /query/concept-descriptions - viewer idShort masked by ABAC filter",
     "token": { "user": "userb", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/concept-descriptions",
     "data": "postBody/queryViewerAllowed.json",
     "shouldMatch": "expected/expectedViewerListMaskedIDShort.json",
     "expectedStatus": 200
@@ -79,7 +79,7 @@
     "context": "POST /query/concept-descriptions - viewer query narrowed by ABAC",
     "token": { "user": "usera", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/concept-descriptions",
     "data": "postBody/queryViewerHidden.json",
     "shouldMatch": "expected/expectedEmptyList.json",
     "expectedStatus": 200
@@ -88,7 +88,7 @@
     "context": "POST /query/concept-descriptions - empty query rejected",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/concept-descriptions",
     "data": "postBody/queryEmpty.json",
     "expectedStatus": 400
   },
@@ -96,7 +96,7 @@
     "context": "POST /query/concept-descriptions - malformed query rejected",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/query/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/concept-descriptions",
     "data": "postBody/queryMalformed.json",
     "expectedStatus": 400
   },
@@ -104,7 +104,7 @@
     "context": "GET concept descriptions - viewer filtered",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "shouldMatch": "expected/expectedViewerList.json",
     "expectedStatus": 200
   },
@@ -112,7 +112,7 @@
     "context": "GET concept descriptions trailing slash - viewer not found",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/concept-descriptions/",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/",
     "expectedStatus": 404
   },
   {
@@ -120,7 +120,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/concept-descriptions/$recent-changes?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/$recent-changes?limit=20",
     "shouldMatch": "expected/expectedRecentChangesViewerIDs.json",
     "expectedStatus": 200
   },
@@ -128,14 +128,14 @@
     "context": "GET /concept-descriptions/$recent-changes/ - viewer not found",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/concept-descriptions/$recent-changes/?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/$recent-changes/?limit=20",
     "expectedStatus": 404
   },
   {
     "context": "GET viewer-visible concept description - viewer",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmFsbG93ZWQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmFsbG93ZWQ",
     "shouldMatch": "postBody/cdViewerAllowed.json",
     "expectedStatus": 200
   },
@@ -143,21 +143,21 @@
     "context": "GET viewer-visible concept description trailing slash - viewer not found",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmFsbG93ZWQ/",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmFsbG93ZWQ/",
     "expectedStatus": 404
   },
   {
     "context": "GET viewer-hidden concept description - viewer receives hidden 404",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmhpZGRlbg",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmhpZGRlbg",
     "expectedStatus": 404
   },
   {
     "context": "POST editor-allowed concept description - editor",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "data": "postBody/cdEditorAllowed.json",
     "shouldMatch": "postBody/cdEditorAllowed.json",
     "expectedStatus": 201
@@ -166,7 +166,7 @@
     "context": "POST editor-denied concept description - editor",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "data": "postBody/cdEditorDenied.json",
     "expectedStatus": 403
   },
@@ -174,7 +174,7 @@
     "context": "POST hidden-existing concept description for old-state checks - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "data": "postBody/cdEditorHiddenExisting.json",
     "shouldMatch": "postBody/cdEditorHiddenExisting.json",
     "expectedStatus": 201
@@ -183,7 +183,7 @@
     "context": "PUT invisible existing concept description - editor denied by old-state check",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOmhpZGRlbi1leGlzdGluZw",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOmhpZGRlbi1leGlzdGluZw",
     "data": "postBody/cdEditorHiddenExistingUpdatedAllowed.json",
     "expectedStatus": 403
   },
@@ -191,7 +191,7 @@
     "context": "PUT visible concept description to disallowed state - editor denied by new-state check",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOnBvc3QtYWxsb3dlZA",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOnBvc3QtYWxsb3dlZA",
     "data": "postBody/cdEditorAllowedUpdatedDenied.json",
     "expectedStatus": 403
   },
@@ -199,42 +199,42 @@
     "context": "DELETE invisible concept description - editor denied",
     "token": { "user": "userx", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOmhpZGRlbi1leGlzdGluZw",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOmhpZGRlbi1leGlzdGluZw",
     "expectedStatus": 403
   },
   {
     "context": "DELETE viewer-visible concept description - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmFsbG93ZWQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmFsbG93ZWQ",
     "expectedStatus": 204
   },
   {
     "context": "DELETE viewer-hidden concept description - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmhpZGRlbg",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6dmlld2VyOmhpZGRlbg",
     "expectedStatus": 204
   },
   {
     "context": "DELETE editor-allowed concept description - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOnBvc3QtYWxsb3dlZA",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOnBvc3QtYWxsb3dlZA",
     "expectedStatus": 204
   },
   {
     "context": "DELETE hidden-existing concept description - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOmhpZGRlbi1leGlzdGluZw",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOmhpZGRlbi1leGlzdGluZw",
     "expectedStatus": 204
   },
   {
     "context": "GET concept descriptions - admin cleanup check",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/concept-descriptions",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions",
     "shouldMatch": "expected/expectedEmptyList.json",
     "expectedStatus": 200
   }

--- a/internal/digitaltwinregistry/integration_tests/digitaltwinregistry_bulk_integration_test.go
+++ b/internal/digitaltwinregistry/integration_tests/digitaltwinregistry_bulk_integration_test.go
@@ -45,7 +45,6 @@ import (
 )
 
 const (
-	dtrTokenURL = "http://127.0.0.1:8080/realms/basyx/protocol/openid-connect/token"
 	dtrClientID = "basyx-ui"
 )
 
@@ -144,7 +143,7 @@ func fetchDTRToken(t *testing.T, user, password string) string {
 	form.Set("username", user)
 	form.Set("password", password)
 
-	req, err := http.NewRequest(http.MethodPost, dtrTokenURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequest(http.MethodPost, keycloakTokenURL, strings.NewReader(form.Encode()))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 

--- a/internal/digitaltwinregistry/integration_tests/digitaltwinregistry_integration_test.go
+++ b/internal/digitaltwinregistry/integration_tests/digitaltwinregistry_integration_test.go
@@ -40,9 +40,11 @@ import (
 )
 
 const (
-	BaseURL         = "http://127.0.0.1:6004"
 	ComposeFilePath = "./docker_compose/docker_compose.yml"
 )
+
+var BaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
+var keycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
 
 func TestMain(m *testing.M) {
 	upArgs := []string{"up", "-d", "--build"}
@@ -50,11 +52,25 @@ func TestMain(m *testing.M) {
 		upArgs = append(upArgs, "--build")
 	}
 
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("digitaltwinregistry-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	BaseURL = runtime.LocalURL("api")
+	keycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("docker_compose/security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: ComposeFilePath,
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
 		UpArgs:      upArgs,
 		HealthURL:   BaseURL + "/health",
-	}))
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }
 
 func getenv(k string) string {
@@ -100,7 +116,7 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			keycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),

--- a/internal/digitaltwinregistry/integration_tests/docker_compose/docker_compose.yml
+++ b/internal/digitaltwinregistry/integration_tests/docker_compose/docker_compose.yml
@@ -1,7 +1,6 @@
 services:
   db:
     image: postgres:18
-    container_name: digitaltwinregistry_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
@@ -14,7 +13,6 @@ services:
       retries: 5
 
   digitaltwinregistry:
-    container_name: digitaltwinregistry
     build:
       context: ../../../..
       dockerfile: ./cmd/digitaltwinregistryservice/Dockerfile
@@ -37,28 +35,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ./security_env:/security_env:ro
+      - ${BASYX_IT_SECURITY_ENV:-./security_env}:/security_env:ro
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -70,13 +67,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak-healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -88,7 +84,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/digitaltwinregistry/integration_tests/it_config.json
+++ b/internal/digitaltwinregistry/integration_tests/it_config.json
@@ -1,13 +1,13 @@
 [
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/aas_shell.json",
     "expectedStatus": 403
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/aas_shell.json",
     "expectedStatus": 403,
     "headers": {
@@ -16,33 +16,33 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/aas_shell.json",
     "expectedStatus": 201,
     "token": { "user": "admin", "password": "pwd" }
   },
   {
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "expectedStatus": 200,
     "shouldMatch": "expected/public_paged_result.json"
   },
   {
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
     "expectedStatus": 200,
     "shouldMatch": "expected/public_result.json"
   },
   {
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
     "expectedStatus": 200,
     "shouldMatch": "postBody/aas_shell.json",
     "token": { "user": "admin", "password": "pwd" }
   },
   {
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
     "expectedStatus": 200,
     "shouldMatch": "expected/bpnRandom.json",
     "headers": {
@@ -51,7 +51,7 @@
   },
   {
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
     "expectedStatus": 200,
     "shouldMatch": "expected/bpn1.json",
     "headers": {
@@ -60,7 +60,7 @@
   },
   {
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
     "expectedStatus": 200,
     "shouldMatch": "expected/bpn2.json",
     "headers": {
@@ -69,77 +69,77 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/shell-descriptors",
     "data": "postBody/aas_shell_no_public_readable.json",
     "expectedStatus": 201,
     "token": { "user": "admin", "password": "pwd" }
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/emptyAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num1AssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num2AssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3AssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num4AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdNoPublicReadableAssetLink.json",
     "shouldMatch": "expected/lookup/nonPublicId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdNoPublicReadableAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -149,7 +149,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -159,7 +159,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdNoPublicReadableAssetLink.json",
     "shouldMatch": "expected/lookup/nonPublicId.json",
     "expectedStatus": 200,
@@ -169,7 +169,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdNoPublicReadableAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -179,14 +179,14 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3and4AssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/emptyAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -196,7 +196,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num1AssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -206,7 +206,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num2AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -216,7 +216,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3AssetLink.json",
     "shouldMatch": "expected/lookup/bothIds.json",
     "expectedStatus": 200,
@@ -226,7 +226,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -236,7 +236,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -246,7 +246,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdNoPublicReadableAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/nonPublicId.json",
     "expectedStatus": 200,
@@ -256,7 +256,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num4AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -266,7 +266,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3and4AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -276,7 +276,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/emptyAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -286,7 +286,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num1AssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -296,7 +296,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num2AssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -306,7 +306,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3AssetLink.json",
     "shouldMatch": "expected/lookup/bothIds.json",
     "expectedStatus": 200,
@@ -316,7 +316,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -326,7 +326,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -336,7 +336,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdNoPublicReadableAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -346,7 +346,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num4AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -356,7 +356,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3and4AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -366,7 +366,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/emptyAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -374,7 +374,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num1AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -382,7 +382,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num2AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -390,7 +390,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3AssetLink.json",
     "shouldMatch": "expected/lookup/bothIds.json",
     "expectedStatus": 200,
@@ -398,7 +398,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num4AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -406,7 +406,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -414,7 +414,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -422,7 +422,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdNoPublicReadableAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/nonPublicId.json",
     "expectedStatus": 200,
@@ -430,7 +430,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3and4AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -438,7 +438,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/emptyAssetLink.json",
     "shouldMatch": "expected/lookup/emptyId.json",
     "expectedStatus": 200,
@@ -449,7 +449,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num1AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -460,7 +460,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num2AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -471,7 +471,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3AssetLink.json",
     "shouldMatch": "expected/lookup/bothIds.json",
     "expectedStatus": 200,
@@ -482,7 +482,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num4AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -493,7 +493,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -504,7 +504,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/globalAssetIdNoPublicReadableAndCustomerPartIdAssetLink.json",
     "shouldMatch": "expected/lookup/nonPublicId.json",
     "expectedStatus": 200,
@@ -515,7 +515,7 @@
   },
   {
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "data": "postBody/num3and4AssetLink.json",
     "shouldMatch": "expected/lookup/publicId.json",
     "expectedStatus": 200,
@@ -526,12 +526,12 @@
   },
   {
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
     "expectedStatus": 200
   },
   {
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
     "expectedStatus": 200,
     "headers": {
       "Edc-Bpn": "BPN_COMPANY_001"
@@ -539,7 +539,7 @@
   },
   {
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
     "expectedStatus": 200,
     "token": { "user": "admin", "password": "pwd" },
     "headers": {

--- a/internal/digitaltwinregistry/security_tests/digitaltwinregistry_security_integration_test.go
+++ b/internal/digitaltwinregistry/security_tests/digitaltwinregistry_security_integration_test.go
@@ -40,20 +40,36 @@ import (
 )
 
 const (
-	wenBaseURL              = "http://127.0.0.1:8082/api/v3"
 	wenComposeFilePath      = "docker_compose/docker_compose.yml"
 	deleteAllShellsActionID = "DELETE_ALL_SHELL_DESCRIPTORS"
 )
 
+var wenBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 8082) + "/api/v3"
+var wenKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("digitaltwinregistry-security-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	wenBaseURL = runtime.LocalURL("api") + "/api/v3"
+	wenKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("docker_compose/security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:        wenComposeFilePath,
+		ProjectName:        runtime.ProjectName,
+		Env:                runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
 		PreDownBeforeUp:    true,
 		DownArgs:           []string{"down", "--remove-orphans"},
 		HealthURL:          wenBaseURL + "/health",
 		HealthTimeout:      3 * time.Minute,
 		SkipDownAfterTests: false,
-	}))
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }
 
 func TestIntegration(t *testing.T) {
@@ -63,7 +79,7 @@ func TestIntegration(t *testing.T) {
 			deleteAllShellsActionID: deleteAllDescriptors,
 		},
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			wenKeycloakTokenURL,
 			"basyx-ui",
 			15*time.Second,
 		),

--- a/internal/digitaltwinregistry/security_tests/docker_compose/docker_compose.yml
+++ b/internal/digitaltwinregistry/security_tests/docker_compose/docker_compose.yml
@@ -1,11 +1,10 @@
 services:
   digitaltwinregistry:
-    container_name: digitaltwinregistry
     build:
       context: ../../../..
       dockerfile: ./cmd/digitaltwinregistryservice/Dockerfile
     ports:
-      - 8082:8080
+      - "127.0.0.1:${BASYX_IT_API_PORT:-8082}:8080"
     environment:
       - SERVER_PORT=8080
       - SERVER_CONTEXTPATH=/api/v3
@@ -25,7 +24,7 @@ services:
       - ABAC_ENABLED=true
       - ABAC_MODELPATH=/security_env/access-rules.json
     volumes:
-      - ./security_env:/security_env:ro
+      - ${BASYX_IT_SECURITY_ENV:-./security_env}:/security_env:ro
     extra_hosts:
       - "localhost:host-gateway"
     healthcheck:
@@ -41,7 +40,6 @@ services:
         condition: service_completed_successfully
 
   db:
-    container_name: postgres_db
     image: postgres:15
     environment:
       POSTGRES_USER: admin
@@ -56,15 +54,14 @@ services:
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "80"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -76,7 +73,7 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import
     depends_on:
@@ -85,7 +82,6 @@ services:
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak-healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -97,7 +93,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/digitaltwinregistry/security_tests/it_config.json
+++ b/internal/digitaltwinregistry/security_tests/it_config.json
@@ -7,7 +7,7 @@
   {
     "context": "POST shell descriptor with fixed createdAt",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:8082/api/v3/shell-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/api/v3/shell-descriptors",
     "data": "bodies/post/shell_descriptor_created_at.json",
     "token": { "user": "admin", "password": "pwd" },
     "expectedStatus": 201
@@ -15,7 +15,7 @@
   {
     "context": "GET shell descriptors createdAfter 2025 returns posted descriptor",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:8082/api/v3/shell-descriptors?createdAfter=2025-05-18T14:18:00.748914Z",
+    "endpoint": "{{BASYX_IT_API_URL}}/api/v3/shell-descriptors?createdAfter=2025-05-18T14:18:00.748914Z",
     "token": { "user": "admin", "password": "pwd" },
     "shouldMatch": "expected/shell-descriptors/created_after_2025_result.json",
     "expectedStatus": 200
@@ -23,14 +23,14 @@
   {
     "context": "GET shell descriptors trailing slash createdAfter 2025 returns not found",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:8082/api/v3/shell-descriptors/?createdAfter=2025-05-18T14:18:00.748914Z",
+    "endpoint": "{{BASYX_IT_API_URL}}/api/v3/shell-descriptors/?createdAfter=2025-05-18T14:18:00.748914Z",
     "token": { "user": "admin", "password": "pwd" },
     "expectedStatus": 404
   },
   {
     "context": "GET shell descriptors createdAfter 3036 returns empty result",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:8082/api/v3/shell-descriptors?createdAfter=3036-05-18T14:18:00.748914Z",
+    "endpoint": "{{BASYX_IT_API_URL}}/api/v3/shell-descriptors?createdAfter=3036-05-18T14:18:00.748914Z",
     "token": { "user": "admin", "password": "pwd" },
     "shouldMatch": "expected/shell-descriptors/created_after_3036_empty.json",
     "expectedStatus": 200
@@ -38,14 +38,14 @@
   {
     "context": "GET shell descriptors trailing slash createdAfter 3036 returns not found",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:8082/api/v3/shell-descriptors/?createdAfter=3036-05-18T14:18:00.748914Z",
+    "endpoint": "{{BASYX_IT_API_URL}}/api/v3/shell-descriptors/?createdAfter=3036-05-18T14:18:00.748914Z",
     "token": { "user": "admin", "password": "pwd" },
     "expectedStatus": 404
   },
   {
     "context": "POST lookup shellsByAssetLink with createdAfter 2025 returns posted descriptor id",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:8082/api/v3/lookup/shellsByAssetLink?createdAfter=2025-05-18T14:18:00.748914Z",
+    "endpoint": "{{BASYX_IT_API_URL}}/api/v3/lookup/shellsByAssetLink?createdAfter=2025-05-18T14:18:00.748914Z",
     "data": "bodies/post/lookup_shells_by_asset_link_part_instance.json",
     "token": { "user": "admin", "password": "pwd" },
     "shouldMatch": "expected/lookup/created_after_2025_public_id.json",
@@ -54,7 +54,7 @@
   {
     "context": "POST lookup shellsByAssetLink trailing slash with createdAfter 2025 returns not found",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:8082/api/v3/lookup/shellsByAssetLink/?createdAfter=2025-05-18T14:18:00.748914Z",
+    "endpoint": "{{BASYX_IT_API_URL}}/api/v3/lookup/shellsByAssetLink/?createdAfter=2025-05-18T14:18:00.748914Z",
     "data": "bodies/post/lookup_shells_by_asset_link_part_instance.json",
     "token": { "user": "admin", "password": "pwd" },
     "expectedStatus": 404
@@ -62,7 +62,7 @@
   {
     "context": "POST lookup shellsByAssetLink with createdAfter 3036 returns empty",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:8082/api/v3/lookup/shellsByAssetLink?createdAfter=3036-05-18T14:18:00.748914Z",
+    "endpoint": "{{BASYX_IT_API_URL}}/api/v3/lookup/shellsByAssetLink?createdAfter=3036-05-18T14:18:00.748914Z",
     "data": "bodies/post/lookup_shells_by_asset_link_part_instance.json",
     "token": { "user": "admin", "password": "pwd" },
     "shouldMatch": "expected/lookup/created_after_3036_empty_id.json",

--- a/internal/digitaltwinregistry/tractus-x-integrationtests/digitaltwinregistry_tractusx_integration_test.go
+++ b/internal/digitaltwinregistry/tractus-x-integrationtests/digitaltwinregistry_tractusx_integration_test.go
@@ -47,13 +47,14 @@ import (
 )
 
 const (
-	tractusBaseURL         = "http://127.0.0.1:5004"
 	tractusContextPath     = "/api/v3"
 	tractusComposeFilePath = "./docker_compose/docker_compose.yml"
 	tractusUseCasesRoot    = "./aas-registry-usecases"
 	edcBpnHeaderName       = "Edc-Bpn"
 	edcBpnTenantOne        = "TENANT_ONE"
 )
+
+var tractusBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 5004)
 
 type tractusUseCase struct {
 	Name  string
@@ -91,8 +92,16 @@ type tractusStepExpectation struct {
 }
 
 func TestMain(m *testing.M) {
+	runtime := testenv.NewComposeRuntimeOrExit("digitaltwinregistry-tractus-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+	})
+	tractusBaseURL = runtime.LocalURL("api")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: tractusComposeFilePath,
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.Env(),
 		UpArgs:      []string{"up", "-d", "--build"},
 		HealthURL:   tractusBaseURL + tractusContextPath + "/health",
 	}))

--- a/internal/digitaltwinregistry/tractus-x-integrationtests/docker_compose/docker_compose.yml
+++ b/internal/digitaltwinregistry/tractus-x-integrationtests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: digitaltwinregistry_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "5432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-5432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   digitaltwinregistry:
-    container_name: digitaltwinregistry
     build:
       context: ../../../..
       dockerfile: ./cmd/digitaltwinregistryservice/Dockerfile
@@ -40,17 +38,16 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "5004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-5004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
     volumes:
-      - ./security_env:/security_env:ro
+      - ${BASYX_IT_SECURITY_ENV:-./security_env}:/security_env:ro
     extra_hosts:
       - "localhost:host-gateway"
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/discoveryservice/integration_tests/discovery_integration_test.go
+++ b/internal/discoveryservice/integration_tests/discovery_integration_test.go
@@ -44,6 +44,9 @@ var discoveryBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
 
 func TestMain(m *testing.M) {
 	if os.Getenv("BASYX_EXTERNAL_COMPOSE") == "1" {
+		testenv.SetEnvDefaultsOrExit(map[string]string{
+			"BASYX_IT_API_URL": discoveryBaseURL,
+		})
 		os.Exit(m.Run())
 	}
 

--- a/internal/discoveryservice/integration_tests/discovery_integration_test.go
+++ b/internal/discoveryservice/integration_tests/discovery_integration_test.go
@@ -37,17 +37,26 @@ import (
 )
 
 const composeFilePath = "./docker_compose/docker_compose.yml"
-const discoveryBaseURL = "http://127.0.0.1:6004"
 const actionShellsByAssetLinkMissingBody = "CHECK_SHELLSBYASSETLINK_MISSING_BODY"
 const actionLookupShellsNilBody = "CHECK_LOOKUPSHELLS_NIL_BODY"
+
+var discoveryBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
 
 func TestMain(m *testing.M) {
 	if os.Getenv("BASYX_EXTERNAL_COMPOSE") == "1" {
 		os.Exit(m.Run())
 	}
 
+	runtime := testenv.NewComposeRuntimeOrExit("discovery-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+	})
+	discoveryBaseURL = runtime.LocalURL("api")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:   composeFilePath,
+		ProjectName:   runtime.ProjectName,
+		Env:           runtime.Env(),
 		HealthURL:     discoveryBaseURL + "/health",
 		HealthTimeout: 2 * time.Minute,
 	}))

--- a/internal/discoveryservice/integration_tests/docker_compose/docker_compose.yml
+++ b/internal/discoveryservice/integration_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: postgres_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "5432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-5432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-discovery:
-    container_name: aas-discovery
     build:
       context: ../../../..
       dockerfile: ./cmd/discoveryservice/Dockerfile
@@ -32,7 +30,7 @@ services:
       - POSTGRES_CONNMAXLIFETIMEMINUTES=5
       - ABAC_ENABLED=false
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
@@ -40,7 +38,6 @@ services:
       - "localhost:host-gateway"
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/discoveryservice/integration_tests/it_config.json
+++ b/internal/discoveryservice/integration_tests/it_config.json
@@ -2,43 +2,43 @@
   {
     "context": "000 - Lookup Collection - GET /lookup/shells",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells",
     "expectedStatus": 200
   },
   {
     "context": "000.1 - Lookup Collection - POST /lookup/shells",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells",
     "expectedStatus": 405
   },
   {
     "context": "000.2 - Lookup Collection - DELETE /lookup/shells",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells",
     "expectedStatus": 405
   },
   {
     "context": "000.3 - Lookup Collection - GET /lookup/shells/ route not found",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/",
     "expectedStatus": 404
   },
   {
     "context": "000.4 - Lookup Collection - POST /lookup/shells/ route not found",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/",
     "expectedStatus": 404
   },
   {
     "context": "000.5 - Lookup Collection - DELETE /lookup/shells/ route not found",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/",
     "expectedStatus": 404
   },
   {
     "context": "001 - Search empty dataset",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=5",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=5",
     "data": "postBody/search_empty_array.json",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
@@ -46,63 +46,63 @@
   {
     "context": "002 - Create AAS A links set 1",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
     "data": "postBody/links_aasA_1.json",
     "expectedStatus": 201
   },
   {
     "context": "003 - Get AAS A links set 1",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
     "shouldMatch": "expected/lookup_aasA_1.json",
     "expectedStatus": 200
   },
   {
     "context": "004 - Replace AAS A links set 2",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
     "data": "postBody/links_aasA_2.json",
     "expectedStatus": 201
   },
   {
     "context": "005 - Get AAS A links set 2",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
     "shouldMatch": "expected/lookup_aasA_2.json",
     "expectedStatus": 200
   },
   {
     "context": "006 - Create AAS B",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0Om9pbC1yZWZpbmVyeQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0Om9pbC1yZWZpbmVyeQ",
     "data": "postBody/links_aasB.json",
     "expectedStatus": 201
   },
   {
     "context": "007 - Create AAS C",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OnJhaWwtc2lnbmFs",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OnJhaWwtc2lnbmFs",
     "data": "postBody/links_aasC.json",
     "expectedStatus": 201
   },
   {
     "context": "008 - Get AAS B",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0Om9pbC1yZWZpbmVyeQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0Om9pbC1yZWZpbmVyeQ",
     "shouldMatch": "expected/lookup_aasB.json",
     "expectedStatus": 200
   },
   {
     "context": "009 - Get AAS C",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OnJhaWwtc2lnbmFs",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OnJhaWwtc2lnbmFs",
     "shouldMatch": "expected/lookup_aasC.json",
     "expectedStatus": 200
   },
   {
     "context": "010 - Search by globalAssetId",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_globalAssetId_green.json",
     "shouldMatch": "expected/search_only_aasA.json",
     "expectedStatus": 200
@@ -110,7 +110,7 @@
   {
     "context": "011 - Search by serialNumber",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_serial_red.json",
     "shouldMatch": "expected/search_only_aasA.json",
     "expectedStatus": 200
@@ -118,7 +118,7 @@
   {
     "context": "012 - Search by plant",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_plant_spidertron.json",
     "shouldMatch": "expected/search_only_aasB.json",
     "expectedStatus": 200
@@ -126,7 +126,7 @@
   {
     "context": "013 - Search by two pairs",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_global_serial.json",
     "shouldMatch": "expected/search_only_aasA.json",
     "expectedStatus": 200
@@ -134,7 +134,7 @@
   {
     "context": "014 - Search no match",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_serial_nonexistent.json",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
@@ -142,19 +142,19 @@
   {
     "context": "015 - Delete AAS A",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
     "expectedStatus": 204
   },
   {
     "context": "016 - Get deleted AAS A",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmFzc2VtYmxlci0x",
     "expectedStatus": 404
   },
   {
     "context": "017 - Search globalAssetId after delete",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_globalAssetId_green.json",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
@@ -162,21 +162,21 @@
   {
     "context": "018 - Create AAS D",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmNvcHBlci1wbGF0ZQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmNvcHBlci1wbGF0ZQ",
     "data": "postBody/links_aasD.json",
     "expectedStatus": 201
   },
   {
     "context": "019 - Create AAS E",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0Omlyb24tZ2Vhcg",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0Omlyb24tZ2Vhcg",
     "data": "postBody/links_aasE.json",
     "expectedStatus": 201
   },
   {
     "context": "020 - Search shared tag",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_sharedTag_train_signal.json",
     "shouldMatch": "expected/search_shared_aasD_aasE.json",
     "expectedStatus": 200
@@ -184,7 +184,7 @@
   {
     "context": "021 - Search unique D",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_uniqueD.json",
     "shouldMatch": "expected/search_only_aasD.json",
     "expectedStatus": 200
@@ -192,7 +192,7 @@
   {
     "context": "022 - Search unique E",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_uniqueE.json",
     "shouldMatch": "expected/search_only_aasE.json",
     "expectedStatus": 200
@@ -200,7 +200,7 @@
   {
     "context": "023 - Search nonexistent pair",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_nonexistent.json",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
@@ -208,86 +208,86 @@
   {
     "context": "024 - Create AAS X links set 1",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
     "data": "postBody/links_aasX_1.json",
     "expectedStatus": 201
   },
   {
     "context": "025 - Get AAS X links set 1",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
     "shouldMatch": "expected/lookup_aasX_1.json",
     "expectedStatus": 200
   },
   {
     "context": "026 - Replace AAS X links set 2",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
     "data": "postBody/links_aasX_2.json",
     "expectedStatus": 201
   },
   {
     "context": "027 - Get AAS X links set 2",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
     "shouldMatch": "expected/lookup_aasX_2.json",
     "expectedStatus": 200
   },
   {
     "context": "028 - Delete AAS X",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
     "expectedStatus": 204
   },
   {
     "context": "029 - Get deleted AAS X",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
     "expectedStatus": 404
   },
   {
     "context": "030 - Delete AAS X again",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmJsdWUtc2NpZW5jZQ",
     "expectedStatus": 404
   },
   {
     "context": "031 - GET with non base64 AAS",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/urn:aas:not-encoded:crude-oil",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/urn:aas:not-encoded:crude-oil",
     "expectedStatus": 400
   },
   {
     "context": "032 - POST with non base64 AAS",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/urn:aas:not-encoded:crude-oil",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/urn:aas:not-encoded:crude-oil",
     "data": "postBody/links_bad_raw_aas.json",
     "expectedStatus": 400
   },
   {
     "context": "033 - DELETE with non base64 AAS",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/urn:aas:not-encoded:crude-oil",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/urn:aas:not-encoded:crude-oil",
     "expectedStatus": 400
   },
   {
     "context": "034 - Create pagination AAS P1",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmNvcHBlcg",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmNvcHBlcg",
     "data": "postBody/links_page_shared.json",
     "expectedStatus": 201
   },
   {
     "context": "035 - Create pagination AAS P2",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0Omlyb24",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0Omlyb24",
     "data": "postBody/links_page_shared.json",
     "expectedStatus": 201
   },
   {
     "context": "036 - POST pagination page 1",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=1",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=1",
     "data": "postBody/search_pagegroup.json",
     "shouldMatch": "expected/search_page_1.json",
     "expectedStatus": 200
@@ -295,7 +295,7 @@
   {
     "context": "037 - POST pagination page 2",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=1&cursor=dXJuOmFhczp0ZXN0Omlyb24",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=1&cursor=dXJuOmFhczp0ZXN0Omlyb24",
     "data": "postBody/search_pagegroup.json",
     "shouldMatch": "expected/search_page_2.json",
     "expectedStatus": 200
@@ -303,164 +303,164 @@
   {
     "context": "038 - Bad values in POST links",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmJhZC12YWx1ZXMtcG9zdA",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmJhZC12YWx1ZXMtcG9zdA",
     "data": "postBody/links_malformed_values.json",
     "expectedStatus": 400
   },
   {
     "context": "039 - Wrong shape object in POST links",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0Ondyb25nLXNoYXBlLXBvc3Q",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0Ondyb25nLXNoYXBlLXBvc3Q",
     "data": "postBody/links_wrong_shape_object.json",
     "expectedStatus": 400
   },
   {
     "context": "040 - Wrong shape string in POST links",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0Ondyb25nLXNoYXBlLXBvc3Q",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0Ondyb25nLXNoYXBlLXBvc3Q",
     "data": "postBody/links_wrong_shape_string.json",
     "expectedStatus": 400
   },
   {
     "context": "041 - Wrong shape null in POST links",
     "action": "CHECK_LOOKUPSHELLS_NIL_BODY",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0Ondyb25nLXNoYXBlLXBvc3Q",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0Ondyb25nLXNoYXBlLXBvc3Q",
     "expectedStatus": 400
   },
   {
     "context": "042 - Search wrong shape assetLinks string",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/search",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/search",
     "data": "postBody/search_wrong_shape_assetLinks_string.json",
     "expectedStatus": 400
   },
   {
     "context": "043 - Search wrong shape assetLinks items",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/search",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/search",
     "data": "postBody/search_wrong_shape_assetLinks_items.json",
     "expectedStatus": 400
   },
   {
     "context": "044 - Search wrong shape root array",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/search",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/search",
     "data": "postBody/search_wrong_shape_array.json",
     "expectedStatus": 400
   },
   {
     "context": "045 - Search wrong shape null",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/search",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/search",
     "data": "postBody/search_wrong_shape_null.json",
     "expectedStatus": 400
   },
   {
     "context": "046 - POST plain string body",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmVuY29kZWQtYW5kLXN0cmluZw",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmVuY29kZWQtYW5kLXN0cmluZw",
     "data": "postBody/links_plain_string.json",
     "expectedStatus": 400
   },
   {
     "context": "047 - Search encoded values bad",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/search",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/search",
     "data": "postBody/search_encoded_values_bad.json",
     "expectedStatus": 400
   },
   {
     "context": "048 - Wrong keys in POST links",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0Ondyb25nLWtleQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0Ondyb25nLWtleQ",
     "data": "postBody/links_wrong_key.json",
     "expectedStatus": 400
   },
   {
     "context": "049 - Empty name or value in POST links",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/dXJuOmFhczp0ZXN0OmVtcHR5LWZpZWxkcw",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/dXJuOmFhczp0ZXN0OmVtcHR5LWZpZWxkcw",
     "data": "postBody/links_empty_fields.json",
     "expectedStatus": 400
   },
   {
     "context": "050 - Search negative limit",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells/search",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/search",
     "data": "postBody/search_negative_limit.json",
     "expectedStatus": 400
   },
   {
     "context": "051 - Missing body on shellsByAssetLink",
     "action": "CHECK_SHELLSBYASSETLINK_MISSING_BODY",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "expectedStatus": 400
   },
   {
     "context": "052 - GET by assetIds single pair",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells?limit=10&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells?limit=10&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9",
     "shouldMatch": "expected/search_only_aasB.json",
     "expectedStatus": 200
   },
   {
     "context": "053 - GET by assetIds two pairs",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells?limit=10&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9&assetIds=eyJuYW1lIjoic2VyaWFsTnVtYmVyIiwidmFsdWUiOiJTTi1lbmdpbmUtdW5pdCJ9",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells?limit=10&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9&assetIds=eyJuYW1lIjoic2VyaWFsTnVtYmVyIiwidmFsdWUiOiJTTi1lbmdpbmUtdW5pdCJ9",
     "shouldMatch": "expected/search_only_aasB.json",
     "expectedStatus": 200
   },
   {
     "context": "054 - GET by assetIds two pairs repeated",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells?limit=10&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9&assetIds=eyJuYW1lIjoic2VyaWFsTnVtYmVyIiwidmFsdWUiOiJTTi1lbmdpbmUtdW5pdCJ9",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells?limit=10&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9&assetIds=eyJuYW1lIjoic2VyaWFsTnVtYmVyIiwidmFsdWUiOiJTTi1lbmdpbmUtdW5pdCJ9",
     "shouldMatch": "expected/search_only_aasB.json",
     "expectedStatus": 200
   },
   {
     "context": "055 - GET pagination page 1",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells?limit=1&assetIds=eyJuYW1lIjoicGFnZUdyb3VwIiwidmFsdWUiOiJzY2llbmNlLXBhY2stMyJ9",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells?limit=1&assetIds=eyJuYW1lIjoicGFnZUdyb3VwIiwidmFsdWUiOiJzY2llbmNlLXBhY2stMyJ9",
     "shouldMatch": "expected/search_page_1.json",
     "expectedStatus": 200
   },
   {
     "context": "056 - GET pagination page 2",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells?limit=1&assetIds=eyJuYW1lIjoicGFnZUdyb3VwIiwidmFsdWUiOiJzY2llbmNlLXBhY2stMyJ9&cursor=dXJuOmFhczp0ZXN0Omlyb24",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells?limit=1&assetIds=eyJuYW1lIjoicGFnZUdyb3VwIiwidmFsdWUiOiJzY2llbmNlLXBhY2stMyJ9&cursor=dXJuOmFhczp0ZXN0Omlyb24",
     "shouldMatch": "expected/search_page_2.json",
     "expectedStatus": 200
   },
   {
     "context": "057 - GET bad cursor",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells?limit=1&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9&cursor=not-base64!!!",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells?limit=1&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9&cursor=not-base64!!!",
     "expectedStatus": 400
   },
   {
     "context": "057.1 - GET nonexistent cursor",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells?limit=1&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9&cursor=dXJuOmFhczp0ZXN0Om5vdC1oZXJl",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells?limit=1&assetIds=eyJuYW1lIjoicGxhbnQiLCJ2YWx1ZSI6IlNQSURFUlRST04tWUFSRCJ9&cursor=dXJuOmFhczp0ZXN0Om5vdC1oZXJl",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "058 - POST bad cursor",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=1&cursor=not-base64!!!",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=1&cursor=not-base64!!!",
     "data": "postBody/search_bad_cursor_pair.json",
     "expectedStatus": 400
   },
   {
     "context": "059 - GET malformed assetIds",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/lookup/shells?limit=10&assetIds=%25%25ZZ-invalid",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells?limit=10&assetIds=%25%25ZZ-invalid",
     "expectedStatus": 400
   },
   {
     "context": "060 - Search empty assetLinks with non-empty dataset",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/lookup/shellsByAssetLink?limit=10",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink?limit=10",
     "data": "postBody/search_empty_array.json",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200

--- a/internal/discoveryservice/security_tests/discoveryservice_security_integration_test.go
+++ b/internal/discoveryservice/security_tests/discoveryservice_security_integration_test.go
@@ -36,11 +36,16 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 )
 
+var (
+	securityBaseURL          = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 5004)
+	securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+)
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -48,8 +53,23 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("discoveryservice-security", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker_compose.yml",
-		HealthURL:   "http://localhost:5004/health",
-	}))
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
+		HealthURL:   securityBaseURL + "/health",
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/discoveryservice/security_tests/docker_compose/docker_compose.yml
+++ b/internal/discoveryservice/security_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: postgres_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "5432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-5432}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   aas-discovery:
-    container_name: aas-discovery
     build:
       context: ../../../..
       dockerfile: ./cmd/discoveryservice/Dockerfile
@@ -34,28 +32,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "5004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-5004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -67,13 +64,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak-healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -87,7 +83,6 @@ services:
 
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/discoveryservice/security_tests/it_config.json
+++ b/internal/discoveryservice/security_tests/it_config.json
@@ -3,7 +3,7 @@
     "context": "Health endpoint - anonymous allowed",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:5004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "shouldMatch": "expected/expectedHealthEndpoint.json",
     "expectedStatus": 200
   },
@@ -11,56 +11,56 @@
     "context": "Description endpoint - anonymous allowed",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:5004/description",
+    "endpoint": "{{BASYX_IT_API_URL}}/description",
     "expectedStatus": 200
   },
   {
     "context": "Description endpoint - viewer allowed",
     "token": { "user": "vieweruser", "password": "admin" },
     "method": "GET",
-    "endpoint": "http://localhost:5004/description",
+    "endpoint": "{{BASYX_IT_API_URL}}/description",
     "expectedStatus": 200
   },
   {
     "context": "Shells GET - viewer with clear=3 allowed",
     "token": { "user": "vieweruser", "password": "admin" },
     "method": "GET",
-    "endpoint": "http://localhost:5004/lookup/shells/MT",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/MT",
     "expectedStatus": 404
   },
   {
     "context": "Shells collection GET trailing slash - viewer not found",
     "token": { "user": "vieweruser", "password": "admin" },
     "method": "GET",
-    "endpoint": "http://localhost:5004/lookup/shells/",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/",
     "expectedStatus": 404
   },
   {
     "context": "Shells GET trailing slash - viewer not found",
     "token": { "user": "vieweruser", "password": "admin" },
     "method": "GET",
-    "endpoint": "http://localhost:5004/lookup/shells/MT/",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/MT/",
     "expectedStatus": 404
   },
   {
     "context": "Shells GET - editor with clear=6 allowed",
     "token": { "user": "editoruser", "password": "admin" },
     "method": "GET",
-    "endpoint": "http://localhost:5004/lookup/shells/MT",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/MT",
     "expectedStatus": 404
   },
   {
     "context": "Shells GET - anonymous denied",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:5004/lookup/shells/MT",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/MT",
     "expectedStatus": 403
   },
   {
     "context": "Shells POST - viewer denied",
     "token": { "user": "vieweruser", "password": "admin" },
     "method": "POST",
-    "endpoint": "http://localhost:5004/lookup/shells/MT",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/MT",
     "data": "postBody/simple_specificAssetIds.json",
     "expectedStatus": 403
   },
@@ -68,7 +68,7 @@
     "context": "Shells POST - editor with clear=6 allowed",
     "token": { "user": "editoruser", "password": "admin" },
     "method": "POST",
-    "endpoint": "http://localhost:5004/lookup/shells/MT",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/MT",
     "data": "postBody/simple_specificAssetIds.json",
     "expectedStatus": 201
   },
@@ -76,7 +76,7 @@
     "context": "Shells POST - admin allowed",
     "token": { "user": "adminuser", "password": "admin" },
     "method": "POST",
-    "endpoint": "http://localhost:5004/lookup/shells/MT",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/MT",
     "data": "postBody/simple_specificAssetIds.json",
     "expectedStatus": 201
   },
@@ -84,7 +84,7 @@
     "context": "Shells DELETE - admin allowed (clear=10)",
     "token": { "user": "adminuser", "password": "admin" },
     "method": "DELETE",
-    "endpoint": "http://localhost:5004/lookup/shells/MT",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shells/MT",
     "expectedStatus": 204
   },
   {
@@ -92,7 +92,7 @@
     "token": { "user": "vieweruser", "password": "admin" },
     "data": "postBody/simple_specificAssetIds.json",
     "method": "POST",
-    "endpoint": "http://localhost:5004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "expectedStatus": 403
   },
   {
@@ -100,7 +100,7 @@
     "token": { "user": "editoruser", "password": "admin" },
     "data": "postBody/simple_specificAssetIds.json",
     "method": "POST",
-    "endpoint": "http://localhost:5004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "expectedStatus": 200
   },
   {
@@ -108,7 +108,7 @@
     "token": { "user": "editoruser", "password": "admin" },
     "data": "postBody/simple_specificAssetIds.json",
     "method": "POST",
-    "endpoint": "http://localhost:5004/lookup/shellsByAssetLink/",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink/",
     "expectedStatus": 404
   },
   {
@@ -116,7 +116,7 @@
     "token": { "user": "adminuser", "password": "admin" },
     "data": "postBody/simple_specificAssetIds.json",
     "method": "POST",
-    "endpoint": "http://localhost:5004/lookup/shellsByAssetLink",
+    "endpoint": "{{BASYX_IT_API_URL}}/lookup/shellsByAssetLink",
     "expectedStatus": 200
   }
 ]

--- a/internal/smregistry/integration_tests/docker_compose/docker_compose.yml
+++ b/internal/smregistry/integration_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db-it:
     image: postgres:18
-    container_name: postgres_db_sm
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "6433:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6433}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   sm-registry-it:
-    container_name: sm-registry-it
     build:
       context: ../../../..
       dockerfile: ./cmd/submodelregistryservice/Dockerfile
@@ -33,7 +31,7 @@ services:
       - ABAC_ENABLED=false
       - BASYX_HISTORY_MODE=api
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
@@ -43,7 +41,6 @@ services:
       - "localhost:host-gateway"
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/smregistry/integration_tests/it_config.json
+++ b/internal/smregistry/integration_tests/it_config.json
@@ -2,99 +2,99 @@
   {
     "context": "001 - Health Check - GET /health",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "shouldMatch": "expected/expectedHealthEndpoint.json",
     "expectedStatus": 200
   },
   {
     "context": "002 - List Submodel Descriptors (Empty) - GET /submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "002.1 - List Submodel Descriptors - GET /submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "expectedStatus": 200
   },
   {
     "context": "002.2 - Create Submodel Descriptor (Malformed) - POST /submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_malformed.json",
     "expectedStatus": 400
   },
   {
     "context": "002.3 - Replace Submodel Descriptor - PUT /submodel-descriptors",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 405
   },
   {
     "context": "002.4 - Delete Submodel Descriptor - DELETE /submodel-descriptors",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "expectedStatus": 405
   },
   {
     "context": "002.5 - List Submodel Descriptors - GET /submodel-descriptors/ route not found",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "002.6 - Create Submodel Descriptor - POST /submodel-descriptors/ route not found",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/",
     "data": "postBody/simple_submodel_descriptor_malformed.json",
     "expectedStatus": 404
   },
   {
     "context": "002.7 - Replace Submodel Descriptor - PUT /submodel-descriptors/ route not found",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/",
     "data": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 404
   },
   {
     "context": "002.8 - Delete Submodel Descriptor - DELETE /submodel-descriptors/ route not found",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/",
     "expectedStatus": 404
   },
   {
     "context": "003 - Get Submodel Descriptor by ID (Not Found) - GET /submodel-descriptors/{submodelId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
     "expectedStatus": 404
   },
   {
     "context": "004 - Get Submodel Descriptor by ID (Bad Encoded URL) - GET /submodel-descriptors/{badId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/HELLOWRONGENCODEDURL",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/HELLOWRONGENCODEDURL",
     "expectedStatus": 400
   },
   {
     "context": "005 - Replace Submodel Descriptor (ID Mismatch) - PUT /submodel-descriptors/{submodelId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
     "data": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 400
   },
   {
     "context": "006 - Create Submodel Descriptor (Missing Endpoints) - POST /submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_malformed.json",
     "expectedStatus": 400
   },
   {
     "context": "007 - Create Submodel Descriptor #1 - POST /submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_1.json",
     "shouldMatch": "postBody/simple_submodel_descriptor_1.json",
     "expectedStatus": 201
@@ -102,7 +102,7 @@
   {
     "context": "008 - Create Submodel Descriptor #2 - POST /submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_2.json",
     "shouldMatch": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 201
@@ -110,7 +110,7 @@
   {
     "context": "009 - Create Submodel Descriptor #3 - POST /submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_3.json",
     "shouldMatch": "postBody/simple_submodel_descriptor_3.json",
     "expectedStatus": 201
@@ -118,69 +118,69 @@
   {
     "context": "010 - Create Submodel Descriptor Duplicate (Conflict) - POST /submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_submodel_descriptor_1.json",
     "expectedStatus": 409
   },
   {
     "context": "011 - List Submodel Descriptors (All) - GET /submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/submodel_paged_all.json",
     "expectedStatus": 200
   },
   {
     "context": "012 - List Submodel Descriptors (limit=2) - GET /submodel-descriptors?limit=2",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors?limit=2",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors?limit=2",
     "shouldMatch": "expected/submodel_paged_limit2.json",
     "expectedStatus": 200
   },
   {
     "context": "013 - List Submodel Descriptors (cursor=...) - GET /submodel-descriptors?cursor=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors?cursor=dXJuOmV4YW1wbGU6c206MDAy",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors?cursor=dXJuOmV4YW1wbGU6c206MDAy",
     "shouldMatch": "expected/submodel_paged_cursor_002.json",
     "expectedStatus": 200
   },
   {
     "context": "013.1 - List Submodel Descriptors (Nonexistent Cursor) - GET /submodel-descriptors?cursor=...",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors?cursor=dXJuOmV4YW1wbGU6c206OTk5",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors?cursor=dXJuOmV4YW1wbGU6c206OTk5",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "014 - Get Submodel Descriptor by ID - GET /submodel-descriptors/{submodelId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAy",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAy",
     "shouldMatch": "postBody/simple_submodel_descriptor_2.json",
     "expectedStatus": 200
   },
   {
     "context": "015 - Replace Submodel Descriptor (204 No Content) - PUT /submodel-descriptors/{submodelId}",
     "method": "PUT",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAy",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAy",
     "data": "postBody/simple_submodel_descriptor_2_updated.json",
     "expectedStatus": 204
   },
   {
     "context": "016 - Get Submodel Descriptor by ID (Updated) - GET /submodel-descriptors/{submodelId}",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAy",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAy",
     "shouldMatch": "postBody/simple_submodel_descriptor_2_updated.json",
     "expectedStatus": 200
   },
   {
     "context": "017 - Delete Submodel Descriptor #1 - DELETE /submodel-descriptors/{submodelId}",
     "method": "DELETE",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/dXJuOmV4YW1wbGU6c206MDAx",
     "expectedStatus": 204
   },
   {
     "context": "018 - List Submodel Descriptors (After Delete) - GET /submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/submodel_paged_after_delete.json",
     "expectedStatus": 200
   },
@@ -191,28 +191,28 @@
   {
     "context": "020 - Verify Submodel Descriptors Empty - GET /submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   },
   {
     "context": "021 - Create Query Submodel Descriptor B - POST /submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/query_submodel_descriptor_b.json",
     "expectedStatus": 201
   },
   {
     "context": "022 - Create Query Submodel Descriptor C - POST /submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/query_submodel_descriptor_c.json",
     "expectedStatus": 201
   },
   {
     "context": "023 - Query Submodel Descriptors with Supplemental Semantic ID Filters - POST /query/submodel-descriptors",
     "method": "POST",
-    "endpoint": "http://127.0.0.1:6004/query/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/query/submodel-descriptors",
     "data": "postBody/query_submodel_descriptors_with_filters.json",
     "shouldMatch": "expected/query_submodel_descriptors_with_filters.json",
     "expectedStatus": 200
@@ -224,7 +224,7 @@
   {
     "context": "025 - Verify Query Submodel Descriptors Empty - GET /submodel-descriptors",
     "method": "GET",
-    "endpoint": "http://127.0.0.1:6004/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/empty_paged_result.json",
     "expectedStatus": 200
   }

--- a/internal/smregistry/integration_tests/smregistry_bulk_integration_test.go
+++ b/internal/smregistry/integration_tests/smregistry_bulk_integration_test.go
@@ -43,8 +43,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const smRegistryBaseURL = "http://127.0.0.1:6004"
-
 var smNoRedirectClient = &http.Client{
 	Timeout: 10 * time.Second,
 	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {

--- a/internal/smregistry/integration_tests/smregistry_integration_test.go
+++ b/internal/smregistry/integration_tests/smregistry_integration_test.go
@@ -42,10 +42,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var smRegistryBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
+
 func deleteAllSubmodelDescriptors(t *testing.T, runner *testenv.JSONSuiteRunner, stepNumber int) {
 	response, err := runner.RunStep(testenv.JSONSuiteStep{
 		Method:         http.MethodGet,
-		Endpoint:       "http://127.0.0.1:6004/submodel-descriptors",
+		Endpoint:       smRegistryBaseURL + "/submodel-descriptors",
 		ExpectedStatus: http.StatusOK,
 	}, stepNumber)
 	require.NoError(t, err)
@@ -61,7 +63,7 @@ func deleteAllSubmodelDescriptors(t *testing.T, runner *testenv.JSONSuiteRunner,
 		enc := base64.RawURLEncoding.EncodeToString([]byte(item.ID))
 		_, err := runner.RunStep(testenv.JSONSuiteStep{
 			Method:         http.MethodDelete,
-			Endpoint:       fmt.Sprintf("http://127.0.0.1:6004/submodel-descriptors/%s", enc),
+			Endpoint:       fmt.Sprintf("%s/submodel-descriptors/%s", smRegistryBaseURL, enc),
 			ExpectedStatus: http.StatusNoContent,
 		}, stepNumber)
 		require.NoError(t, err)
@@ -285,9 +287,17 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
+	runtime := testenv.NewComposeRuntimeOrExit("smregistry-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+	})
+	smRegistryBaseURL = runtime.LocalURL("api")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:   "docker_compose/docker_compose.yml",
-		HealthURL:     "http://127.0.0.1:6004/health",
+		ProjectName:   runtime.ProjectName,
+		Env:           runtime.Env(),
+		HealthURL:     smRegistryBaseURL + "/health",
 		HealthTimeout: 2 * time.Minute,
 	}))
 }

--- a/internal/smregistry/integration_tests/smregistry_integration_test.go
+++ b/internal/smregistry/integration_tests/smregistry_integration_test.go
@@ -284,6 +284,9 @@ func TestIntegration(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	if os.Getenv("BASYX_EXTERNAL_COMPOSE") == "1" {
+		testenv.SetEnvDefaultsOrExit(map[string]string{
+			"BASYX_IT_API_URL": smRegistryBaseURL,
+		})
 		os.Exit(m.Run())
 	}
 

--- a/internal/smregistry/security_tests/docker_compose/docker_compose.yml
+++ b/internal/smregistry/security_tests/docker_compose/docker_compose.yml
@@ -1,13 +1,12 @@
 services:
   db:
     image: postgres:18
-    container_name: postgres_db_sm_security
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     ports:
-      - "6435:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6435}:5432"
     command: ["postgres", "-c", "listen_addresses=*"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   sm-registry-security:
-    container_name: sm-registry-security
     build:
       context: ../../../..
       dockerfile: ./cmd/submodelregistryservice/Dockerfile
@@ -35,28 +33,27 @@ services:
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
       - BASYX_HISTORY_MODE=api
     ports:
-      - "6005:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6005}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: keycloak_smregistry_security
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -68,13 +65,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ./keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: keycloak_healthcheck_smregistry_security
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -86,7 +82,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/smregistry/security_tests/it_config.json
+++ b/internal/smregistry/security_tests/it_config.json
@@ -3,7 +3,7 @@
     "context": "Health endpoint - anonymous allowed",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6005/health",
+    "endpoint": "{{BASYX_IT_API_URL}}/health",
     "shouldMatch": "expected/expectedHealthEndpoint.json",
     "expectedStatus": 200
   },
@@ -12,7 +12,7 @@
     "context": "POST Submodel A - ANON - DENIED",
     "token": null,
     "method": "POST",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_smd_a.json",
     "expectedStatus": 403
   },
@@ -20,7 +20,7 @@
     "context": "POST Submodel A - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_smd_a.json",
     "expectedStatus": 201
   },
@@ -28,7 +28,7 @@
     "context": "POST Submodel B - User X - DENIED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_smd_b.json",
     "expectedStatus": 403
   },
@@ -37,7 +37,7 @@
     "action": "ASSERT_BULK_FAILURE",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/bulk/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/bulk/submodel-descriptors",
     "data": "postBody/bulk_create_smd_b.json",
     "expectedStatus": 202,
     "expectedBulkFailureStatus": 403,
@@ -48,7 +48,7 @@
     "context": "POST Submodel D - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_smd_d.json",
     "expectedStatus": 201
   },
@@ -56,7 +56,7 @@
     "context": "POST Submodel B - User Y - ALLOWED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_smd_b.json",
     "expectedStatus": 201
   },
@@ -64,7 +64,7 @@
     "context": "POST Submodel C - User Y - ALLOWED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_smd_c.json",
     "expectedStatus": 201
   },
@@ -72,7 +72,7 @@
     "context": "POST Submodel X - ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "data": "postBody/simple_smd_x.json",
     "expectedStatus": 201
   },
@@ -81,7 +81,7 @@
     "context": "GET Submodel A - ANON - ALLOWED",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE",
     "shouldMatch": "expected/expected_smd_a.json",
     "expectedStatus": 200
   },
@@ -89,21 +89,21 @@
     "context": "GET Submodel A trailing slash - ANON - NOT FOUND",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUE/",
     "expectedStatus": 404
   },
   {
     "context": "GET Submodel B - ANON - DENIED",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI",
     "expectedStatus": 404
   },
   {
     "context": "GET Submodel B - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUI",
     "shouldMatch": "expected/expected_smd_b.json",
     "expectedStatus": 200
   },
@@ -111,14 +111,14 @@
     "context": "GET Submodel C - User A - DENIED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUM",
     "expectedStatus": 404
   },
   {
     "context": "GET Submodel D - User B - ALLOWED",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLUQ",
     "shouldMatch": "expected/expected_smd_d.json",
     "expectedStatus": 200
   },
@@ -126,14 +126,14 @@
     "context": "GET Submodel X - User B - DENIED",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
     "expectedStatus": 404
   },
   {
     "context": "GET Submodel X - ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
     "shouldMatch": "expected/expected_smd_x.json",
     "expectedStatus": 200
   },
@@ -142,7 +142,7 @@
     "context": "GET ALL Submodels - ANON - ALLOWED",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/expectedSMDAnon.json",
     "expectedStatus": 200
   },
@@ -150,7 +150,7 @@
     "context": "GET ALL Submodels trailing slash - ANON - NOT FOUND",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/",
     "expectedStatus": 404
   },
   {
@@ -158,7 +158,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors?limit=20",
     "shouldMatch": "expected/expectedRecentChangesAnonDescriptorIDs.json",
     "expectedStatus": 200
   },
@@ -166,14 +166,14 @@
     "context": "GET /submodel-descriptors/ - ANON - NOT FOUND",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/?limit=20",
     "expectedStatus": 404
   },
   {
     "context": "GET ALL Submodels - User A - ALLOWED",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/expectedSMDUserA.json",
     "expectedStatus": 200
   },
@@ -182,7 +182,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors?limit=20",
     "shouldMatch": "expected/expectedRecentChangesUserADescriptorIDs.json",
     "expectedStatus": 200
   },
@@ -190,7 +190,7 @@
     "context": "GET ALL Submodels - User B - ALLOWED",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/expectedSMDUserB.json",
     "expectedStatus": 200
   },
@@ -199,7 +199,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors?limit=20",
     "shouldMatch": "expected/expectedRecentChangesUserBDescriptorIDs.json",
     "expectedStatus": 200
   },
@@ -207,7 +207,7 @@
     "context": "GET ALL Submodels - User X - ALLOWED",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/expectedSMDUserX.json",
     "expectedStatus": 200
   },
@@ -215,7 +215,7 @@
     "context": "GET ALL Submodels - User Y - ALLOWED",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/expectedSMDUserY.json",
     "expectedStatus": 200
   },
@@ -223,7 +223,7 @@
     "context": "GET ALL Submodels - ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors",
     "shouldMatch": "expected/expectedSMDAdmin.json",
     "expectedStatus": 200
   },
@@ -232,7 +232,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors?limit=20",
     "shouldMatch": "expected/expectedRecentChangesAdminDescriptorIDs.json",
     "expectedStatus": 200
   },
@@ -241,7 +241,7 @@
     "context": "PUT Submodel X - ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
     "data": "postBody/simple_smd_x_updated.json",
     "expectedStatus": 204
   },
@@ -249,7 +249,7 @@
     "context": "GET Submodel X - ADMIN - Updated",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
     "shouldMatch": "postBody/simple_smd_x_updated.json",
     "expectedStatus": 200
   },
@@ -257,14 +257,14 @@
     "context": "DELETE Submodel X - ADMIN - ALLOWED",
     "token": { "user": "admin", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
     "expectedStatus": 204
   },
   {
     "context": "GET Submodel X - ADMIN - After Delete",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6005/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodel-descriptors/aHR0cHM6Ly9leGFtcGxlLm9yZy9YL1NNLVg",
     "expectedStatus": 404
   }
 ]

--- a/internal/smregistry/security_tests/smregistry_security_integration_test.go
+++ b/internal/smregistry/security_tests/smregistry_security_integration_test.go
@@ -40,11 +40,16 @@ import (
 
 const actionAssertRecentChangeIDs = "ASSERT_RECENT_CHANGE_IDS"
 
+var (
+	securityBaseURL          = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6005)
+	securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+)
+
 func TestIntegration(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		DefaultExpectedStatus: http.StatusOK,
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -97,8 +102,23 @@ func extractRecentChangeIDs(t *testing.T, responseBody string) []string {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("smregistry-security", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile: "docker_compose/docker_compose.yml",
-		HealthURL:   "http://localhost:6005/health",
-	}))
+		ProjectName: runtime.ProjectName,
+		Env:         runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
+		HealthURL:   securityBaseURL + "/health",
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/submodelrepository/integration_tests/delegation_operation_integration_test.go
+++ b/internal/submodelrepository/integration_tests/delegation_operation_integration_test.go
@@ -156,7 +156,7 @@ func TestDelegationOperation(t *testing.T) {
 		t.Skip("delegation callback from container to ephemeral host listener is not reliable in external compose mode")
 	}
 
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 
 	delegationURL, shutdown := startAdderMicroservice(t)
 	defer shutdown()

--- a/internal/submodelrepository/integration_tests/docker_compose/docker_compose.yml
+++ b/internal/submodelrepository/integration_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db_it:
     image: postgres:18
-    container_name: postgres_db_it
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -38,7 +37,7 @@ services:
     volumes:
       - ./rsa-key.pem:/app/rsa-key.pem:ro
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     extra_hosts:
       - "localhost:host-gateway"
       - "host.docker.internal:host-gateway"
@@ -66,11 +65,11 @@ services:
       - JWS_PRIVATEKEYPATH=/app/rsa-key.pem
       - SERVER_STRICTVERIFICATION=off
       - GENERAL_SUBMODELREGISTRYINTEGRATION=true
-      - GENERAL_EXTERNALURL=http://127.0.0.1:6008
+      - GENERAL_EXTERNALURL=http://127.0.0.1:${BASYX_IT_SYNC_API_PORT:-6008}
     volumes:
       - ./rsa-key.pem:/app/rsa-key.pem:ro
     ports:
-      - "6008:5004"
+      - "127.0.0.1:${BASYX_IT_SYNC_API_PORT:-6008}:5004"
     command: ["/app/submodelrepositoryservice", "-config", "/config/config.yaml"]
     extra_hosts:
       - "localhost:host-gateway"
@@ -96,9 +95,9 @@ services:
       - POSTGRES_CONNMAXLIFETIMEMINUTES=5
       - SERVER_STRICTVERIFICATION=off
       - GENERAL_AASREGISTRYINTEGRATION=true
-      - GENERAL_EXTERNALURL=http://127.0.0.1:6006
+      - GENERAL_EXTERNALURL=http://127.0.0.1:${BASYX_IT_AAS_API_PORT:-6006}
     ports:
-      - "6006:5004"
+      - "127.0.0.1:${BASYX_IT_AAS_API_PORT:-6006}:5004"
     command: ["/app/aasrepositoryservice", "-config", "/config/config.yaml"]
     depends_on:
       basyx_configuration:
@@ -127,7 +126,7 @@ services:
     volumes:
       - ./rsa-key.pem:/app/rsa-key.pem:ro
     ports:
-      - "6007:5004"
+      - "127.0.0.1:${BASYX_IT_INVALID_API_PORT:-6007}:5004"
     command: ["/app/submodelrepositoryservice", "-config", "/config/config.yaml"]
     extra_hosts:
       - "localhost:host-gateway"
@@ -138,7 +137,6 @@ services:
         condition: service_healthy
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/submodelrepository/integration_tests/it_config.json
+++ b/internal/submodelrepository/integration_tests/it_config.json
@@ -2,38 +2,38 @@
     {
         "context": "Health endpoint",
         "method": "GET",
-        "endpoint": "http://localhost:6004/health",
+        "endpoint": "{{BASYX_IT_API_URL}}/health",
         "shouldMatch": "expected/expectedHealthEndpoint.json",
         "expectedStatus": 200
     },
     {
         "context": "Description endpoint",
         "method": "GET",
-        "endpoint": "http://localhost:6004/description",
+        "endpoint": "{{BASYX_IT_API_URL}}/description",
         "expectedStatus": 200
     },
     {
         "context": "Get All Submodels",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "expectedStatus": 200
     },
     {
         "context": "Replace Submodel",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "expectedStatus": 405
     },
     {
         "context": "Delete Submodel",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "expectedStatus": 405
     },
     {
         "context": "Post Submodel",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodel.json",
         "shouldMatch": "bodies/post/postSubmodel.json",
         "expectedStatus": 201
@@ -41,2041 +41,2041 @@
     {
         "context": "Get All Submodels Trailing Slash",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/",
         "expectedStatus": 404
     },
     {
         "context": "Replace Submodel Trailing Slash",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/",
         "expectedStatus": 404
     },
     {
         "context": "Delete Submodel Trailing Slash",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/submodels/",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/",
         "expectedStatus": 404
     },
     {
         "context": "Post Submodel Trailing Slash",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/",
         "data": "bodies/post/postSubmodel.json",
         "expectedStatus": 404
     },
     {
         "context": "Get All Submodels (Nonexistent Cursor)",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels?cursor=ZG9lcy1ub3QtZXhpc3Q",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels?cursor=ZG9lcy1ub3QtZXhpc3Q",
         "shouldMatch": "expected/empty_paged_result.json",
         "expectedStatus": 200
     },
     {
         "context": "Create Top Level Property",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postTopLevelProperty.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Top Level Property",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
         "shouldMatch": "expected/expectedGetTopLevelProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "Get All Submodels Reference",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/$reference",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/$reference",
         "shouldMatch": "expected/expectedGetAllSubmodelsReference.json",
         "expectedStatus": 200
     },
     {
         "context": "Get All Submodels Reference (Nonexistent Cursor)",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/$reference?cursor=ZG9lcy1ub3QtZXhpc3Q",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/$reference?cursor=ZG9lcy1ub3QtZXhpc3Q",
         "shouldMatch": "expected/empty_paged_result.json",
         "expectedStatus": 200
     },
     {
         "context": "Get All Submodel Elements Reference",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/$reference",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/$reference",
         "shouldMatch": "expected/expectedGetAllSubmodelElementsReference.json",
         "expectedStatus": 200
     },
     {
         "context": "Get All Submodel Elements Reference (Nonexistent Cursor)",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/$reference?cursor=ZG9lcy1ub3QtZXhpc3Q",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/$reference?cursor=ZG9lcy1ub3QtZXhpc3Q",
         "shouldMatch": "expected/empty_paged_result.json",
         "expectedStatus": 200
     },
     {
         "context": "Pagination valid",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "shouldMatch": "expected/expectedGetAllSMEWithPagination.json",
         "expectedStatus": 200
     },
     {
         "context": "Pagination nonexistent cursor",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements?cursor=ZG9lcy1ub3QtZXhpc3Q",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements?cursor=ZG9lcy1ub3QtZXhpc3Q",
         "shouldMatch": "expected/empty_paged_result.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT - Update Top Level Property",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
         "data": "bodies/put/putTopLevelProperty.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Updated Top Level Property",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
         "shouldMatch": "bodies/put/putTopLevelProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT - Update SubmodelElement",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
         "data": "bodies/put/putTopLevelPropertySubmodelElement.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Updated SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
         "shouldMatch": "bodies/put/putTopLevelPropertySubmodelElement.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT - Revert Top Level Property",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
         "data": "bodies/put/putTopLevelProperty.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Reverted Top Level Property",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
         "shouldMatch": "bodies/put/putTopLevelProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "Delete item in nested structure",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNestedStructure.json",
         "expectedStatus": 201
     },
     {
         "context": "Delete item in nested structure",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/1.2.3.4.5.6[0]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/1.2.3.4.5.6[0]",
         "data": "bodies/post/postNestedStructure.json",
         "expectedStatus": 204
     },
     {
         "context": "Delete item in nested structure - Delete non-existing item",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/1.2.3.4.5.6[3]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/1.2.3.4.5.6[3]",
         "data": "bodies/post/postNestedStructure.json",
         "expectedStatus": 404
     },
     {
         "context": "Delete item in nested structure",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/1",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/1",
         "shouldMatch": "expected/expectedNestedStructureAfterDeleteListItem.json",
         "expectedStatus": 200
     },
     {
         "context": "Delete item in nested structure",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/1.2.3.4.5.6[0]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/1.2.3.4.5.6[0]",
         "shouldMatch": "expected/expectedItemInListAfterDelete.json",
         "expectedStatus": 200
     },
     {
         "context": "Delete Top Level Property",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
         "expectedStatus": 204
     },
     {
         "context": "Get Deleted Top Level Property",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/myTopLevelProperty",
         "expectedStatus": 404
     },
     {
         "context": "Get SMEs From nonexisting Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWwx/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWwx/submodel-elements",
         "expectedStatus": 404
     },
     {
         "context": "Create Full Submodel Elements Json",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postFullSME.json",
         "expectedStatus": 201
     },
     {
         "context": "Post Full Submodel",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postFullSM.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Full Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2FjcGx0Lm9yZy9TdWJtb2RlbHMvQXNzZXRzL1Rlc3RBc3NldC9JZGVudGlmaWNhdGlvbg",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2FjcGx0Lm9yZy9TdWJtb2RlbHMvQXNzZXRzL1Rlc3RBc3NldC9JZGVudGlmaWNhdGlvbg",
         "shouldMatch": "expected/expectedGetFullSM.json",
         "expectedStatus": 200
     },
     {
         "context": "Delete Full Submodel",
         "method": "DELETE",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2FjcGx0Lm9yZy9TdWJtb2RlbHMvQXNzZXRzL1Rlc3RBc3NldC9JZGVudGlmaWNhdGlvbg",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2FjcGx0Lm9yZy9TdWJtb2RlbHMvQXNzZXRzL1Rlc3RBc3NldC9JZGVudGlmaWNhdGlvbg",
         "expectedStatus": 204
     },
     {
         "context": "Get Deleted Full Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2FjcGx0Lm9yZy9TdWJtb2RlbHMvQXNzZXRzL1Rlc3RBc3NldC9JZGVudGlmaWNhdGlvbg",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2FjcGx0Lm9yZy9TdWJtb2RlbHMvQXNzZXRzL1Rlc3RBc3NldC9JZGVudGlmaWNhdGlvbg",
         "expectedStatus": 404
     },
     {
         "context": "GET Get Submodels Metadata with limit",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/$metadata?limit=5",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/$metadata?limit=5",
         "shouldMatch": "expected/expectedGetSubmodelsMetadata.json",
         "expectedStatus": 200
     },
     {
         "context": "GET Get Submodel by Id",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw?extent=withBlobValue",
         "shouldMatch": "expected/expectedGetSubmodelById.json",
         "expectedStatus": 200
     },
     {
         "context": "GET Get non-existing Submodel by Id",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2V4YW1wbGUuY29tL2lkL25vbnRoaW5n",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2V4YW1wbGUuY29tL2lkL25vbnRoaW5n",
         "expectedStatus": 404
     },
     {
         "context": "Post heavy Submodel",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies//heavySubmodel.json",
         "expectedStatus": 201
     },
     {
         "context": "Get heavy Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw",
         "shouldMatch": "bodies//heavySubmodel.json",
         "expectedStatus": 200
     },
     {
         "context": "Post minimal Administration Submodel",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies//submodelMinimalAdministration.json",
         "expectedStatus": 201
     },
     {
         "context": "Get minimal Administration Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU1pbmltYWxBZG1pbmlzdHJhdGlvblN1Ym1vZGVs",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU1pbmltYWxBZG1pbmlzdHJhdGlvblN1Ym1vZGVs",
         "shouldMatch": "bodies//submodelMinimalAdministration.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Submodel with Operation SubmodelElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodelWithOperation.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Submodel with Operation SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlPcGVyYXRpb25TdWJtb2RlbA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlPcGVyYXRpb25TdWJtb2RlbA",
         "shouldMatch": "bodies/post/postSubmodelWithOperation.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Submodel with Entity SubmodelElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodelWithEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Submodel with Entity SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA",
         "shouldMatch": "bodies/post/postSubmodelWithEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "Get All SubmodelElements Deep - Entity Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements?level=deep",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements?level=deep",
         "shouldMatch": "expected/expectedGetAllSubmodelElementsEntityDeep.json",
         "expectedStatus": 200
     },
     {
         "context": "Get All SubmodelElements Core - Entity Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements?level=core",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements?level=core",
         "shouldMatch": "expected/expectedGetAllSubmodelElementsEntityCore.json",
         "expectedStatus": 200
     },
     {
         "context": "Get Submodel with Entity SubmodelElement - Get Statement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity.StatementProperty1",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity.StatementProperty1",
         "shouldMatch": "expected/expectedEntityProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT - Update Entity",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity",
         "data": "bodies/put/putEntity.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Updated Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity",
         "shouldMatch": "bodies/put/putEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "GET - Verify Entity Statement Was Replaced",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity.UpdatedStatementProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity.UpdatedStatementProperty",
         "shouldMatch": "expected/expectedEntityUpdatedProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "GET - Verify Old Entity Statement Was Deleted",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity.StatementProperty1",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity.StatementProperty1",
         "expectedStatus": 404
     },
     {
         "context": "PUT - Revert Entity",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity",
         "data": "bodies/put/putEntityRevert.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Reverted Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlFbnRpdHlTdWJtb2RlbA/submodel-elements/DemoEntity",
         "shouldMatch": "bodies/put/putEntityRevert.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Submodel with Capability SubmodelElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodelWithCapability.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Submodel with Capability SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlDYXBhYmlsaXR5U3VibW9kZWw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlDYXBhYmlsaXR5U3VibW9kZWw",
         "shouldMatch": "bodies/post/postSubmodelWithCapability.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Submodel with RelationshipElement SubmodelElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodelWithRelationshipElement.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Submodel with RelationshipElement SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
         "shouldMatch": "bodies/post/postSubmodelWithRelationshipElement.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Submodel with AnnotatedRelationshipElement SubmodelElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodelWithAnnotatedRelationshipElement.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Submodel with AnnotatedRelationshipElement SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
         "shouldMatch": "bodies/post/postSubmodelWithAnnotatedRelationshipElement.json",
         "expectedStatus": 200
     },
     {
         "context": "Get Submodel with AnnotatedRelationshipElement SubmodelElement - Get Annotation",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement.AnnotationProperty1",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement.AnnotationProperty1",
         "shouldMatch": "expected/expectedAREProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Submodel with ReferenceElement SubmodelElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodelWithReferenceElement.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Submodel with ReferenceElement SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw",
         "shouldMatch": "bodies/post/postSubmodelWithReferenceElement.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Submodel with Range SubmodelElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodelWithRangeElement.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Submodel with Range SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs",
         "shouldMatch": "bodies/post/postSubmodelWithRangeElement.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Submodel with File SubmodelElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodelWithFile.json",
         "expectedStatus": 201
     },
     {
         "context": "Get Submodel with File SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q",
         "shouldMatch": "bodies/post/postSubmodelWithFile.json",
         "expectedStatus": 200
     },
     {
         "context": "Get File SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile",
         "shouldMatch": "expected/expectedFileSubmodelElement.json",
         "expectedStatus": 200
     },
     {
         "context": "Get SubmodelElements",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements",
         "shouldMatch": "expected/expectedSubmodelElements.json",
         "expectedStatus": 200
     },
     {
         "context": "Get All Submodels ValueOnly",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/$value?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/$value?extent=withBlobValue",
         "shouldMatch": "expected/expectedAllSubmodelsValueOnly.json",
         "expectedStatus": 200
     },
     {
         "context": "Get Heavy Submodel ValueOnly",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/$value",
         "shouldMatch": "expected/expectedHeavySubmodelValueOnly.json",
         "expectedStatus": 200
     },
     {
         "context": "Get Minimal Administration Submodel ValueOnly",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU1pbmltYWxBZG1pbmlzdHJhdGlvblN1Ym1vZGVs/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU1pbmltYWxBZG1pbmlzdHJhdGlvblN1Ym1vZGVs/$value",
         "shouldMatch": "expected/expectedMinimalAdministrationSubmodelValueOnly.json",
         "expectedStatus": 200
     },
     {
         "context": "Get All Submodel Elements ValueOnly - Heavy Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/$value",
         "shouldMatch": "expected/expectedHeavySubmodelElementsValueOnly.json",
         "expectedStatus": 200
     },
     {
         "context": "Get ManufacturerName Property ValueOnly",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/ManufacturerName/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/ManufacturerName/$value",
         "shouldMatch": "expected/expectedManufacturerNameValueOnly.json",
         "expectedStatus": 200
     },
     {
         "context": "Get ProductSerialNumber Collection ValueOnly",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/ProductSerialNumber/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/ProductSerialNumber/$value",
         "shouldMatch": "expected/expectedProductSerialNumberValueOnly.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH SubmodelElement - Existing Property Partial Update",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
         "data": "bodies/patch/patchSubmodelElementPropertyPartial.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH SubmodelElement - Verify Property Partial Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
         "shouldMatch": "expected/expectedSubmodelElementPropertyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH SubmodelElement - Non Existing Element",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ThisElementDoesNotExist",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ThisElementDoesNotExist",
         "data": "bodies/patch/patchSubmodelElementPropertyPartial.json",
         "expectedStatus": 404
     },
     {
         "context": "PATCH SubmodelElement - Malformed SubmodelIdentifier",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/not-base64/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/not-base64/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
         "data": "bodies/patch/patchSubmodelElementPropertyPartial.json",
         "expectedStatus": 400
     },
     {
         "context": "PATCH Property ValueOnly - Update ProductModelName",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/ProductModelName/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/ProductModelName/$value",
         "data": "bodies/patch/patchPropertyValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH Property ValueOnly - Verify ProductModelName Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/ProductModelName/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQUhlYXZ5U3VibW9kZWw/submodel-elements/ProductModelName/$value",
         "shouldMatch": "expected/expectedPropertyValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH MultiLanguageProperty ValueOnly - Update ExampleMultiLanguageProperty",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]/$value",
         "data": "bodies/patch/patchMultiLanguagePropertyValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH MultiLanguageProperty ValueOnly - Verify ExampleMultiLanguageProperty Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]/$value",
         "shouldMatch": "expected/expectedMultiLanguagePropertyValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH Range ValueOnly - Update DemoRange",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs/submodel-elements/DemoRange/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs/submodel-elements/DemoRange/$value",
         "data": "bodies/patch/patchRangeValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH Range ValueOnly - Verify DemoRange Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs/submodel-elements/DemoRange/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs/submodel-elements/DemoRange/$value",
         "shouldMatch": "expected/expectedRangeValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH ReferenceElement ValueOnly - Update DemoOperation",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw/submodel-elements/DemoReferenceElement/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw/submodel-elements/DemoReferenceElement/$value",
         "data": "bodies/patch/patchReferenceElementValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH ReferenceElement ValueOnly - Verify DemoOperation Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw/submodel-elements/DemoReferenceElement/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw/submodel-elements/DemoReferenceElement/$value",
         "shouldMatch": "expected/expectedReferenceElementValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH File ValueOnly - Update DemoFile",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/$value",
         "data": "bodies/patch/patchFileValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH File ValueOnly - Verify DemoFile Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/$value",
         "shouldMatch": "expected/expectedFileValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH Blob ValueOnly - Update ExampleBlob",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementCollection.ExampleBlob/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementCollection.ExampleBlob/$value",
         "data": "bodies/patch/patchBlobValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH Blob ValueOnly - Verify ExampleBlob Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementCollection.ExampleBlob/$value?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementCollection.ExampleBlob/$value?extent=withBlobValue",
         "shouldMatch": "expected/expectedBlobValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH RelationshipElement ValueOnly - Update DemoRelationshipElement",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement/$value",
         "data": "bodies/patch/patchRelationshipElementValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH RelationshipElement ValueOnly - Verify DemoRelationshipElement Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement/$value",
         "shouldMatch": "expected/expectedRelationshipElementValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH AnnotatedRelationshipElement ValueOnly - Update DemoAnnotatedRelationshipElement",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement/$value",
         "data": "bodies/patch/patchAnnotatedRelationshipElementValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH AnnotatedRelationshipElement ValueOnly - Verify DemoAnnotatedRelationshipElement Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement/$value",
         "shouldMatch": "expected/expectedAnnotatedRelationshipElementValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH SubmodelElementCollection ValueOnly - Update ExampleSubmodelElementCollection",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection/$value",
         "data": "bodies/patch/patchSubmodelElementCollectionValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH SubmodelElementCollection ValueOnly - Verify ExampleSubmodelElementCollection Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection/$value?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection/$value?extent=withBlobValue",
         "shouldMatch": "expected/expectedSubmodelElementCollectionValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH SubmodelElementList ValueOnly - Update ExampleSubmodelElementListOrdered",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered/$value",
         "data": "bodies/patch/patchSubmodelElementListValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH SubmodelElementList ValueOnly - Verify ExampleSubmodelElementListOrdered Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered/$value",
         "shouldMatch": "expected/expectedSubmodelElementListValueOnlyAfterPatch.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH Submodel ValueOnly - Non Existing Submodel",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/SmFubmlrU2F5c1RoaXNTdWJtb2RlbERvZXNudEV4aXN0c1NvTnVoVWhoaA/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/SmFubmlrU2F5c1RoaXNTdWJtb2RlbERvZXNudEV4aXN0c1NvTnVoVWhoaA/$value",
         "data": "bodies/patch/patchSubmodelValueOnly.json",
         "expectedStatus": 404
     },
     {
         "context": "PATCH Submodel ValueOnly - Existing Submodel",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value",
         "data": "bodies/patch/patchSubmodelValueOnly.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH Submodel ValueOnly - Verify Patch Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value?extent=withBlobValue",
         "shouldMatch": "bodies/patch/patchSubmodelValueOnly.json",
         "expectedStatus": 200
     },
     {
         "context": "PATCH Submodel ValueOnly - Existing Submodel Non-Existent SME",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value",
         "data": "bodies/patch/patchSubmodelValueOnlyNonExistingSME.json",
         "expectedStatus": 404
     },
     {
         "context": "PATCH Submodel - Non Existing Submodel",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/SmFubmlrU2F5c1RoaXNTdWJtb2RlbERvZXNudEV4aXN0c1NvTnVoVWhoaA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/SmFubmlrU2F5c1RoaXNTdWJtb2RlbERvZXNudEV4aXN0c1NvTnVoVWhoaA",
         "data": "bodies/patch/patchSubmodelByIDNotFound.json",
         "expectedStatus": 404
     },
     {
         "context": "PATCH Submodel - Malformed SubmodelIdentifier",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/not-base64",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/not-base64",
         "data": "bodies/patch/patchSubmodelByIDTopLevelCategory.json",
         "expectedStatus": 400
     },
     {
         "context": "PATCH Submodel - Path and Body ID Mismatch",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw",
         "data": "bodies/patch/patchSubmodelByIDIdMismatch.json",
         "expectedStatus": 400
     },
     {
         "context": "PATCH Submodel - Existing Submodel Top-Level Partial Update",
         "method": "PATCH",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw",
         "data": "bodies/patch/patchSubmodelByIDTopLevelCategory.json",
         "expectedStatus": 204
     },
     {
         "context": "PATCH Submodel - Verify SubmodelElements are preserved",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value?extent=withBlobValue",
         "shouldMatch": "bodies/patch/patchSubmodelValueOnly.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT Submodel - Update existing Submodel",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw",
         "data": "bodies/put/putSubmodelUpdate.json",
         "expectedStatus": 204
     },
     {
         "context": "PUT Submodel - Verify updated Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw?extent=withBlobValue",
         "shouldMatch": "expected/expectedSubmodelAfterPutUpdate.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT Submodel - Create Submodel",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/QmFTeXg",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/QmFTeXg",
         "data": "bodies/put/putSubmodelCreate.json",
         "expectedStatus": 201
     },
     {
         "context": "PUT Submodel - Verify created Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/QmFTeXg?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/QmFTeXg?extent=withBlobValue",
         "shouldMatch": "expected/expectedSubmodelAfterPutCreate.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT AnnotatedRelationshipElement SubmodelElement (Replace)",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
         "data": "bodies/put/putARE.json",
         "expectedStatus": 204
     },
     {
         "context": "PUT AnnotatedRelationshipElement - Verify updated Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
         "shouldMatch": "bodies/put/putARE.json",
         "expectedStatus": 200
     },
     {
         "context": "POST BasicEventElement Submodel",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data": "bodies/post/postSubmodelWithBasicEventElement.json",
         "expectedStatus": 201
     },
     {
         "context": "GET BasicEventElement Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlCYXNpY0V2ZW50RWxlbWVudFN1Ym1vZGVs",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlCYXNpY0V2ZW50RWxlbWVudFN1Ym1vZGVs",
         "shouldMatch": "bodies/post/postSubmodelWithBasicEventElement.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT BasicEventElement SubmodelElement (Replace)",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlCYXNpY0V2ZW50RWxlbWVudFN1Ym1vZGVs/submodel-elements/ExampleBasicEvent",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlCYXNpY0V2ZW50RWxlbWVudFN1Ym1vZGVs/submodel-elements/ExampleBasicEvent",
         "data": "bodies/put/putBasicEventElement.json",
         "expectedStatus": 204
     },
     {
         "context": "PUT BasicEventElement - Verify updated Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlCYXNpY0V2ZW50RWxlbWVudFN1Ym1vZGVs/submodel-elements/ExampleBasicEvent",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlCYXNpY0V2ZW50RWxlbWVudFN1Ym1vZGVs/submodel-elements/ExampleBasicEvent",
         "shouldMatch": "bodies/put/putBasicEventElement.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT MultiLanguageProperty SubmodelElement (Replace)",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]",
         "data": "bodies/put/putMultiLanguageProperty.json",
         "expectedStatus": 204
     },
     {
         "context": "PUT MultiLanguageProperty - Verify updated Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]",
         "shouldMatch": "bodies/put/putMultiLanguageProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT Operation SubmodelElement",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlPcGVyYXRpb25TdWJtb2RlbA/submodel-elements/DemoOperation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlPcGVyYXRpb25TdWJtb2RlbA/submodel-elements/DemoOperation",
         "data": "bodies/put/putOperation.json",
         "expectedStatus": 204
     },
     {
         "context": "PUT Operation - Verify updated Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlPcGVyYXRpb25TdWJtb2RlbA/submodel-elements/DemoOperation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlPcGVyYXRpb25TdWJtb2RlbA/submodel-elements/DemoOperation",
         "shouldMatch": "bodies/put/putOperation.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT ReferenceElement SubmodelElement (Replace)",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw/submodel-elements/DemoReferenceElement",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw/submodel-elements/DemoReferenceElement",
         "data": "bodies/put/putReferenceElement.json",
         "expectedStatus": 204
     },
     {
         "context": "GET ReferenceElement - Verify updated Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw/submodel-elements/DemoReferenceElement",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWZlcmVuY2VFbGVtZW50U3VibW9kZWw/submodel-elements/DemoReferenceElement",
         "shouldMatch": "bodies/put/putReferenceElement.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT RelationshipElement (Replace)",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
         "data": "bodies/put/putRelationshipElement.json",
         "expectedStatus": 204
     },
     {
         "context": "Get RelationshipElement SubmodelElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
         "shouldMatch": "bodies/put/putRelationshipElement.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT Range SubmodelElement (Replace)",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs/submodel-elements/DemoRange",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs/submodel-elements/DemoRange",
         "data": "bodies/put/putRange.json",
         "expectedStatus": 204
     },
     {
         "context": "PUT Range - Verify updated Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs/submodel-elements/DemoRange",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSYW5nZVN1Ym1vZGVs/submodel-elements/DemoRange",
         "shouldMatch": "bodies/put/putRange.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT SubmodelElementCollection - Update ExampleSubmodelElementCollection",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection",
         "data": "bodies/put/putCollection.json",
         "expectedStatus": 204
     },
     {
         "context": "PUT SubmodelElementCollection - Verify Update",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection?extent=withBlobValue",
         "shouldMatch": "bodies/put/putCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT - Update Property (Nested)",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
         "data": "bodies/put/putProperty.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Updated Property",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
         "shouldMatch": "bodies/put/putProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT - Update Blob",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementCollection.ExampleBlob",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementCollection.ExampleBlob",
         "data": "bodies/put/putBlob.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Updated Blob",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementCollection.ExampleBlob?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementCollection.ExampleBlob?extent=withBlobValue",
         "shouldMatch": "bodies/put/putBlob.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT - Update File",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile",
         "data": "bodies/put/putFile.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Updated File",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile",
         "shouldMatch": "bodies/put/putFile.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT - Update SubmodelElementList",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered",
         "data": "bodies/put/putList.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Updated SubmodelElementList",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered",
         "shouldMatch": "bodies/put/putList.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT - Update Capability",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlDYXBhYmlsaXR5U3VibW9kZWw/submodel-elements/DemoCapability",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlDYXBhYmlsaXR5U3VibW9kZWw/submodel-elements/DemoCapability",
         "data": "bodies/put/putCapability.json",
         "expectedStatus": 204
     },
     {
         "context": "GET - Verify Updated Capability",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlDYXBhYmlsaXR5U3VibW9kZWw/submodel-elements/DemoCapability",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlDYXBhYmlsaXR5U3VibW9kZWw/submodel-elements/DemoCapability",
         "shouldMatch": "bodies/put/putCapability.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New Property Element",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewProperty.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created Property Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
         "shouldMatch": "bodies/post/postNewProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New Range Element",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewRange.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created Range Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestRange",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestRange",
         "shouldMatch": "bodies/post/postNewRange.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New MultiLanguageProperty Element",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewMultiLanguageProperty.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created MultiLanguageProperty Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestMultiLanguageProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestMultiLanguageProperty",
         "shouldMatch": "bodies/post/postNewMultiLanguageProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New ReferenceElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewReferenceElement.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created ReferenceElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestReferenceElement",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestReferenceElement",
         "shouldMatch": "bodies/post/postNewReferenceElement.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New RelationshipElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewRelationshipElement.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created RelationshipElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestRelationshipElement",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestRelationshipElement",
         "shouldMatch": "bodies/post/postNewRelationshipElement.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New Blob Element",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewBlob.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created Blob Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestBlob?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestBlob?extent=withBlobValue",
         "shouldMatch": "bodies/post/postNewBlob.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New File Element",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewFile.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created File Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestFile",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestFile",
         "shouldMatch": "bodies/post/postNewFile.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New SubmodelElementCollection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created SubmodelElementCollection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestCollection",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestCollection",
         "shouldMatch": "bodies/post/postNewCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New SubmodelElementList",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created SubmodelElementList",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestList",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestList",
         "shouldMatch": "bodies/post/postNewList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New Entity Element",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created Entity Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestEntity",
         "shouldMatch": "bodies/post/postNewEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New BasicEventElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewBasicEventElement.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created BasicEventElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestBasicEvent",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestBasicEvent",
         "shouldMatch": "bodies/post/postNewBasicEventElement.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New AnnotatedRelationshipElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewAnnotatedRelationshipElement.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created AnnotatedRelationshipElement",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestAnnotatedRelationshipElement",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestAnnotatedRelationshipElement",
         "shouldMatch": "bodies/post/postNewAnnotatedRelationshipElement.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create New Capability Element",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewCapability.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Created Capability Element",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestCapability",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestCapability",
         "shouldMatch": "bodies/post/postNewCapability.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create Collection for nested tests",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postTestContainerCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Collection for nested tests",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "shouldMatch": "bodies/post/postTestContainerCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create List for nested tests",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/postTestContainerList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify List for nested tests",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "shouldMatch": "bodies/post/postTestContainerList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create Entity for nested tests",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/postTestContainerEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Entity for nested tests",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "shouldMatch": "bodies/post/postTestContainerEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Create AnnotatedRelationshipElement for nested tests",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/postTestContainerAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify AnnotatedRelationshipElement for nested tests",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "shouldMatch": "bodies/post/postTestContainerAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Property in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postPropertyInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Property in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedProperty",
         "shouldMatch": "bodies/post/nested/postPropertyInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Property in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postPropertyInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Property in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[0]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[0]",
         "shouldMatch": "bodies/post/nested/postPropertyInList.json",
         "expectedStatus": 200
     },
     {
         "context": "GET - Verify List with level core returns one level",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List?level=core",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List?level=core",
         "shouldMatch": "expected/expectedGetTestContainerListLevelCoreOneLevel.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Property in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postPropertyInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Property in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedPropertyEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedPropertyEntity",
         "shouldMatch": "bodies/post/nested/postPropertyInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "GET - Verify Entity with level core returns one level",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity?level=core",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity?level=core",
         "shouldMatch": "expected/expectedGetTestContainerEntityLevelCoreOneLevel.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Property in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postPropertyInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Property in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedPropertyAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedPropertyAnnotation",
         "shouldMatch": "bodies/post/nested/postPropertyInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "GET - Verify AnnotatedRelationship with level core returns one level",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship?level=core",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship?level=core",
         "shouldMatch": "expected/expectedGetTestContainerAnnotatedRelationshipLevelCoreOneLevel.json",
         "expectedStatus": 200
     },
     {
         "context": "GET - Verify TestContainer with level core returns one level",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer?level=core",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer?level=core",
         "shouldMatch": "expected/expectedGetTestContainerLevelCoreOneLevel.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Range in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postRangeInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Range in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedRange",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedRange",
         "shouldMatch": "bodies/post/nested/postRangeInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Range in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postRangeInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Range in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[1]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[1]",
         "shouldMatch": "bodies/post/nested/postRangeInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - File in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postFileInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify File in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedFile",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedFile",
         "shouldMatch": "bodies/post/nested/postFileInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Blob with minimal fields",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/variations/postBlobMinimal.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Blob minimal",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/MinimalBlob",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/MinimalBlob",
         "shouldMatch": "bodies/post/variations/postBlobMinimal.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Property with all optional fields",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/variations/postPropertyFull.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Property with all fields",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/FullProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/FullProperty",
         "shouldMatch": "bodies/post/variations/postPropertyFull.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - SubmodelElementList with valueTypeListElement",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/variations/postListWithValueType.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify List with valueType",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ListWithValueType",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ListWithValueType",
         "shouldMatch": "bodies/post/variations/postListWithValueType.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Entity with specificAssetIds",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/variations/postEntityWithSpecificAssetIds.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Entity with specificAssetIds",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/EntityWithAssetIds",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/EntityWithAssetIds",
         "shouldMatch": "bodies/post/variations/postEntityWithSpecificAssetIds.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - MultiLanguageProperty in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postMultiLanguagePropertyInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify MultiLanguageProperty in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedMultiLang",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedMultiLang",
         "shouldMatch": "bodies/post/nested/postMultiLanguagePropertyInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - MultiLanguageProperty in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postMultiLanguagePropertyInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify MultiLanguageProperty in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[2]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[2]",
         "shouldMatch": "bodies/post/nested/postMultiLanguagePropertyInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - MultiLanguageProperty in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postMultiLanguagePropertyInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify MultiLanguageProperty in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedMultiLangEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedMultiLangEntity",
         "shouldMatch": "bodies/post/nested/postMultiLanguagePropertyInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - MultiLanguageProperty in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postMultiLanguagePropertyInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify MultiLanguageProperty in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedMultiLangAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedMultiLangAnnotation",
         "shouldMatch": "bodies/post/nested/postMultiLanguagePropertyInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - ReferenceElement in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postReferenceElementInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify ReferenceElement in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedReference",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedReference",
         "shouldMatch": "bodies/post/nested/postReferenceElementInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - ReferenceElement in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postReferenceElementInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify ReferenceElement in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[3]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[3]",
         "shouldMatch": "bodies/post/nested/postReferenceElementInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - ReferenceElement in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postReferenceElementInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify ReferenceElement in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedReferenceEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedReferenceEntity",
         "shouldMatch": "bodies/post/nested/postReferenceElementInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - ReferenceElement in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postReferenceElementInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify ReferenceElement in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedReferenceAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedReferenceAnnotation",
         "shouldMatch": "bodies/post/nested/postReferenceElementInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - RelationshipElement in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postRelationshipElementInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify RelationshipElement in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedRelationship",
         "shouldMatch": "bodies/post/nested/postRelationshipElementInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - RelationshipElement in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postRelationshipElementInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify RelationshipElement in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[4]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[4]",
         "shouldMatch": "bodies/post/nested/postRelationshipElementInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - RelationshipElement in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postRelationshipElementInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify RelationshipElement in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedRelationshipEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedRelationshipEntity",
         "shouldMatch": "bodies/post/nested/postRelationshipElementInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - RelationshipElement in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postRelationshipElementInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify RelationshipElement in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedRelationshipAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedRelationshipAnnotation",
         "shouldMatch": "bodies/post/nested/postRelationshipElementInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Blob in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postBlobInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Blob in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedBlob?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedBlob?extent=withBlobValue",
         "shouldMatch": "bodies/post/nested/postBlobInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Blob in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postBlobInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Blob in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[5]?extent=withBlobValue",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[5]?extent=withBlobValue",
         "shouldMatch": "bodies/post/nested/postBlobInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Blob in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postBlobInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Blob in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedBlobEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedBlobEntity",
         "shouldMatch": "bodies/post/nested/postBlobInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Blob in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postBlobInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Blob in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedBlobAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedBlobAnnotation",
         "shouldMatch": "bodies/post/nested/postBlobInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - File in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postFileInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify File in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[6]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[6]",
         "shouldMatch": "bodies/post/nested/postFileInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - File in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postFileInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify File in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedFileEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedFileEntity",
         "shouldMatch": "bodies/post/nested/postFileInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - File in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postFileInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify File in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedFileAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedFileAnnotation",
         "shouldMatch": "bodies/post/nested/postFileInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Collection in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postCollectionInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Collection in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedCollection",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedCollection",
         "shouldMatch": "bodies/post/nested/postCollectionInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Collection in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postCollectionInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Collection in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[7]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[7]",
         "shouldMatch": "bodies/post/nested/postCollectionInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Collection in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postCollectionInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Collection in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedCollectionEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedCollectionEntity",
         "shouldMatch": "bodies/post/nested/postCollectionInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Collection in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postCollectionInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Collection in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedCollectionAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedCollectionAnnotation",
         "shouldMatch": "bodies/post/nested/postCollectionInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - List in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postListInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify List in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedList",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedList",
         "shouldMatch": "bodies/post/nested/postListInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - List in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postListInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify List in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[8]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[8]",
         "shouldMatch": "bodies/post/nested/postListInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - List in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postListInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify List in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedListEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedListEntity",
         "shouldMatch": "bodies/post/nested/postListInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - List in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postListInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify List in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedListAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedListAnnotation",
         "shouldMatch": "bodies/post/nested/postListInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Entity in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postEntityInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Entity in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedEntity",
         "shouldMatch": "bodies/post/nested/postEntityInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Entity in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postEntityInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Entity in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[9]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[9]",
         "shouldMatch": "bodies/post/nested/postEntityInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Entity in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postEntityInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Entity in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedEntityEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedEntityEntity",
         "shouldMatch": "bodies/post/nested/postEntityInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Entity in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postEntityInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Entity in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedEntityAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedEntityAnnotation",
         "shouldMatch": "bodies/post/nested/postEntityInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - BasicEventElement in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postBasicEventElementInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify BasicEventElement in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedEvent",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedEvent",
         "shouldMatch": "bodies/post/nested/postBasicEventElementInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - BasicEventElement in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postBasicEventElementInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify BasicEventElement in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[10]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[10]",
         "shouldMatch": "bodies/post/nested/postBasicEventElementInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - BasicEventElement in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postBasicEventElementInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify BasicEventElement in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedEventEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedEventEntity",
         "shouldMatch": "bodies/post/nested/postBasicEventElementInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - BasicEventElement in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postBasicEventElementInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify BasicEventElement in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedEventAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedEventAnnotation",
         "shouldMatch": "bodies/post/nested/postBasicEventElementInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - AnnotatedRelationshipElement in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postAnnotatedRelationshipElementInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify AnnotatedRelationshipElement in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedAnnotatedRel",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedAnnotatedRel",
         "shouldMatch": "bodies/post/nested/postAnnotatedRelationshipElementInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - AnnotatedRelationshipElement in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postAnnotatedRelationshipElementInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify AnnotatedRelationshipElement in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[11]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[11]",
         "shouldMatch": "bodies/post/nested/postAnnotatedRelationshipElementInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - AnnotatedRelationshipElement in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postAnnotatedRelationshipElementInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify AnnotatedRelationshipElement in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedAnnotatedRelEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedAnnotatedRelEntity",
         "shouldMatch": "bodies/post/nested/postAnnotatedRelationshipElementInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - AnnotatedRelationshipElement in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postAnnotatedRelationshipElementInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify AnnotatedRelationshipElement in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedAnnotatedRelAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedAnnotatedRelAnnotation",
         "shouldMatch": "bodies/post/nested/postAnnotatedRelationshipElementInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Capability in Collection",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postCapabilityInCollection.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Capability in Collection",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedCapability",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedCapability",
         "shouldMatch": "bodies/post/nested/postCapabilityInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Capability in List",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postCapabilityInList.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Capability in List",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[12]",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List[12]",
         "shouldMatch": "bodies/post/nested/postCapabilityInList.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Capability in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postCapabilityInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Capability in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedCapabilityEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedCapabilityEntity",
         "shouldMatch": "bodies/post/nested/postCapabilityInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Capability in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postCapabilityInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Capability in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedCapabilityAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedCapabilityAnnotation",
         "shouldMatch": "bodies/post/nested/postCapabilityInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Range in Entity",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postRangeInEntity.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Range in Entity",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedRangeEntity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity.NestedRangeEntity",
         "shouldMatch": "bodies/post/nested/postRangeInEntity.json",
         "expectedStatus": 200
     },
     {
         "context": "POST - Range in AnnotatedRelationship",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postRangeInAnnotatedRelationship.json",
         "expectedStatus": 201
     },
     {
         "context": "GET - Verify Range in AnnotatedRelationship",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedRangeAnnotation",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship.NestedRangeAnnotation",
         "shouldMatch": "bodies/post/nested/postRangeInAnnotatedRelationship.json",
         "expectedStatus": 200
     },
     {
         "context": "POST (Colliding) - Range in AnnotatedRelationship - Expected 409",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.AnnotatedRelationship",
         "data": "bodies/post/nested/postRangeInAnnotatedRelationship.json",
         "expectedStatus": 409
     },
     {
         "context": "POST (Colliding) - Range in Entity - Expected 409",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.Entity",
         "data": "bodies/post/nested/postRangeInEntity.json",
         "expectedStatus": 409
     },
     {
         "context": "POST (Colliding) - Capability in List - Expected 409",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.List",
         "data": "bodies/post/nested/postCapabilityInList.json",
         "expectedStatus": 409
     },
     {
         "context": "POST (Colliding) - Capability in Collection - Expected 409",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer",
         "data": "bodies/post/nested/postCapabilityInCollection.json",
         "expectedStatus": 409
     },
     {
         "context": "POST (Colliding) - Property Element",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
         "data": "bodies/post/postNewProperty.json",
         "expectedStatus": 409
     },
@@ -2083,34 +2083,34 @@
         "context": "GET Signed Submodel",
         "action": "ASSERT_SIGNED_SUBMODEL",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$signed",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$signed",
         "shouldMatch": "expected/expectedSignedSubmodel.json",
         "expectedStatus": 200
     },
     {
         "context": "GET Signed Submodel Value Only",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value/$signed",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/$value/$signed",
         "expectedStatus": 200
     },
     {
         "context": "POST QL Demo Submodels - A",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/query/submodelA.json",
         "expectedStatus": 201
     },
     {
         "context": "POST QL Demo Submodels - B",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/query/submodelB.json",
         "expectedStatus": 201
     },
     {
         "context": "Query Submodel By ID Starts With",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryByIdStartsWith.json",
         "shouldMatch":"expected/query/paginatedSubmodelAB.json",
         "expectedStatus": 200
@@ -2118,7 +2118,7 @@
     {
         "context": "Query Submodel By ID Short Exact",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryByIdShortExact.json",
         "shouldMatch":"expected/query/paginatedSubmodelB.json",
         "expectedStatus": 200
@@ -2126,7 +2126,7 @@
     {
         "context": "Query Submodel By ID Short Contains",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data": "bodies/query/queryByIdShortContains.json",
         "shouldMatch": "expected/query/paginatedSubmodelAB.json",
         "expectedStatus": 200
@@ -2134,7 +2134,7 @@
     {
         "context": "Query Submodel By ID Exact",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryByIdExact.json",
         "shouldMatch":"expected/query/paginatedSubmodelA.json",
         "expectedStatus": 200
@@ -2142,7 +2142,7 @@
     {
         "context": "Query Submodel By ID Contains",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryByIdContains.json",
         "shouldMatch":"expected/query/paginatedSubmodelA_278.json",
         "expectedStatus": 200
@@ -2150,7 +2150,7 @@
     {
         "context": "Query Submodel By ID Contains 2",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryByIdContains2.json",
         "shouldMatch":"expected/query/paginatedSubmodelB.json",
         "expectedStatus": 200
@@ -2158,35 +2158,35 @@
     {
         "context": "POST QL Demo Submodels - C (TechnicalData)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/query/submodelC.json",
         "expectedStatus": 201
     },
     {
         "context": "POST QL Demo Submodels - D (OperationalData)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/query/submodelD.json",
         "expectedStatus": 201
     },
     {
         "context": "POST QL Demo Submodels - E (No SemanticId)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/query/submodelE.json",
         "expectedStatus": 201
     },
     {
         "context": "POST QL Demo Submodels - F (No SemanticId with SME)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/query/submodelF.json",
         "expectedStatus": 201
     },
     {
         "context": "Query Submodel By SemanticId Exact (Nameplate)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySemanticIdExact.json",
         "shouldMatch":"expected/query/paginatedSubmodelB.json",
         "expectedStatus": 200
@@ -2194,7 +2194,7 @@
     {
         "context": "Query Submodel By SemanticId Contains (TechnicalData)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySemanticIdContains.json",
         "shouldMatch":"expected/query/paginatedSubmodelC.json",
         "expectedStatus": 200
@@ -2202,7 +2202,7 @@
     {
         "context": "Query Submodel By SME Value Exact (ManufacturerName=ACME Corporation)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeValueExact.json",
         "shouldMatch":"expected/query/paginatedSubmodelB.json",
         "expectedStatus": 200
@@ -2210,7 +2210,7 @@
     {
         "context": "Query Submodel By SME Value Contains (SerialNumber contains 12345)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeValueContains.json",
         "shouldMatch":"expected/query/paginatedSubmodelB.json",
         "expectedStatus": 200
@@ -2218,7 +2218,7 @@
     {
         "context": "Query Submodel By SME idShort Exact (Temperature)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeIdShortExact.json",
         "shouldMatch":"expected/query/paginatedSubmodelsBFWithTemperature.json",
         "expectedStatus": 200
@@ -2226,7 +2226,7 @@
     {
         "context": "Query Submodel By AND Condition (id contains nuhuh AND idShort contains Query_Language)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryAndCondition.json",
         "shouldMatch":"expected/query/paginatedSubmodelsIdContainsNuhuh.json",
         "expectedStatus": 200
@@ -2234,7 +2234,7 @@
     {
         "context": "Query Submodel By OR Condition (idShort=Submodel_1 OR idShort=Submodel_3)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryOrCondition.json",
         "shouldMatch":"expected/query/paginatedSubmodelsOrCondition.json",
         "expectedStatus": 200
@@ -2242,7 +2242,7 @@
     {
         "context": "Query Submodel By NOT Condition (id NOT contains nuhuh)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryNotCondition.json",
         "shouldMatch":"expected/query/paginatedSubmodelsNotNuhuh.json",
         "expectedStatus": 200
@@ -2250,7 +2250,7 @@
     {
         "context": "Query Submodel By Starts-With (idShort starts with Query_Language)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryStartsWith.json",
         "shouldMatch":"expected/query/paginatedAllQuerySubmodels.json",
         "expectedStatus": 200
@@ -2258,7 +2258,7 @@
     {
         "context": "Query Submodel By Ends-With (idShort ends with Submodel_1)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryEndsWith.json",
         "shouldMatch":"expected/query/paginatedSubmodelA.json",
         "expectedStatus": 200
@@ -2266,7 +2266,7 @@
     {
         "context": "Query Submodel By Regex (idShort matches Query_Language_Submodel_[0-9]+)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryRegex.json",
         "shouldMatch":"expected/query/paginatedAllQuerySubmodels.json",
         "expectedStatus": 200
@@ -2274,7 +2274,7 @@
     {
         "context": "Query Submodel No Match Returns Empty Result",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryNoMatch.json",
         "shouldMatch":"expected/query/paginatedEmptyResult.json",
         "expectedStatus": 200
@@ -2282,7 +2282,7 @@
     {
         "context": "Query Submodel By SME ValueType (SimpleProperty valueType=xs:string)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeValueType.json",
         "shouldMatch":"expected/query/paginatedSubmodelE.json",
         "expectedStatus": 200
@@ -2290,7 +2290,7 @@
     {
         "context": "Query Submodel By Combined SME and SM (Status=Running AND idShort contains Device1)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeAndSmCombined.json",
         "shouldMatch":"expected/query/paginatedSubmodelD.json",
         "expectedStatus": 200
@@ -2298,7 +2298,7 @@
     {
         "context": "Query Submodel Without SemanticId (LEFT JOIN test)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/queryNoSemanticIdSubmodel.json",
         "shouldMatch":"expected/query/paginatedSubmodelE.json",
         "expectedStatus": 200
@@ -2306,14 +2306,14 @@
     {
         "context": "POST QL Demo Submodels - G (MultiLanguageProperty and SME with SemanticId)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/query/submodelG.json",
         "expectedStatus": 201
     },
     {
         "context": "Query Submodel By SME Language (language=fr AND idShort contains Query_Language)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeLanguage.json",
         "shouldMatch":"expected/query/paginatedSubmodelG.json",
         "expectedStatus": 200
@@ -2321,7 +2321,7 @@
     {
         "context": "Query Submodel By SME SemanticId (contains TechnicalSpecification)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeSemanticId.json",
         "shouldMatch":"expected/query/paginatedSubmodelG.json",
         "expectedStatus": 200
@@ -2329,14 +2329,14 @@
     {
         "context": "POST QL Demo Submodels - H (Nested SubmodelElementCollection with Properties)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/query/submodelH.json",
         "expectedStatus": 201
     },
     {
         "context": "Query Submodel By Nested SME Value Contains (NestedSerialNumber contains NESTED-SN)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeNestedValueContains.json",
         "shouldMatch":"expected/query/paginatedSubmodelH.json",
         "expectedStatus": 200
@@ -2344,7 +2344,7 @@
     {
         "context": "Query Submodel By Nested SME idShort Exact (NestedTemperature)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeNestedIdShortExact.json",
         "shouldMatch":"expected/query/paginatedSubmodelH.json",
         "expectedStatus": 200
@@ -2352,7 +2352,7 @@
     {
         "context": "Query Submodel By Deeply Nested SME Value Exact (DeeplyNestedProperty=DeepValue-XYZ)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/query/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/query/submodels",
         "data":"bodies/query/querySmeDeepNestedValueExact.json",
         "shouldMatch":"expected/query/paginatedSubmodelH.json",
         "expectedStatus": 200
@@ -2360,546 +2360,546 @@
     {
         "context": "Post TechnicalData",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/TechnicalData.json",
         "expectedStatus": 201
     },
     {
         "context": "GET TechnicalData Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9iYXN5eC5kZXYvY29tcG9uZW50cy9zdWJtb2RlbC1yZXBvc2l0b3J5L1RlY2huaWNhbERhdGEvMjAyNi0wNC0wMlQxMTowNzowMFo",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9iYXN5eC5kZXYvY29tcG9uZW50cy9zdWJtb2RlbC1yZXBvc2l0b3J5L1RlY2huaWNhbERhdGEvMjAyNi0wNC0wMlQxMTowNzowMFo",
         "shouldMatch":"bodies/post/smt/TechnicalData.json",
         "expectedStatus": 200
     },
     {
         "context": "Post AID (AssetInterfacesDescription)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/AID.json",
         "expectedStatus": 201
     },
     {
         "context": "GET AID Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQXNzZXRJbnRlcmZhY2VzRGVzY3JpcHRpb24",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQXNzZXRJbnRlcmZhY2VzRGVzY3JpcHRpb24",
         "shouldMatch":"bodies/post/smt/AID.json",
         "expectedStatus": 200
     },
     {
         "context": "Post AIDataset",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/AIDataset.json",
         "expectedStatus": 201
     },
     {
         "context": "GET AIDataset Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQUlEYXRhc2V0LzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQUlEYXRhc2V0LzEvMA",
         "shouldMatch":"bodies/post/smt/AIDataset.json",
         "expectedStatus": 200
     },
     {
         "context": "Post AIDeployment",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/AIDeployment.json",
         "expectedStatus": 201
     },
     {
         "context": "GET AIDeployment Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQUlEZXBsb3ltZW50LzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQUlEZXBsb3ltZW50LzEvMA",
         "shouldMatch":"bodies/post/smt/AIDeployment.json",
         "expectedStatus": 200
     },
     {
         "context": "Post AIMC (AssetInterfacesMappingConfiguration)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/AIMC.json",
         "expectedStatus": 201
     },
     {
         "context": "GET AIMC Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQXNzZXRJbnRlcmZhY2VzTWFwcGluZ0NvbmZpZ3VyYXRpb24vMS8wLw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQXNzZXRJbnRlcmZhY2VzTWFwcGluZ0NvbmZpZ3VyYXRpb24vMS8wLw",
         "shouldMatch":"bodies/post/smt/AIMC.json",
         "expectedStatus": 200
     },
     {
         "context": "Post AIModelNameplate",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/AIModelNameplate.json",
         "expectedStatus": 201
     },
     {
         "context": "GET AIModelNameplate Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQUlNb2RlbE5hbWVwbGF0ZS8xLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQUlNb2RlbE5hbWVwbGF0ZS8xLzA",
         "shouldMatch":"bodies/post/smt/AIModelNameplate.json",
         "expectedStatus": 200
     },
     {
         "context": "Post AssetLctn (AssetLocation)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/AssetLctn.json",
         "expectedStatus": 201
     },
     {
         "context": "GET AssetLctn Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvRGF0YU1vZGVsZm9yQXNzZXRMb2NhdGlvbi8xLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvRGF0YU1vZGVsZm9yQXNzZXRMb2NhdGlvbi8xLzA",
         "shouldMatch":"bodies/post/smt/AssetLctn.json",
         "expectedStatus": 200
     },
     {
         "context": "Post BOM (HierarchicalStructures)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/BOM.json",
         "expectedStatus": 201
     },
     {
         "context": "GET BOM Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvSGllcmFyY2hpY2FsU3RydWN0dXJlc0JvTS8xLzE",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvSGllcmFyY2hpY2FsU3RydWN0dXJlc0JvTS8xLzE",
         "shouldMatch":"bodies/post/smt/BOM.json",
         "expectedStatus": 200
     },
     {
         "context": "Post BackendSpecificMatInf",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/BackendSpecificMatInf.json",
         "expectedStatus": 201
     },
     {
         "context": "GET BackendSpecificMatInf Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL0JhY2tlbmRTcGVjaWZpY01hdGVyaWFsSW5mb3JtYXRpb24vMS8wLw",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL0JhY2tlbmRTcGVjaWZpY01hdGVyaWFsSW5mb3JtYXRpb24vMS8wLw",
         "shouldMatch":"bodies/post/smt/BackendSpecificMatInf.json",
         "expectedStatus": 200
     },
     {
         "context": "Post CarbFtprnt (CarbonFootprint)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/CarbFtprnt.json",
         "expectedStatus": 201
     },
     {
         "context": "GET CarbFtprnt Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ2FyYm9uRm9vdHByaW50LzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ2FyYm9uRm9vdHByaW50LzEvMA",
         "shouldMatch":"bodies/post/smt/CarbFtprnt.json",
         "expectedStatus": 200
     },
     {
         "context": "Post CntrlCnfgCNC (ControlConfigurationofCNCMachines)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/CntrlCnfgCNC.json",
         "expectedStatus": 201
     },
     {
         "context": "GET CntrlCnfgCNC Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ29udHJvbENvbmZpZ3VyYXRpb25vZkNOQ01hY2hpbmVzLzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ29udHJvbENvbmZpZ3VyYXRpb25vZkNOQ01hY2hpbmVzLzEvMA",
         "shouldMatch":"bodies/post/smt/CntrlCnfgCNC.json",
         "expectedStatus": 200
     },
     {
         "context": "Post ContactInfo (ContactInformation)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/ContactInfo.json",
         "expectedStatus": 201
     },
     {
         "context": "GET ContactInfo Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ29udGFjdEluZm9ybWF0aW9uLzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ29udGFjdEluZm9ybWF0aW9uLzEvMA",
         "shouldMatch":"bodies/post/smt/ContactInfo.json",
         "expectedStatus": 200
     },
     {
         "context": "Post ControlComponent (ControlComponentType)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/ControlComponent.json",
         "expectedStatus": 201
     },
     {
         "context": "GET ControlComponent Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ29udHJvbENvbXBvbmVudFR5cGUvMi8w",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ29udHJvbENvbXBvbmVudFR5cGUvMi8w",
         "shouldMatch":"bodies/post/smt/ControlComponent.json",
         "expectedStatus": 200
     },
     {
         "context": "Post ControlComponent2 (ControlComponentInstance)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/ControlComponent2.json",
         "expectedStatus": 201
     },
     {
         "context": "GET ControlComponent2 Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ29udHJvbENvbXBvbmVudC9JbnN0YW5jZS8yLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvQ29udHJvbENvbXBvbmVudC9JbnN0YW5jZS8yLzA",
         "shouldMatch":"bodies/post/smt/ControlComponent2.json",
         "expectedStatus": 200
     },
     {
         "context": "Post DEXPI",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/DEXPI.json",
         "expectedStatus": 201
     },
     {
         "context": "GET DEXPI Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvREVYUEkvMS8w",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvREVYUEkvMS8w",
         "shouldMatch":"bodies/post/smt/DEXPI.json",
         "expectedStatus": 200
     },
     {
         "context": "Post DataRetPol (DataRetentionPolicies)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/DataRetPol.json",
         "expectedStatus": 201
     },
     {
         "context": "GET DataRetPol Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvRGF0YVJldGVudGlvblBvbGljaWVzLzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvRGF0YVJldGVudGlvblBvbGljaWVzLzEvMA",
         "shouldMatch":"bodies/post/smt/DataRetPol.json",
         "expectedStatus": 200
     },
     {
         "context": "Post ExecutedProcesses",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/ExecutedProcesses.json",
         "expectedStatus": 201
     },
     {
         "context": "GET ExecutedProcesses Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL0V4ZWN1dGVkUHJvY2Vzc2VzLzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL0V4ZWN1dGVkUHJvY2Vzc2VzLzEvMA",
         "shouldMatch":"bodies/post/smt/ExecutedProcesses.json",
         "expectedStatus": 200
     },
     {
         "context": "Post FuncSaf (FunctionalSafety)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/FuncSaf.json",
         "expectedStatus": 201
     },
     {
         "context": "GET FuncSaf Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvRnVuY3Rpb25hbFNhZmV0eS8xLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvRnVuY3Rpb25hbFNhZmV0eS8xLzA",
         "shouldMatch":"bodies/post/smt/FuncSaf.json",
         "expectedStatus": 200
     },
     {
         "context": "Post HandoverDoc (HandoverDocumentation)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/HandoverDoc.json",
         "expectedStatus": 201
     },
     {
         "context": "GET HandoverDoc Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvSGFuZG92ZXJEb2N1bWVudGF0aW9uLzIvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvSGFuZG92ZXJEb2N1bWVudGF0aW9uLzIvMA",
         "shouldMatch":"bodies/post/smt/HandoverDoc.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Identification (PlasticsAndRubberMouldsIdentification)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/Identification.json",
         "expectedStatus": 201
     },
     {
         "context": "GET Identification Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL2V1cm9tYXAvTW91bGRzL0lkZW50aWZpY2F0aW9uLzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL2V1cm9tYXAvTW91bGRzL0lkZW50aWZpY2F0aW9uLzEvMA",
         "shouldMatch":"bodies/post/smt/Identification.json",
         "expectedStatus": 200
     },
     {
         "context": "Post InspDocOfSteelProd (InspectionDocumentsOfSteelProducts)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/InspDocOfSteelProd.json",
         "expectedStatus": 201
     },
     {
         "context": "GET InspDocOfSteelProd Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvSW5zcGVjdGlvbkRvY3VtZW50c09mU3RlZWxQcm9kdWN0cy8xLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvSW5zcGVjdGlvbkRvY3VtZW50c09mU3RlZWxQcm9kdWN0cy8xLzA",
         "shouldMatch":"bodies/post/smt/InspDocOfSteelProd.json",
         "expectedStatus": 200
     },
     {
         "context": "Post IntInfForUse (IntelligentInformationForUse)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/IntInfForUse.json",
         "expectedStatus": 201
     },
     {
         "context": "GET IntInfForUse Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvSW50ZWxsaWdlbnRJbmZvcm1hdGlvbkZvclVzZS8xLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvSW50ZWxsaWdlbnRJbmZvcm1hdGlvbkZvclVzZS8xLzA",
         "shouldMatch":"bodies/post/smt/IntInfForUse.json",
         "expectedStatus": 200
     },
     {
         "context": "Post M3D (ProvisionOf3DModels)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/M3D.json",
         "expectedStatus": 201
     },
     {
         "context": "GET M3D Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUHJvdmlzaW9uT2YzRE1vZGVscy8xLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUHJvdmlzaW9uT2YzRE1vZGVscy8xLzA",
         "shouldMatch":"bodies/post/smt/M3D.json",
         "expectedStatus": 200
     },
     {
         "context": "Post MTP (ModuleTypePackage)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/MTP.json",
         "expectedStatus": 201
     },
     {
         "context": "GET MTP Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvTW9kdWxlVHlwZVBhY2thZ2UvMS8w",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvTW9kdWxlVHlwZVBhY2thZ2UvMS8w",
         "shouldMatch":"bodies/post/smt/MTP.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Nameplate (DigitalNameplate)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/Nameplate.json",
         "expectedStatus": 201
     },
     {
         "context": "GET Nameplate Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvRGlnaXRhbE5hbWVwbGF0ZS8zLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvRGlnaXRhbE5hbWVwbGF0ZS8zLzA",
         "shouldMatch":"bodies/post/smt/Nameplate.json",
         "expectedStatus": 200
     },
     {
         "context": "Post PAMSpecSheet (PAMSpecificationSheet)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/PAMSpecSheet.json",
         "expectedStatus": 201
     },
     {
         "context": "GET PAMSpecSheet Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUEFNU3BlY2lmaWNhdGlvblNoZWV0LzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUEFNU3BlY2lmaWNhdGlvblNoZWV0LzEvMA",
         "shouldMatch":"bodies/post/smt/PAMSpecSheet.json",
         "expectedStatus": 200
     },
     {
         "context": "Post PredictiveMaintenance",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/PredictiveMaintenance.json",
         "expectedStatus": 201
     },
     {
         "context": "GET PredictiveMaintenance Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUHJlZGljdGl2ZU1haW50ZW5hbmNlLzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUHJlZGljdGl2ZU1haW50ZW5hbmNlLzEvMA",
         "shouldMatch":"bodies/post/smt/PredictiveMaintenance.json",
         "expectedStatus": 200
     },
     {
         "context": "Post ProcessParameters",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/ProcessParameters.json",
         "expectedStatus": 201
     },
     {
         "context": "GET ProcessParameters Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC1pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUHJvY2Vzc1BhcmFtZXRlcnMvMS8w",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC1pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUHJvY2Vzc1BhcmFtZXRlcnMvMS8w",
         "shouldMatch":"bodies/post/smt/ProcessParameters.json",
         "expectedStatus": 200
     },
     {
         "context": "Post ProductionCalendar",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/ProductionCalendar.json",
         "expectedStatus": 201
     },
     {
         "context": "GET ProductionCalendar Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUHJvZHVjdGlvbkNhbGVuZGFyLzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUHJvZHVjdGlvbkNhbGVuZGFyLzEvMA",
         "shouldMatch":"bodies/post/smt/ProductionCalendar.json",
         "expectedStatus": 200
     },
     {
         "context": "Post PwrDrvTrainSize (SizingofPowerDriveTrains)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/PwrDrvTrainSize.json",
         "expectedStatus": 201
     },
     {
         "context": "GET PwrDrvTrainSize Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvU2l6aW5nb2ZQb3dlckRyaXZlVHJhaW5zLzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvU2l6aW5nb2ZQb3dlckRyaXZlVHJhaW5zLzEvMA",
         "shouldMatch":"bodies/post/smt/PwrDrvTrainSize.json",
         "expectedStatus": 200
     },
     {
         "context": "Post Reliability",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/Reliability.json",
         "expectedStatus": 201
     },
     {
         "context": "GET Reliability Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUmVsaWFiaWxpdHkvMS8w",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvUmVsaWFiaWxpdHkvMS8w",
         "shouldMatch":"bodies/post/smt/Reliability.json",
         "expectedStatus": 200
     },
     {
         "context": "Post SftwrNameplate (SoftwareNameplate)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/SftwrNameplate.json",
         "expectedStatus": 201
     },
     {
         "context": "GET SftwrNameplate Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvU29mdHdhcmVOYW1lcGxhdGUvMS8w",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvU29mdHdhcmVOYW1lcGxhdGUvMS8w",
         "shouldMatch":"bodies/post/smt/SftwrNameplate.json",
         "expectedStatus": 200
     },
     {
         "context": "Post SimModels (SimulationModels)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/SimModels.json",
         "expectedStatus": 201
     },
     {
         "context": "GET SimModels Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvU2ltdWxhdGlvbk1vZGVscy8xLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvU2ltdWxhdGlvbk1vZGVscy8xLzA",
         "shouldMatch":"bodies/post/smt/SimModels.json",
         "expectedStatus": 200
     },
     {
         "context": "Post SrvcReqNot (ServiceRequestNotification)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/SrvcReqNot.json",
         "expectedStatus": 201
     },
     {
         "context": "GET SrvcReqNot Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvU2VydmljZVJlcXVlc3ROb3RpZmljYXRpb24vMS8w",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvU2VydmljZVJlcXVlc3ROb3RpZmljYXRpb24vMS8w",
         "shouldMatch":"bodies/post/smt/SrvcReqNot.json",
         "expectedStatus": 200
     },
     {
         "context": "Post TechnicalDataAGV",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/TechnicalDataAGV.json",
         "expectedStatus": 201
     },
     {
         "context": "GET TechnicalDataAGV Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvdGVjaG5pY2FsZGF0YWFndi8xLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvdGVjaG5pY2FsZGF0YWFndi8xLzA",
         "shouldMatch":"bodies/post/smt/TechnicalDataAGV.json",
         "expectedStatus": 200
     },
     {
         "context": "Post TimeSeries",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/TimeSeries.json",
         "expectedStatus": 201
     },
     {
         "context": "GET TimeSeries Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvVGltZVNlcmllcy8xLzE",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvVGltZVNlcmllcy8xLzE",
         "shouldMatch":"bodies/post/smt/TimeSeries.json",
         "expectedStatus": 200
     },
     {
         "context": "Post TimeSrsWOP (TimeSeriesWithOperations)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/TimeSrsWOP.json",
         "expectedStatus": 201
     },
     {
         "context": "GET TimeSrsWOP Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvVGltZVNlcmllc1dpdGhPcGVyYXRpb25zLzEvMQ",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvVGltZVNlcmllc1dpdGhPcGVyYXRpb25zLzEvMQ",
         "shouldMatch":"bodies/post/smt/TimeSrsWOP.json",
         "expectedStatus": 200
     },
     {
         "context": "Post WorkstMachine (WorkstationWorkerMatchingData)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/WorkstMachine.json",
         "expectedStatus": 201
     },
     {
         "context": "GET WorkstMachine Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvd29ya3N0YXRpb25NYXRjaGluZy8xLzA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvd29ya3N0YXRpb25NYXRjaGluZy8xLzA",
         "shouldMatch":"bodies/post/smt/WorkstMachine.json",
         "expectedStatus": 200
     },
     {
         "context": "Post WrlsComm (WirelessCommunication)",
         "method": "POST",
-        "endpoint": "http://localhost:6004/submodels",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels",
         "data":"bodies/post/smt/WrlsComm.json",
         "expectedStatus": 201
     },
     {
         "context": "GET WrlsComm Submodel",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvV2lyZWxlc3NDb21tdW5pY2F0aW9uLzEvMA",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cHM6Ly9hZG1pbi1zaGVsbC5pby9pZHRhL1N1Ym1vZGVsVGVtcGxhdGUvV2lyZWxlc3NDb21tdW5pY2F0aW9uLzEvMA",
         "shouldMatch":"bodies/post/smt/WrlsComm.json",
         "expectedStatus": 200
     },
@@ -2907,75 +2907,75 @@
     {
         "context": "PUT (Rename idShort) - Rename Top Level Property",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
         "data": "bodies/put/putPropertyRenameIdShort.json",
         "expectedStatus": 204
     },
     {
         "context": "GET (Rename idShort) - Verify Renamed Top Level Property at New Path",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/RenamedTestProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/RenamedTestProperty",
         "shouldMatch": "bodies/put/putPropertyRenameIdShort.json",
         "expectedStatus": 200
     },
     {
         "context": "GET (Rename idShort) - Verify Old Path Returns 404",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
         "expectedStatus": 404
     },
     {
         "context": "PUT (Rename idShort) - Revert Top Level Property",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/RenamedTestProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/RenamedTestProperty",
         "data": "bodies/post/postNewProperty.json",
         "expectedStatus": 204
     },
     {
         "context": "GET (Rename idShort) - Verify Reverted Top Level Property",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
         "shouldMatch": "bodies/post/postNewProperty.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT (Rename idShort) - Rename Nested Property in Collection",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedProperty",
         "data": "bodies/put/putNestedPropertyRenameIdShort.json",
         "expectedStatus": 204
     },
     {
         "context": "GET (Rename idShort) - Verify Renamed Nested Property at New Path",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.RenamedNestedProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.RenamedNestedProperty",
         "shouldMatch": "bodies/put/putNestedPropertyRenameIdShort.json",
         "expectedStatus": 200
     },
     {
         "context": "GET (Rename idShort) - Verify Old Nested Path Returns 404",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedProperty",
         "expectedStatus": 404
     },
     {
         "context": "PUT (Rename idShort) - Revert Nested Property",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.RenamedNestedProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.RenamedNestedProperty",
         "data": "bodies/post/nested/postPropertyInCollection.json",
         "expectedStatus": 204
     },
     {
         "context": "GET (Rename idShort) - Verify Reverted Nested Property",
         "method": "GET",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/TestContainer.NestedProperty",
         "shouldMatch": "bodies/post/nested/postPropertyInCollection.json",
         "expectedStatus": 200
     },
     {
         "context": "PUT (Rename idShort Conflict) - Rename to Existing idShort - Expected 409",
         "method": "PUT",
-        "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
+        "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/NewTestProperty",
         "data": "bodies/put/putPropertyRenameConflict.json",
         "expectedStatus": 409
     }

--- a/internal/submodelrepository/integration_tests/submodelrepository_extent_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_extent_integration_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func TestSubmodelRepositoryExtentShapesBlobValues(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:extent-%d", time.Now().UnixNano())
 	submodelIDEncoded := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
 	topBlobValue := base64.StdEncoding.EncodeToString([]byte("top-blob-value"))
@@ -149,7 +149,7 @@ func TestSubmodelRepositoryExtentShapesBlobValues(t *testing.T) {
 }
 
 func TestSubmodelRepositoryHistoryExtentAndCoreLevel(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:history-extent-%d", time.Now().UnixNano())
 	submodelIDEncoded := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
 	topBlobValue := base64.StdEncoding.EncodeToString([]byte("history-top-blob-value"))

--- a/internal/submodelrepository/integration_tests/submodelrepository_file_put_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_file_put_integration_test.go
@@ -41,7 +41,7 @@ import (
 // failures that occurred when a File submodel element was PUT without the
 // optional value field (see PostgreSQLFileHandler.Update).
 func TestPutFileSubmodelElementWithoutValue(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:file-put-no-value-%d", time.Now().UnixNano())
 	submodelIDEncoded := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
 

--- a/internal/submodelrepository/integration_tests/submodelrepository_history_recent_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_history_recent_integration_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 func TestSubmodelRepositoryHistoryTracksSubmodelElementChangesAndRecentDeletes(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	uniqueSuffix := time.Now().UnixNano()
 	submodelID := fmt.Sprintf("urn:example:sm:history:%d", uniqueSuffix)
 	submodelIDShort := fmt.Sprintf("HistorySubmodel%d", uniqueSuffix)

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -71,8 +71,15 @@ var (
 	xsdGMonthDayPattern  = regexp.MustCompile(`^--(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])` + xsdTimezonePattern + `$`)
 )
 
-const submodelRepositoryIntegrationTestDSN = "postgres://admin:admin123@127.0.0.1:6432/basyxTestDB?sslmode=disable"
 const actionAssertSignedSubmodel = "ASSERT_SIGNED_SUBMODEL"
+
+var submodelRepositoryBaseURL = testenv.LocalURLFromEnv("BASYX_IT_API_PORT", 6004)
+var submodelRepositoryInvalidBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_INVALID_API_PORT", 6007)
+var submodelRepositoryAASBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_AAS_API_PORT", 6006)
+var submodelRepositoryAASExternalURL = testenv.LocalURLFromEnv("BASYX_IT_AAS_API_PORT", 6006)
+var submodelRepositorySyncBaseURL = testenv.LocalhostURLFromEnv("BASYX_IT_SYNC_API_PORT", 6008)
+var submodelRepositorySyncExternalURL = testenv.LocalURLFromEnv("BASYX_IT_SYNC_API_PORT", 6008)
+var submodelRepositoryIntegrationTestDSN = testenv.PostgresURLFromEnv("BASYX_IT_DB_PORT", 6432, "basyxTestDB")
 
 // uploadFileAttachment uploads a file to the attachment endpoint
 func uploadFileAttachment(endpoint string, filePath string, fileName string) (int, error) {
@@ -398,7 +405,7 @@ func assertXSDTimeLexical(t *testing.T, value string) {
 }
 
 func TestTemporalXSDRoundTripFormatting(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := "urn:basyx:integration:temporal-format"
 	submodelIDEncoded := common.EncodeString(submodelID)
 	t.Run("Duration regex guards invalid lexicals", func(t *testing.T) {
@@ -547,7 +554,7 @@ func TestTemporalXSDRoundTripFormatting(t *testing.T) {
 }
 
 func TestTemporalPropertyUpdateRoundTrip(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:temporal-update-%d", time.Now().UnixNano())
 	submodelIDEncoded := common.EncodeString(submodelID)
 	elementEndpoint := func(idShort string) string {
@@ -667,7 +674,7 @@ func TestTemporalPropertyUpdateRoundTrip(t *testing.T) {
 }
 
 func TestPropertyEmptyStringRoundTrip(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:property-empty-string-%d", time.Now().UnixNano())
 	submodelIDEncoded := common.EncodeString(submodelID)
 
@@ -721,7 +728,7 @@ func TestPropertyEmptyStringRoundTrip(t *testing.T) {
 }
 
 func TestContractSubmodelRepository(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 
 	createSubmodel := func(t *testing.T, submodelID string, submodelIDShort string) string {
 		t.Helper()
@@ -1444,7 +1451,7 @@ func TestContractSubmodelRepository(t *testing.T) {
 }
 
 func TestPathNotationEndpoints(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:path-endpoints-%d", time.Now().UnixNano())
 	submodelIDEncoded := common.EncodeString(submodelID)
 
@@ -1916,7 +1923,7 @@ func expectedSignedSubmodelPayload(t *testing.T, expectedJWSPath string) []byte 
 
 // TestFileAttachmentOperations tests file upload, download, and deletion for File SME
 func TestFileAttachmentOperations(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := "aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q" // base64 encoded: http://iese.fraunhofer.de/id/sm/OnlyFileSubmodel_Test
 	testFilePath := "testFiles/marcus.gif"
 	weakFileContent := []byte{0x00, 0x01, 0x02, 0x03}
@@ -2035,7 +2042,7 @@ func TestFileAttachmentOperations(t *testing.T) {
 }
 
 func TestDeleteSubmodelElementByPathUnlinksFileAttachmentLargeObject(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:lo-delete-file-%d", time.Now().UnixNano())
 	encodedSubmodelID := common.EncodeString(submodelID)
 	filePath := "DeleteFile"
@@ -2060,7 +2067,7 @@ func TestDeleteSubmodelElementByPathUnlinksFileAttachmentLargeObject(t *testing.
 }
 
 func TestPutParentSubmodelElementUnlinksNestedFileAttachmentLargeObject(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:lo-replace-parent-%d", time.Now().UnixNano())
 	encodedSubmodelID := common.EncodeString(submodelID)
 	parentPath := "Container"
@@ -2159,7 +2166,7 @@ func countPostgresLargeObjects(t *testing.T, dsn string) int64 {
 }
 
 func TestUploadAttachmentToNonFileSubmodelElementReturnsMethodNotAllowed(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:non-file-attachment-%d", time.Now().UnixNano())
 	submodelIDEncoded := common.EncodeString(submodelID)
 	nonFileElementIDShort := "NonFileProperty"
@@ -2204,7 +2211,7 @@ func TestUploadAttachmentToNonFileSubmodelElementReturnsMethodNotAllowed(t *test
 }
 
 func TestLocationHeadersForCreateEndpoints(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 
 	t.Run("PostSubmodelReturnsLocationHeader", func(t *testing.T) {
 		submodelID := fmt.Sprintf("urn:basyx:integration:post-location-submodel-%d", time.Now().UnixNano())
@@ -2322,7 +2329,7 @@ func TestLocationHeadersForCreateEndpoints(t *testing.T) {
 }
 
 func TestPutSubmodelElementByPathCreatesWhenMissing(t *testing.T) {
-	baseURL := "http://localhost:6004"
+	baseURL := submodelRepositoryBaseURL
 	submodelID := fmt.Sprintf("urn:basyx:integration:put-create-sme-%d", time.Now().UnixNano())
 	submodelIDEncoded := common.EncodeString(submodelID)
 	targetPath := "SMC"
@@ -2383,7 +2390,7 @@ func TestStandaloneStartupRejectsUnsupportedAASRegistryToggle(t *testing.T) {
 		t.Skip("requires bundled integration docker compose setup")
 	}
 
-	assertServiceNeverHealthy(t, "http://localhost:6007/health", 20*time.Second)
+	assertServiceNeverHealthy(t, submodelRepositoryInvalidBaseURL+"/health", 20*time.Second)
 }
 
 func TestStandaloneSubmodelRepositorySyncUpdatesReferencingAASDescriptor(t *testing.T) {
@@ -2391,10 +2398,10 @@ func TestStandaloneSubmodelRepositorySyncUpdatesReferencingAASDescriptor(t *test
 		t.Skip("requires bundled integration docker compose setup")
 	}
 
-	companionAASBaseURL := "http://localhost:6006"
-	companionAASExternalURL := "http://127.0.0.1:6006"
-	submodelSyncBaseURL := "http://localhost:6008"
-	submodelSyncExternalURL := "http://127.0.0.1:6008"
+	companionAASBaseURL := submodelRepositoryAASBaseURL
+	companionAASExternalURL := submodelRepositoryAASExternalURL
+	submodelSyncBaseURL := submodelRepositorySyncBaseURL
+	submodelSyncExternalURL := submodelRepositorySyncExternalURL
 
 	waitForServiceHealthy(t, companionAASBaseURL+"/health", 2*time.Minute)
 	waitForServiceHealthy(t, submodelSyncBaseURL+"/health", 2*time.Minute)
@@ -2527,10 +2534,27 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
+	runtime := testenv.NewComposeRuntimeOrExit("submodelrepository-it", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "aas-api", EnvVar: "BASYX_IT_AAS_API_PORT"},
+		{Name: "sync-api", EnvVar: "BASYX_IT_SYNC_API_PORT"},
+		{Name: "invalid-api", EnvVar: "BASYX_IT_INVALID_API_PORT"},
+	})
+	submodelRepositoryBaseURL = runtime.LocalURL("api")
+	submodelRepositoryAASBaseURL = runtime.LocalhostURL("aas-api")
+	submodelRepositoryAASExternalURL = runtime.LocalURL("aas-api")
+	submodelRepositorySyncBaseURL = runtime.LocalhostURL("sync-api")
+	submodelRepositorySyncExternalURL = runtime.LocalURL("sync-api")
+	submodelRepositoryInvalidBaseURL = runtime.LocalhostURL("invalid-api")
+	submodelRepositoryIntegrationTestDSN = runtime.PostgresURL("db", "basyxTestDB")
+
 	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     "docker_compose/docker_compose.yml",
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.Env(),
 		PreDownBeforeUp: true,
-		HealthURL:       "http://localhost:6004/health",
+		HealthURL:       submodelRepositoryBaseURL + "/health",
 		HealthTimeout:   150 * time.Second,
 	}))
 }

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -2531,6 +2531,12 @@ func requireDescriptorEndpointInterface(t *testing.T, db *sql.DB, href string, e
 // TestMain handles setup and teardown
 func TestMain(m *testing.M) {
 	if os.Getenv("BASYX_EXTERNAL_COMPOSE") == "1" {
+		testenv.SetEnvDefaultsOrExit(map[string]string{
+			"BASYX_IT_API_URL":         submodelRepositoryBaseURL,
+			"BASYX_IT_AAS_API_URL":     submodelRepositoryAASExternalURL,
+			"BASYX_IT_SYNC_API_URL":    submodelRepositorySyncExternalURL,
+			"BASYX_IT_INVALID_API_URL": submodelRepositoryInvalidBaseURL,
+		})
 		os.Exit(m.Run())
 	}
 

--- a/internal/submodelrepository/query_integration_tests/docker_compose/docker_compose.yml
+++ b/internal/submodelrepository/query_integration_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db:
     image: postgres:18
-    container_name: smrepo_security_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   submodel-repository-security:
-    container_name: submodel-repository-security
     build:
       context: ../../../..
       dockerfile: ./cmd/submodelrepositoryservice/Dockerfile
@@ -35,28 +33,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: smrepo_security_keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -68,13 +65,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ../../../aasregistry/security_tests/docker_compose/keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: smrepo_security_keycloak_healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -86,7 +82,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/submodelrepository/query_integration_tests/it_config_query.json
+++ b/internal/submodelrepository/query_integration_tests/it_config_query.json
@@ -2,7 +2,7 @@
     {
         "context":  "Health endpoint",
         "method":  "GET",
-        "endpoint":  "http://127.0.0.1:6004/health",
+        "endpoint":  "{{BASYX_IT_API_URL}}/health",
         "expectedStatus":  200,
         "token":  {
                       "user":  "admin",
@@ -12,7 +12,7 @@
     {
         "context":  "Create Submodel",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/submodels",
         "data":  "bodies/post/sophisticatedQuerySubmodel.json",
         "expectedStatus":  201,
         "token":  {
@@ -23,7 +23,7 @@
     {
         "context":  "Query 001 - sm_id_contains_base",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/001_sm_id_contains_base.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -35,7 +35,7 @@
     {
         "context":  "Query 002 - sm_id_contains_negative",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/002_sm_id_contains_negative.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -47,7 +47,7 @@
     {
         "context":  "Query 003 - sm_id_exact_runtime",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/003_sm_id_exact_runtime.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -59,7 +59,7 @@
     {
         "context":  "Query 004 - sm_idshort_eq",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/004_sm_idshort_eq.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -71,7 +71,7 @@
     {
         "context":  "Query 005 - sm_idshort_ne",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/005_sm_idshort_ne.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -83,7 +83,7 @@
     {
         "context":  "Query 006 - sm_idshort_starts",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/006_sm_idshort_starts.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -95,7 +95,7 @@
     {
         "context":  "Query 007 - sm_idshort_ends",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/007_sm_idshort_ends.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -107,7 +107,7 @@
     {
         "context":  "Query 008 - sm_idshort_regex_true",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/008_sm_idshort_regex_true.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -119,7 +119,7 @@
     {
         "context":  "Query 009 - sm_semantic_type_eq",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/009_sm_semantic_type_eq.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -131,7 +131,7 @@
     {
         "context":  "Query 010 - sm_semantic_key0_value_eq",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/010_sm_semantic_key0_value_eq.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -143,7 +143,7 @@
     {
         "context":  "Query 011 - sm_semantic_key1_value_contains",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/011_sm_semantic_key1_value_contains.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -155,7 +155,7 @@
     {
         "context":  "Query 012 - sme_idshort_instance_eq",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/012_sme_idshort_instance_eq.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -167,7 +167,7 @@
     {
         "context":  "Query 013 - sme_idshort_instance_false",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/013_sme_idshort_instance_false.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -179,7 +179,7 @@
     {
         "context":  "Query 014 - sme_value_serial_eq",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/014_sme_value_serial_eq.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -191,7 +191,7 @@
     {
         "context":  "Query 015 - sme_value_serial_contains",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/015_sme_value_serial_contains.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -203,7 +203,7 @@
     {
         "context":  "Query 016 - sme_value_serial_starts",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/016_sme_value_serial_starts.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -215,7 +215,7 @@
     {
         "context":  "Query 017 - sme_value_serial_ends",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/017_sme_value_serial_ends.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -227,7 +227,7 @@
     {
         "context":  "Query 018 - sme_value_regex_numeric",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/018_sme_value_regex_numeric.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -239,7 +239,7 @@
     {
         "context":  "Query 019 - sme_valuetype_string",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/019_sme_valuetype_string.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -251,7 +251,7 @@
     {
         "context":  "Query 020 - sme_valuetype_double",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/020_sme_valuetype_double.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -263,7 +263,7 @@
     {
         "context":  "Query 021 - sme_semantic_contains_serialnumber",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/021_sme_semantic_contains_serialnumber.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -275,7 +275,7 @@
     {
         "context":  "Query 022 - sme_semantic_exact_collection",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/022_sme_semantic_exact_collection.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -287,7 +287,7 @@
     {
         "context":  "Query 023 - sme_language_en",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/023_sme_language_en.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -299,7 +299,7 @@
     {
         "context":  "Query 024 - sme_language_fr_false",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/024_sme_language_fr_false.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -311,7 +311,7 @@
     {
         "context":  "Query 025 - nested_collection_property_value",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/025_nested_collection_property_value.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -323,7 +323,7 @@
     {
         "context":  "Query 026 - nested_collection_property2_value",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/026_nested_collection_property2_value.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -335,7 +335,7 @@
     {
         "context":  "Query 027 - nested_collection_idshort",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/027_nested_collection_idshort.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -347,7 +347,7 @@
     {
         "context":  "Query 028 - nested_list_item0_value",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/028_nested_list_item0_value.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -359,7 +359,7 @@
     {
         "context":  "Query 029 - nested_list_item1_value",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/029_nested_list_item1_value.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -371,7 +371,7 @@
     {
         "context":  "Query 030 - nested_list_item1_value_contains",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/030_nested_list_item1_value_contains.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -383,7 +383,7 @@
     {
         "context":  "Query 031 - nested_list_item0_wrong_value",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/031_nested_list_item0_wrong_value.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -395,7 +395,7 @@
     {
         "context":  "Query 032 - and_sm_and_sme",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/032_and_sm_and_sme.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -407,7 +407,7 @@
     {
         "context":  "Query 033 - and_negative",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/033_and_negative.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -419,7 +419,7 @@
     {
         "context":  "Query 034 - or_one_true",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/034_or_one_true.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -431,7 +431,7 @@
     {
         "context":  "Query 035 - or_all_false",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/035_or_all_false.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -443,7 +443,7 @@
     {
         "context":  "Query 036 - not_false_inner",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/036_not_false_inner.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -455,7 +455,7 @@
     {
         "context":  "Query 037 - not_true_inner",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/037_not_true_inner.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -467,7 +467,7 @@
     {
         "context":  "Query 038 - complex_and_or_1",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/038_complex_and_or_1.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -479,7 +479,7 @@
     {
         "context":  "Query 039 - complex_and_or_2",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/039_complex_and_or_2.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -491,7 +491,7 @@
     {
         "context":  "Query 040 - complex_with_not",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/040_complex_with_not.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -503,7 +503,7 @@
     {
         "context":  "Query 041 - filter_fragment_instance_match",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/041_filter_fragment_instance_match.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -515,7 +515,7 @@
     {
         "context":  "Query 042 - filter_fragment_instance_no_match",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/042_filter_fragment_instance_no_match.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/res42.json",
         "expectedStatus":  200,
@@ -527,7 +527,7 @@
     {
         "context":  "Query 043 - filter_fragment_collection_match",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/043_filter_fragment_collection_match.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -539,7 +539,7 @@
     {
         "context":  "Query 044 - filter_fragment_list_match",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/044_filter_fragment_list_match.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -551,7 +551,7 @@
     {
         "context":  "Query 045 - filter_all_false",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/045_filter_all_false.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_sme_response.json",
         "expectedStatus":  200,
@@ -563,7 +563,7 @@
     {
         "context":  "Query 046 - filter_different_sme",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/046_filter_different_sme.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/res46.json",
         "expectedStatus":  200,
@@ -575,7 +575,7 @@
     {
         "context":  "Query 047 - triple_and",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/047_triple_and.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -587,7 +587,7 @@
     {
         "context":  "Query 048 - triple_and_2",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/048_triple_and_2.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -599,7 +599,7 @@
     {
         "context":  "Query 049 - nested_not_or_false",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/049_nested_not_or_false.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -611,7 +611,7 @@
     {
         "context":  "Query 050 - sme_wildcard_semantic_match",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/050_sme_wildcard_semantic_match.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -623,7 +623,7 @@
     {
         "context":  "Query 051 - sme_wildcard_semantic_false",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/051_sme_wildcard_semantic_false.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -635,7 +635,7 @@
     {
         "context":  "Query 052 - collection_and_list_combined",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/052_collection_and_list_combined.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -647,7 +647,7 @@
     {
         "context":  "Query 053 - collection_and_list_mismatch",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/053_collection_and_list_mismatch.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_response.json",
         "expectedStatus":  200,
@@ -659,7 +659,7 @@
     {
         "context":  "Query 054 - manufacturer_value_contains",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/054_manufacturer_value_contains.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/full_response.json",
         "expectedStatus":  200,
@@ -671,7 +671,7 @@
     {
         "context":  "Query 055 - all false filter",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/055.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_sme_response.json",
         "expectedStatus":  200,
@@ -683,7 +683,7 @@
     {
         "context":  "Query 056",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/056.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/res56.json",
         "expectedStatus":  200,
@@ -695,7 +695,7 @@
     {
         "context":  "Query 057",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/057.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_sme_response.json",
         "expectedStatus":  200,
@@ -707,7 +707,7 @@
     {
         "context":  "Query 058",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/058.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/res58.json",
         "expectedStatus":  200,
@@ -719,7 +719,7 @@
     {
         "context":  "Create Submodel 2",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/submodels",
         "data":  "bodies/post/sub2.json",
         "expectedStatus":  201,
         "token":  {
@@ -730,7 +730,7 @@
     {
         "context":  "Query 101",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/101.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/empty_sme_response_2.json",
         "expectedStatus":  200,
@@ -742,7 +742,7 @@
     {
         "context":  "Query 102",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/102.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/res102.json",
         "expectedStatus":  200,
@@ -754,7 +754,7 @@
     {
         "context":  "Query 103",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/103.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/res103.json",
         "expectedStatus":  200,
@@ -766,7 +766,7 @@
     {
         "context":  "Create supplemental semantic ID query submodel",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/submodels",
         "data":  "bodies/post/supplementalSemanticIdsQuerySubmodel.json",
         "expectedStatus":  201,
         "token":  {
@@ -777,7 +777,7 @@
     {
         "context":  "Query 059 - Submodel supplemental semantic ID shorthand",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/059_sm_supplemental_semantic_id.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/supplementalSemanticIdsQueryResult.json",
         "expectedStatus":  200,
@@ -789,7 +789,7 @@
     {
         "context":  "Query 060 - Indexed submodel supplemental semantic ID",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/060_sm_supplemental_semantic_id_indexed.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/supplementalSemanticIdsQueryResult.json",
         "expectedStatus":  200,
@@ -801,7 +801,7 @@
     {
         "context":  "Query 061 - Submodel element supplemental semantic ID shorthand",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/061_sme_supplemental_semantic_id.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/supplementalSemanticIdsQueryResult.json",
         "expectedStatus":  200,
@@ -813,7 +813,7 @@
     {
         "context":  "Query 062 - Indexed submodel element supplemental semantic ID",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/062_sme_supplemental_semantic_id_indexed.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/supplementalSemanticIdsQueryResult.json",
         "expectedStatus":  200,
@@ -825,7 +825,7 @@
     {
         "context":  "Query 063 - Filter submodel supplemental semantic IDs",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/063_sm_supplemental_semantic_id_filter.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/smSupplementalSemanticIdsFilteredResult.json",
         "expectedStatus":  200,
@@ -837,7 +837,7 @@
     {
         "context":  "Query 064 - Filter submodel element supplemental semantic IDs",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/064_sme_supplemental_semantic_id_filter.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/smeSupplementalSemanticIdsFilteredResult.json",
         "expectedStatus":  200,
@@ -849,7 +849,7 @@
     {
         "context":  "Delete supplemental semantic ID query submodel",
         "method":  "DELETE",
-        "endpoint":  "http://127.0.0.1:6004/submodels/c3VwcGxlbWVudGFsLXF1ZXJ5LXNt",
+        "endpoint":  "{{BASYX_IT_API_URL}}/submodels/c3VwcGxlbWVudGFsLXF1ZXJ5LXNt",
         "expectedStatus":  204,
         "token":  {
                       "user":  "admin",
@@ -859,7 +859,7 @@
     {
         "context":  "Security userx GET all submodels",
         "method":  "GET",
-        "endpoint":  "http://127.0.0.1:6004/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/submodels",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_userx_get_submodels.json",
         "expectedStatus":  200,
         "token":  {
@@ -870,7 +870,7 @@
     {
         "context":  "Security userx query true",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/security_true.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_userx_query_true.json",
         "expectedStatus":  200,
@@ -882,7 +882,7 @@
     {
         "context":  "Security userx query true with filter",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/security_true_with_filter.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_userx_query_true_with_filter.json",
         "expectedStatus":  200,
@@ -894,7 +894,7 @@
     {
         "context":  "Security usery GET all submodels",
         "method":  "GET",
-        "endpoint":  "http://127.0.0.1:6004/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/submodels",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_usery_get_submodels.json",
         "expectedStatus":  200,
         "token":  {
@@ -905,7 +905,7 @@
     {
         "context":  "Security usery query true",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/security_true.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_usery_query_true.json",
         "expectedStatus":  200,
@@ -917,7 +917,7 @@
     {
         "context":  "Security usery query true with filter",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/security_true_with_filter.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_usery_query_true_with_filter.json",
         "expectedStatus":  200,
@@ -929,7 +929,7 @@
     {
         "context":  "Security usera GET all submodels",
         "method":  "GET",
-        "endpoint":  "http://127.0.0.1:6004/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/submodels",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_usera_get_submodels.json",
         "expectedStatus":  200,
         "token":  {
@@ -940,7 +940,7 @@
     {
         "context":  "Security usera query true",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/security_true.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_usera_query_true.json",
         "expectedStatus":  200,
@@ -952,7 +952,7 @@
     {
         "context":  "Security usera query true with filter",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/security_true_with_filter.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_usera_query_true_with_filter.json",
         "expectedStatus":  200,
@@ -964,7 +964,7 @@
     {
         "context":  "Security admin GET all submodels",
         "method":  "GET",
-        "endpoint":  "http://127.0.0.1:6004/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/submodels",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_admin_get_submodels.json",
         "expectedStatus":  200,
         "token":  {
@@ -975,7 +975,7 @@
     {
         "context":  "Security admin query true",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/security_true.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_admin_query_true.json",
         "expectedStatus":  200,
@@ -987,7 +987,7 @@
     {
         "context":  "Security admin query true with filter",
         "method":  "POST",
-        "endpoint":  "http://127.0.0.1:6004/query/submodels",
+        "endpoint":  "{{BASYX_IT_API_URL}}/query/submodels",
         "data":  "bodies/query_tests/security_true_with_filter.json",
         "shouldMatch":  "expected/sophisticatedQueryTests/security_admin_query_true_with_filter.json",
         "expectedStatus":  200,

--- a/internal/submodelrepository/query_integration_tests/submodelrepository_query_integration_test.go
+++ b/internal/submodelrepository/query_integration_tests/submodelrepository_query_integration_test.go
@@ -35,11 +35,16 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 )
 
+var (
+	securityBaseURL          = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+	securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+)
+
 func TestIntegrationQuerySuite(t *testing.T) {
 	testenv.RunJSONSuite(t, testenv.JSONSuiteOptions{
 		ConfigPath: "it_config_query.json",
 		TokenProvider: testenv.NewPasswordGrantTokenProvider(
-			"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+			securityKeycloakTokenURL,
 			"basyx-ui",
 			10*time.Second,
 		),
@@ -50,10 +55,25 @@ func TestIntegrationQuerySuite(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("submodelrepository-query", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     "docker_compose/docker_compose.yml",
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
 		PreDownBeforeUp: true,
-		HealthURL:       "http://localhost:6004/health",
+		HealthURL:       securityBaseURL + "/health",
 		HealthTimeout:   150 * time.Second,
-	}))
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }

--- a/internal/submodelrepository/security_tests/docker_compose/docker_compose.yml
+++ b/internal/submodelrepository/security_tests/docker_compose/docker_compose.yml
@@ -1,14 +1,13 @@
 services:
   db:
     image: postgres:18
-    container_name: smrepo_security_db
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DB: basyxTestDB
     command: ["postgres", "-c", "listen_addresses=*"]
     ports:
-      - "6432:5432"
+      - "127.0.0.1:${BASYX_IT_DB_PORT:-6432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
       interval: 10s
@@ -16,7 +15,6 @@ services:
       retries: 5
 
   submodel-repository-security:
-    container_name: submodel-repository-security
     build:
       context: ../../../..
       dockerfile: ./cmd/submodelrepositoryservice/Dockerfile
@@ -36,28 +34,27 @@ services:
       - ABAC_MODELPATH=/security_env/access-rules.json
       - OIDC_TRUSTLISTPATH=/security_env/trustlist.json
     ports:
-      - "6004:5004"
+      - "127.0.0.1:${BASYX_IT_API_PORT:-6004}:5004"
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
       keycloak-healthcheck:
         condition: service_completed_successfully
     volumes:
-      - ../security_env:/security_env
+      - ${BASYX_IT_SECURITY_ENV:-../security_env}:/security_env
     extra_hosts:
       - "localhost:host-gateway"
 
   keycloak:
     image: keycloak/keycloak:26.0.6
-    container_name: smrepo_security_keycloak
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://db:5432/basyxTestDB
       KC_DB_USERNAME: admin
       KC_DB_PASSWORD: admin123
       KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8080"
-      KC_HOSTNAME_URL: "http://localhost:8080"
+      KC_HOSTNAME_PORT: "${BASYX_IT_KEYCLOAK_PORT:-8080}"
+      KC_HOSTNAME_URL: "http://localhost:${BASYX_IT_KEYCLOAK_PORT:-8080}"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_HTTP_ENABLED: "true"
@@ -69,13 +66,12 @@ services:
       KC_HTTP_MANAGEMENT_ENABLED: "true"
     command: ["start-dev", "--import-realm", "--health-enabled=true"]
     ports:
-      - 8080:8080
+      - "0.0.0.0:${BASYX_IT_KEYCLOAK_PORT:-8080}:8080"
     volumes:
       - ../../../aasregistry/security_tests/docker_compose/keycloak/realm:/opt/keycloak/data/import
 
   keycloak-healthcheck:
     image: curlimages/curl:latest
-    container_name: smrepo_security_keycloak_healthcheck
     command: >
       sh -c "
         echo 'Waiting for Keycloak to become ready...';
@@ -87,7 +83,6 @@ services:
       - keycloak
 
   basyx_configuration:
-    container_name: basyx_configuration
     build:
       context: ../../../..
       dockerfile: ./cmd/basyxconfigurationservice/Dockerfile

--- a/internal/submodelrepository/security_tests/it_config.json
+++ b/internal/submodelrepository/security_tests/it_config.json
@@ -3,21 +3,21 @@
     "context": "Anonymous description allowed",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/description",
+    "endpoint": "{{BASYX_IT_API_URL}}/description",
     "expectedStatus": 200
   },
   {
     "context": "Anonymous list denied",
     "token": null,
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "expectedStatus": 403
   },
   {
     "context": "POST annotated submodel - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "data": "bodies/postSubmodelWithAnnotatedRelationshipElementRecent.json",
     "shouldMatch": "bodies/postSubmodelWithAnnotatedRelationshipElementRecent.json",
     "expectedStatus": 201
@@ -26,7 +26,7 @@
     "context": "POST relationship submodel - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "data": "bodies/postSubmodelWithRelationshipElementRecent.json",
     "shouldMatch": "bodies/postSubmodelWithRelationshipElementRecent.json",
     "expectedStatus": 201
@@ -35,14 +35,14 @@
     "context": "GET annotated submodel - userx denied (referable-only user)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
     "expectedStatus": 403
   },
   {
     "context": "GET annotated submodel elements - userx allowed (referable-only user)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements",
     "shouldMatch": "expected/expectedAnnotatedSubmodelElements.json",
     "expectedStatus": 200
   },
@@ -50,14 +50,14 @@
     "context": "GET annotated submodel elements trailing slash - userx not found",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/",
     "expectedStatus": 404
   },
   {
     "context": "GET exact annotated SME - userx allowed (referable-only user)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
     "shouldMatch": "expected/expectedAnnotatedRelationshipElement.json",
     "expectedStatus": 200
   },
@@ -65,28 +65,28 @@
     "context": "GET exact annotated SME trailing slash - userx not found",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement/",
     "expectedStatus": 404
   },
   {
     "context": "GET annotation child - userx denied (referable-only does not grant child here)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement.AnnotationProperty1",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement.AnnotationProperty1",
     "expectedStatus": 403
   },
   {
     "context": "GET relationship submodel - userx denied (referable-only user)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
     "expectedStatus": 403
   },
   {
     "context": "GET exact relationship SME - userx allowed (referable-only user)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
     "shouldMatch": "expected/expectedRelationshipElement.json",
     "expectedStatus": 200
   },
@@ -94,7 +94,7 @@
     "context": "POST demo submodel shell - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "data": "bodies/postSubmodelRecent.json",
     "expectedStatus": 201
   },
@@ -102,7 +102,7 @@
     "context": "POST demo collection-heavy SME root - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
     "data": "../integration_tests/bodies/post/postFullSME.json",
     "expectedStatus": 201
   },
@@ -110,49 +110,49 @@
     "context": "GET /submodels - userx allowed via $sme# existential",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "expectedStatus": 200
   },
   {
     "context": "GET /submodels/ - userx not found",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/",
     "expectedStatus": 404
   },
   {
     "context": "GET demo submodel - userx allowed via $sme# existential",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw",
     "expectedStatus": 200
   },
   {
     "context": "GET demo submodel trailing slash - userx not found",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/",
     "expectedStatus": 404
   },
   {
     "context": "GET demo submodel elements - userx allowed via $sme# existential",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
     "expectedStatus": 200
   },
   {
     "context": "GET demo submodel elements trailing slash - userx not found",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/",
     "expectedStatus": 404
   },
   {
     "context": "GET nested relationship SME - userx allowed via no-index idShortPath field",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleRelationshipElement",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleRelationshipElement",
     "shouldMatch": "expected/expectedDemoRelationshipElement.json",
     "expectedStatus": 200
   },
@@ -160,28 +160,28 @@
     "context": "GET nested relationship SME trailing slash - userx not found",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleRelationshipElement/",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleRelationshipElement/",
     "expectedStatus": 404
   },
   {
     "context": "GET nested annotated SME - userx denied via false $sme# formula",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleAnnotatedRelationshipElement",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleAnnotatedRelationshipElement",
     "expectedStatus": 404
   },
   {
     "context": "GET list item [0] - userx denied (no indexed-path grant rule)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
     "expectedStatus": 404
   },
   {
     "context": "GET nested relationship SME - usery allowed via indexed idShortPath field",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleRelationshipElement",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleRelationshipElement",
     "shouldMatch": "expected/expectedDemoRelationshipElement.json",
     "expectedStatus": 200
   },
@@ -189,7 +189,7 @@
     "context": "GET list item [0] - usery allowed via $sme# valueType existential",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
     "shouldMatch": "expected/expectedDemoListItem0.json",
     "expectedStatus": 200
   },
@@ -197,28 +197,28 @@
     "context": "GET multilanguage property - usery allowed via $sme# language existential",
     "token": { "user": "usery", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]",
     "expectedStatus": 200
   },
   {
     "context": "GET multilanguage property - userx denied via $sme# language existential (false formula)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[1]",
     "expectedStatus": 404
   },
   {
     "context": "GET property without language - userx denied via $sme# language existential (missing language field)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/ExampleSubmodelElementCollection.ExampleSubmodelElementListOrdered[0]",
     "expectedStatus": 404
   },
   {
     "context": "GET /submodels - usera formula filtered",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "shouldMatch": "expected/expectedSubmodelsUserA.json",
     "expectedStatus": 200
   },
@@ -226,7 +226,7 @@
     "context": "GET annotated submodel - usera formula filtered",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
     "shouldMatch": "bodies/postSubmodelWithAnnotatedRelationshipElementRecent.json",
     "expectedStatus": 200
   },
@@ -234,14 +234,14 @@
     "context": "GET relationship submodel - usera filtered out",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
     "expectedStatus": 404
   },
   {
     "context": "GET annotated submodel elements - usera formula filtered",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements",
     "shouldMatch": "expected/expectedAnnotatedSubmodelElements.json",
     "expectedStatus": 200
   },
@@ -249,7 +249,7 @@
     "context": "GET exact annotated SME - usera formula filtered",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
     "shouldMatch": "expected/expectedAnnotatedRelationshipElement.json",
     "expectedStatus": 200
   },
@@ -257,7 +257,7 @@
     "context": "GET relationship submodel elements - usera filtered out",
     "token": { "user": "usera", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements",
     "shouldMatch": "expected/expectedEmptySubmodelElements.json",
     "expectedStatus": 200
   },
@@ -265,7 +265,7 @@
     "context": "GET /submodels - userb object filtered (IDENTIFIABLE OR)",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "expectedStatus": 200
   },
   {
@@ -273,7 +273,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/$recent-changes?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/$recent-changes?limit=20",
     "shouldMatch": "expected/expectedRecentChangesAdminIDs.json",
     "expectedStatus": 200
   },
@@ -281,7 +281,7 @@
     "context": "GET /submodels/$recent-changes/ - admin not found",
     "token": { "user": "admin", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/$recent-changes/?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/$recent-changes/?limit=20",
     "expectedStatus": 404
   },
   {
@@ -289,7 +289,7 @@
     "action": "ASSERT_RECENT_CHANGE_IDS",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/$recent-changes?limit=20",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/$recent-changes?limit=20",
     "shouldMatch": "expected/expectedRecentChangesUserBIDs.json",
     "expectedStatus": 200
   },
@@ -297,7 +297,7 @@
     "context": "GET annotated submodel - userb object access",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
     "shouldMatch": "bodies/postSubmodelWithAnnotatedRelationshipElementRecent.json",
     "expectedStatus": 200
   },
@@ -305,7 +305,7 @@
     "context": "GET relationship submodel - userb object access",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
     "shouldMatch": "bodies/postSubmodelWithRelationshipElementRecent.json",
     "expectedStatus": 200
   },
@@ -313,7 +313,7 @@
     "context": "GET relationship submodel elements - userb REFERABLE object access",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements",
     "shouldMatch": "expected/expectedRelationshipSubmodelElements.json",
     "expectedStatus": 200
   },
@@ -321,7 +321,7 @@
     "context": "GET exact relationship SME - userb REFERABLE object access",
     "token": { "user": "userb", "password": "pwd" },
     "method": "GET",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
     "shouldMatch": "expected/expectedRelationshipElement.json",
     "expectedStatus": 200
   },
@@ -329,7 +329,7 @@
     "context": "POST submodel - userx allowed only for matching body condition",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "data": "bodies/post/writeAllowedSubmodel.json",
     "expectedStatus": 201
   },
@@ -337,7 +337,7 @@
     "context": "POST submodel - userx denied for non-matching body condition",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "data": "bodies/post/writeDeniedSubmodel.json",
     "expectedStatus": 403
   },
@@ -345,7 +345,7 @@
     "context": "POST SME - userx denied for non-matching body condition",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
     "data": "bodies/post/writeDeniedProperty.json",
     "expectedStatus": 403
   },
@@ -353,7 +353,7 @@
     "context": "POST SME - userx allowed only for matching body condition",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
     "data": "bodies/post/writeAllowedProperty.json",
     "expectedStatus": 201
   },
@@ -361,7 +361,7 @@
     "context": "POST SME seed for PUT old/new check - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements",
     "data": "bodies/post/securityUpdateCheckProperty.json",
     "expectedStatus": 201
   },
@@ -369,7 +369,7 @@
     "context": "PUT SME - userx denied if new data would violate formula (needs old+new check)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/SecurityAllowedProperty",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/SecurityAllowedProperty",
     "data": "bodies/put/putSecurityAllowedPropertyUpdate.json",
     "expectedStatus": 403
   },
@@ -377,7 +377,7 @@
     "context": "PUT SME - usery denied if old data would violate formula (needs old+new check)",
     "token": { "user": "usery", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/SecurityUpdateCheckProperty",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9EZW1vU3VibW9kZWw/submodel-elements/SecurityUpdateCheckProperty",
     "data": "bodies/put/putSecurityUpdateCheckPropertyUpdate.json",
     "expectedStatus": 403
   },
@@ -385,28 +385,28 @@
     "context": "DELETE submodel - userx denied (referable-only delete should not allow submodel delete)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw",
     "expectedStatus": 403
   },
   {
     "context": "DELETE annotated SME - userx denied (no delete access on this referable)",
     "token": { "user": "userx", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlBbm5vdGF0ZWRSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoAnnotatedRelationshipElement",
     "expectedStatus": 403
   },
   {
     "context": "DELETE relationship SME - userx allowed when target referable is allowed",
     "token": { "user": "userx", "password": "pwd" },
     "method": "DELETE",
-    "endpoint": "http://localhost:6004/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/TWFyY3VzVGhpc0lzQU9ubHlSZWxhdGlvbnNoaXBFbGVtZW50U3VibW9kZWw/submodel-elements/DemoRelationshipElement",
     "expectedStatus": 204
   },
   {
     "context": "POST file submodel - admin",
     "token": { "user": "admin", "password": "pwd" },
     "method": "POST",
-    "endpoint": "http://localhost:6004/submodels",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels",
     "data": "../integration_tests/bodies/post/postSubmodelWithFile.json",
     "expectedStatus": 201
   },
@@ -415,7 +415,7 @@
     "action": "UPLOAD_ATTACHMENT_MULTIPART",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/attachment",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/attachment",
     "data": "../integration_tests/testFiles/marcus.gif",
     "headers": { "X-Upload-FileName": "userx-create-attempt.gif" },
     "expectedStatus": 403
@@ -425,7 +425,7 @@
     "action": "UPLOAD_ATTACHMENT_MULTIPART",
     "token": { "user": "admin", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/attachment",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/attachment",
     "data": "../integration_tests/testFiles/marcus.gif",
     "headers": { "X-Upload-FileName": "admin-create.gif" },
     "expectedStatus": 204
@@ -435,7 +435,7 @@
     "action": "UPLOAD_ATTACHMENT_MULTIPART",
     "token": { "user": "userx", "password": "pwd" },
     "method": "PUT",
-    "endpoint": "http://localhost:6004/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/attachment",
+    "endpoint": "{{BASYX_IT_API_URL}}/submodels/aHR0cDovL2llc2UuZnJhdW5ob2Zlci5kZS9pZC9zbS9Pbmx5RmlsZVN1Ym1vZGVsX1Rlc3Q/submodel-elements/DemoFile/attachment",
     "data": "../integration_tests/testFiles/marcus.gif",
     "headers": { "X-Upload-FileName": "userx-update.gif" },
     "expectedStatus": 204

--- a/internal/submodelrepository/security_tests/submodelrepository_security_integration_test.go
+++ b/internal/submodelrepository/security_tests/submodelrepository_security_integration_test.go
@@ -45,9 +45,14 @@ import (
 const actionUploadAttachmentMultipart = "UPLOAD_ATTACHMENT_MULTIPART"
 const actionAssertRecentChangeIDs = "ASSERT_RECENT_CHANGE_IDS"
 
+var (
+	securityBaseURL          = testenv.LocalhostURLFromEnv("BASYX_IT_API_PORT", 6004)
+	securityKeycloakTokenURL = testenv.LocalhostURLFromEnv("BASYX_IT_KEYCLOAK_PORT", 8080) + "/realms/basyx/protocol/openid-connect/token"
+)
+
 func TestIntegration(t *testing.T) {
 	tokenProvider := testenv.NewPasswordGrantTokenProvider(
-		"http://localhost:8080/realms/basyx/protocol/openid-connect/token",
+		securityKeycloakTokenURL,
 		"basyx-ui",
 		10*time.Second,
 	)
@@ -182,10 +187,25 @@ func runAttachmentUploadAction(t *testing.T, step testenv.JSONSuiteStep, tokenPr
 }
 
 func TestMain(m *testing.M) {
-	os.Exit(testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
+	runtime := testenv.NewComposeRuntimeOrExit("submodelrepository-security", []testenv.PortBinding{
+		{Name: "api", EnvVar: "BASYX_IT_API_PORT"},
+		{Name: "db", EnvVar: "BASYX_IT_DB_PORT"},
+		{Name: "keycloak", EnvVar: "BASYX_IT_KEYCLOAK_PORT"},
+	})
+	securityBaseURL = runtime.LocalhostURL("api")
+	securityKeycloakTokenURL = runtime.LocalhostURL("keycloak") + "/realms/basyx/protocol/openid-connect/token"
+	securityEnv := testenv.PrepareSecurityEnvOrExit("security_env", map[string]string{
+		"http://localhost:8080": runtime.LocalhostURL("keycloak"),
+	})
+
+	code := testenv.RunComposeTestMain(m, testenv.ComposeTestMainOptions{
 		ComposeFile:     "docker_compose/docker_compose.yml",
+		ProjectName:     runtime.ProjectName,
+		Env:             runtime.EnvWith("BASYX_IT_SECURITY_ENV=" + securityEnv),
 		PreDownBeforeUp: true,
-		HealthURL:       "http://localhost:6004/health",
+		HealthURL:       securityBaseURL + "/health",
 		HealthTimeout:   150 * time.Second,
-	}))
+	})
+	_ = os.RemoveAll(securityEnv)
+	os.Exit(code)
 }


### PR DESCRIPTION
## Description of Changes

Fixes Docker-backed integration test collisions by isolating compose project names, networks, volumes, containers, and published host ports across Go test packages.

Key changes:
- Added shared compose runtime helpers for unique project names, reserved local ports, env propagation, URL/DSN helpers, and per-run security fixture rewrites.
- Updated `RunComposeTestMain` to pass `-p <project>`, forward custom env vars, and default compose teardown to `down -v --remove-orphans`.
- Parameterized Go-test compose files to remove fixed `container_name` values and fixed host-port bindings.
- Rewired integration/security/query/migration/marker-access tests to consume dynamic URLs, DSNs, Keycloak token URLs, and generated security fixture directories.
- Extended JSON suite templating with explicit `{{BASYX_...}}` placeholders while preserving literal `$metadata`, `$reference`, and `$path` endpoint tokens.

## Related Issue

Closes #451

## BaSyx Configuration for Testing

No manual BaSyx configuration is required. Direct `docker compose up` remains supported through default port values, while Go tests allocate per-run ports automatically through environment variables.

## AAS Files Used for Testing

No new AAS files were added. Existing integration fixtures are used, including the AAS Environment preconfiguration and upload test assets already present in the repository.

## Additional Information

Validation performed:
- `go test ./internal/common/testenv`
- `go clean -testcache`
- `go test -v ./internal/submodelrepository/integration_tests`
- representative compose package tests for AASX file server, AAS registry security, AAS Environment, company lookup, and migration
- `go test ./...`
- `go test ./... -cover`
- `go vet ./...`
- `golangci-lint run ./...`

Static checks also confirmed:
- no `container_name` remains in Go-test compose files
- no bare fixed host-port mappings remain in those compose files
- no generated observer/security temp artifacts are included