### PR TITLE
Pin Docker base images by digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,21 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 1
+  - package-ecosystem: "docker"
+    directories:
+      - "/cmd/*"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 1
+    groups:
+      golang-base-images:
+        patterns:
+          - "golang"
+      distroless-base-images:
+        patterns:
+          - "gcr.io/distroless/static"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/container-source-guard.yml
+++ b/.github/workflows/container-source-guard.yml
@@ -1,0 +1,43 @@
+name: Container Source Guard
+
+on:
+  pull_request:
+    paths:
+      - 'cmd/**/Dockerfile'
+      - 'internal/containerchecks/**'
+      - '.github/workflows/container-source-guard.yml'
+      - '.github/workflows/docker-release.yml'
+      - '.github/workflows/docker-snapshot.yml'
+      - 'go.mod'
+      - 'go.sum'
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/**/Dockerfile'
+      - 'internal/containerchecks/**'
+      - '.github/workflows/container-source-guard.yml'
+      - '.github/workflows/docker-release.yml'
+      - '.github/workflows/docker-snapshot.yml'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+
+jobs:
+  dockerfile-digest-pinning:
+    name: Dockerfile digest pinning
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify Dockerfile base image digest pinning
+        run: go test -v ./internal/containerchecks

--- a/cmd/aasenvironmentservice/Dockerfile
+++ b/cmd/aasenvironmentservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -trimpath \
     -o healthprobe ./internal/healthprobe
 
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/aasregistryservice/Dockerfile
+++ b/cmd/aasregistryservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/aasrepositoryservice/Dockerfile
+++ b/cmd/aasrepositoryservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/aasxfileserverservice/Dockerfile
+++ b/cmd/aasxfileserverservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/basyxconfigurationservice/Dockerfile
+++ b/cmd/basyxconfigurationservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/companylookupservice/Dockerfile
+++ b/cmd/companylookupservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/conceptdescriptionrepositoryservice/Dockerfile
+++ b/cmd/conceptdescriptionrepositoryservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/digitaltwinregistryservice/Dockerfile
+++ b/cmd/digitaltwinregistryservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/discoveryservice/Dockerfile
+++ b/cmd/discoveryservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/dppapiservice/Dockerfile
+++ b/cmd/dppapiservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/submodelregistryservice/Dockerfile
+++ b/cmd/submodelregistryservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/cmd/submodelrepositoryservice/Dockerfile
+++ b/cmd/submodelrepositoryservice/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     -o healthprobe ./internal/healthprobe
 
 # Stage 2: Distroless runtime image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 WORKDIR /app
 

--- a/internal/containerchecks/dockerfiles_test.go
+++ b/internal/containerchecks/dockerfiles_test.go
@@ -1,0 +1,150 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+// Package containerchecks contains repository-level checks for container sources.
+package containerchecks
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var dockerImageDigestPattern = regexp.MustCompile(`(?i)@sha256:[a-f0-9]{64}$`)
+
+func TestDockerfilesUseDigestPinnedBaseImages(t *testing.T) {
+	dockerfiles := findServiceDockerfiles(t)
+	if len(dockerfiles) == 0 {
+		t.Fatal("expected at least one service Dockerfile")
+	}
+
+	for _, dockerfilePath := range dockerfiles {
+		serviceName := filepath.Base(filepath.Dir(dockerfilePath))
+		t.Run(serviceName, func(t *testing.T) {
+			assertDockerfileBaseImagesArePinned(t, dockerfilePath)
+		})
+	}
+}
+
+func findServiceDockerfiles(t *testing.T) []string {
+	t.Helper()
+
+	cmdPath := filepath.Join("..", "..", "cmd")
+	entries, err := os.ReadDir(cmdPath)
+	if err != nil {
+		t.Fatalf("read cmd directory: %v", err)
+	}
+
+	var dockerfiles []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		dockerfilePath := filepath.Join(cmdPath, entry.Name(), "Dockerfile")
+		if _, err := os.Stat(dockerfilePath); err == nil {
+			dockerfiles = append(dockerfiles, dockerfilePath)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", dockerfilePath, err)
+		}
+	}
+
+	return dockerfiles
+}
+
+func assertDockerfileBaseImagesArePinned(t *testing.T, dockerfilePath string) {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Clean(dockerfilePath)) // #nosec G304 -- repository-local Dockerfile path discovered from cmd service directories.
+	if err != nil {
+		t.Fatalf("read %s: %v", dockerfilePath, err)
+	}
+
+	stageNames := make(map[string]struct{})
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		instruction, ok := parseFromInstruction(scanner.Text())
+		if !ok {
+			continue
+		}
+
+		if _, ok := stageNames[instruction.image]; !ok && !dockerImageDigestPattern.MatchString(instruction.image) {
+			t.Errorf("%s:%d base image %q is not pinned by sha256 digest", dockerfilePath, lineNumber, instruction.image)
+		}
+
+		if instruction.stageName != "" {
+			stageNames[instruction.stageName] = struct{}{}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan %s: %v", dockerfilePath, err)
+	}
+}
+
+type fromInstruction struct {
+	image     string
+	stageName string
+}
+
+func parseFromInstruction(line string) (fromInstruction, bool) {
+	fields := strings.Fields(line)
+	if len(fields) == 0 || !strings.EqualFold(fields[0], "FROM") {
+		return fromInstruction{}, false
+	}
+
+	imageIndex := firstImageFieldIndex(fields)
+	if imageIndex >= len(fields) {
+		return fromInstruction{}, false
+	}
+
+	return fromInstruction{
+		image:     fields[imageIndex],
+		stageName: stageNameFromFields(fields, imageIndex),
+	}, true
+}
+
+func firstImageFieldIndex(fields []string) int {
+	imageIndex := 1
+	for imageIndex < len(fields) && strings.HasPrefix(fields[imageIndex], "--") {
+		imageIndex++
+	}
+
+	return imageIndex
+}
+
+func stageNameFromFields(fields []string, imageIndex int) string {
+	aliasIndex := imageIndex + 2
+	if aliasIndex >= len(fields) || !strings.EqualFold(fields[imageIndex+1], "AS") {
+		return ""
+	}
+
+	return fields[aliasIndex]
+}


### PR DESCRIPTION
## Summary

- Pin all production service Dockerfile builder/runtime base images with `@sha256` digests
- Add a container source guard test for Dockerfile base image digest pinning
- Add a CI workflow to run the container source guard on Dockerfile/container workflow changes
- Configure Dependabot Docker updates for service Dockerfiles

Closes #453