### PR TITLE
Align DPP API with JTC 24 and improve dependency workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,13 @@ updates:
       default-days: 1
     groups:
       golang-base-images:
+        group-by: dependency-name
         patterns:
           - "golang"
       distroless-base-images:
+        group-by: dependency-name
         patterns:
-          - "gcr.io/distroless/static"
+          - "distroless/static"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -67,6 +67,13 @@ jobs:
             image_builds: |
               eclipsebasyx/digitaltwinregistry-go:SNAPSHOT|./cmd/digitaltwinregistryservice/Dockerfile
               eclipsebasyx/basyxconfigurationservice-go:SNAPSHOT|./cmd/basyxconfigurationservice/Dockerfile
+          - target_name: CatenaXample
+            compose_files: |
+              examples/CatenaXample/docker-compose.yml
+            image_builds: |
+              eclipsebasyx/digitaltwinregistry-go:SNAPSHOT|./cmd/digitaltwinregistryservice/Dockerfile
+              eclipsebasyx/submodelrepository-go:SNAPSHOT|./cmd/submodelrepositoryservice/Dockerfile
+              eclipsebasyx/basyxconfigurationservice-go:SNAPSHOT|./cmd/basyxconfigurationservice/Dockerfile
           - target_name: Company Lookup Example
             compose_files: |
               examples/BaSyxCompanyLookup/docker-compose.yml

--- a/cmd/dppapiservice/openapi.yaml
+++ b/cmd/dppapiservice/openapi.yaml
@@ -12,15 +12,15 @@ servers:
 security:
 - bearerAuth: []
 tags:
-- description: EN 18222 Life Cycle API operations mapped to AAS services.
+- description: DPP life-cycle operations.
   name: DPP Life Cycle
-- description: EN 18222 fine-granular element-level DPP operations.
+- description: Element-level DPP operations.
   name: DPP Fine Granular
 paths:
   /v1/dpps/{dppId}:
     delete:
       description: |
-        Deletes the AAS and DPP metadata resources when deletion is legally permitted. Implementations must enforce archiving and deletion restrictions required by applicable regulation.
+        Deletes the DPP resource when deletion is legally permitted. Implementations must enforce archiving and deletion restrictions required by applicable regulation.
       operationId: deleteDPPById
       parameters:
       - description: Percent-encoded Digital Product Passport identifier.
@@ -77,7 +77,7 @@ paths:
       - DPP Life Cycle
     get:
       description: |
-        Retrieves an AAS and all DPP-relevant Submodels, then composes a single DigitalProductPassport document. Compressed responses use content section properties; full responses use the expanded read-only elements array.
+        Retrieves a DigitalProductPassport document. Compressed responses use content section properties; full responses use the expanded read-only elements array.
       operationId: readDPPById
       parameters:
       - description: Percent-encoded Digital Product Passport identifier.
@@ -140,7 +140,7 @@ paths:
       - DPP Life Cycle
     patch:
       description: |
-        Accepts a compressed partial DPP document using JSON Merge Patch (RFC 7396), decomposes changed header fields into the DppMetadata Submodel and changed content fields into the corresponding content Submodels, updates lastUpdate, and archives the change according to EN 18221. Full representation writes are not supported.
+        Applies a compressed partial DPP document using JSON Merge Patch (RFC 7396), updates lastUpdate, and archives the change according to EN 18221. Full representation writes are not supported.
       operationId: updateDPPById
       parameters:
       - description: Percent-encoded Digital Product Passport identifier.
@@ -217,7 +217,7 @@ paths:
   /v1/dpps:
     post:
       description: |
-        Decomposes the submitted compressed DPP into an AAS, one mandatory DppMetadata Submodel, and one or more content Submodels. Creation is atomic. Full representation writes are not supported.
+        Creates a DPP from the submitted compressed DPP document. Creation is atomic. Full representation writes are not supported.
       operationId: createDPP
       parameters:
       - description: |
@@ -279,7 +279,7 @@ paths:
   /v1/dppsByProductId/{productId}:
     get:
       description: |
-        Resolves the product identifier through the AAS globalAssetId or specificAssetId linkage and composes the corresponding DPP document.
+        Resolves the product identifier and returns the corresponding DPP document.
       operationId: readDPPByProductId
       parameters:
       - description: Percent-encoded product identifier as specified by EN 18219.
@@ -343,7 +343,7 @@ paths:
   /v1/dppsByIdAndDate/{dppId}:
     get:
       description: |
-        Retrieves the DPP version that was current at the provided ISO 8601 UTC timestamp by selecting AAS and Submodel versions whose updatedAt values are less than or equal to the requested date.
+        Retrieves the DPP version that was current at the provided ISO 8601 UTC timestamp.
       operationId: readDPPVersionByIdAndDate
       parameters:
       - description: Percent-encoded Digital Product Passport identifier.
@@ -477,10 +477,10 @@ paths:
       summary: Resolve product IDs to DPP IDs
       tags:
       - DPP Life Cycle
-  /v1/dpps/{dppId}/elements/{elementPath}:
+  /v1/dpps/{dppId}/elements/{elementIdPath}:
     get:
       description: |
-        Retrieves one data element by content section and AAS idShort-based SubmodelElement path. Use <contentSection>/<idShort.path>; slash-containing paths must be percent-encoded.
+        Retrieves one DPP data element. The elementIdPath is an RFC 9535 Normalized Path selecting a single element inside the compressed DPP document and must be percent-encoded once as one path segment.
       operationId: readDataElement
       parameters:
       - description: Percent-encoded Digital Product Passport identifier.
@@ -492,10 +492,11 @@ paths:
           minLength: 1
           type: string
         style: simple
-      - description: Percent-encoded <contentSection>/<idShort.path> DPP element path.
+      - description: RFC 9535 Normalized Path selecting one DPP data element. Clients must percent-encode it once when placing it in a path segment.
+        example: "$['https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0']['ProductCarbonFootprints']"
         explode: false
         in: path
-        name: elementPath
+        name: elementIdPath
         required: true
         schema:
           minLength: 1
@@ -554,7 +555,7 @@ paths:
       - DPP Fine Granular
     patch:
       description: |
-        Updates one DPP data element within a content Submodel using its compressed JSON value and updates the lastUpdate field of the DppMetadata Submodel. Full representation writes are not supported.
+        Updates one DPP data element using its compressed JSON value and updates lastUpdate. The elementIdPath is an RFC 9535 Normalized Path selecting a single element inside the compressed DPP document and must be percent-encoded once as one path segment. Full representation writes are not supported.
       operationId: updateDataElement
       parameters:
       - description: Percent-encoded Digital Product Passport identifier.
@@ -566,10 +567,11 @@ paths:
           minLength: 1
           type: string
         style: simple
-      - description: Percent-encoded <contentSection>/<idShort.path> DPP element path.
+      - description: RFC 9535 Normalized Path selecting one DPP data element. Clients must percent-encode it once when placing it in a path segment.
+        example: "$['https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0']['ProductCarbonFootprints']"
         explode: false
         in: path
-        name: elementPath
+        name: elementIdPath
         required: true
         schema:
           minLength: 1
@@ -659,12 +661,12 @@ components:
         minLength: 1
         type: string
       style: simple
-    ElementPath:
-      description: Percent-encoded DPP elementId / AAS idShort-based SubmodelElement
-        path.
+    ElementIdPath:
+      description: RFC 9535 Normalized Path selecting one DPP data element. Clients must percent-encode it once when placing it in a path segment.
+      example: "$['https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0']['ProductCarbonFootprints']"
       explode: false
       in: path
-      name: elementPath
+      name: elementIdPath
       required: true
       schema:
         minLength: 1
@@ -758,7 +760,7 @@ components:
     DigitalProductPassport:
       additionalProperties: true
       description: |
-        A single DPP JSON document composed from the DppMetadata header and DPP content. Compressed write payloads use top-level content section properties whose names become contributing Submodel idShort values. Full read payloads use the expanded read-only elements array defined by EN 18223 Annex A.
+        A single DPP JSON document composed from DPP header fields and content sections. Compressed write payloads use top-level content section properties whose names match contentSpecificationIds entries. Full read payloads use the expanded read-only elements array defined by the DPP API annex.
       example:
         digitalProductPassportId: https://www.example.org/dpp/1234545
         uniqueProductIdentifier: https://www.example.org/1234545
@@ -769,17 +771,17 @@ components:
         economicOperatorId: gxx:ppp456789
         facilityId: gxx:xxx987654
         contentSpecificationIds:
-        - carbonFootprint - IDTA-02023-1-0
+        - https://admin-shell-io/idta/digitalproductpassport/Nameplate/1
+        https://admin-shell-io/idta/digitalproductpassport/Nameplate/1:
+          ManufacturerName: VoltFabrik GmbH
       properties:
         digitalProductPassportId:
-          description: "DPP identifier. Similar to, but not necessarily identical\
-            \ to, the AAS id."
+          description: Digital Product Passport identifier.
           example: https://www.example.org/dpp/1234545
           minLength: 1
           type: string
         uniqueProductIdentifier:
-          description: Product identifier corresponding to the AAS AssetInformation
-            globalAssetId.
+          description: Unique product identifier associated with the DPP.
           example: https://www.example.org/1234545
           minLength: 1
           type: string
@@ -794,7 +796,7 @@ components:
           minLength: 1
           type: string
         lastUpdate:
-          description: Timestamp corresponding to AAS AdministrativeInformation updatedAt.
+          description: Timestamp of the latest DPP update.
           example: 2025-08-22T03:12:00Z
           format: date-time
           type: string
@@ -810,13 +812,12 @@ components:
           type: string
         contentSpecificationIds:
           description: |
-            Semantic identifiers of contributing content Submodels. Compressed writes currently support unambiguous section-to-specification mapping; expanded DataElementCollection write payloads are rejected.
+            Optional identifiers of content specifications contributing DPP content sections. In compressed representation, a top-level content section named exactly like one of these identifiers contains data for that content specification. Expanded DataElementCollection write payloads are rejected.
           example:
-          - carbonFootprint - IDTA-02023-1-0
+          - https://admin-shell-io/idta/digitalproductpassport/Nameplate/1
           items:
             minLength: 1
             type: string
-          minItems: 1
           type: array
         elements:
           description: Expanded read-only DPP DataElements returned when representation=full.
@@ -824,12 +825,10 @@ components:
             $ref: "#/components/schemas/DataElement"
           type: array
       required:
-      - contentSpecificationIds
       - digitalProductPassportId
       - dppSchemaVersion
       - dppStatus
       - economicOperatorId
-      - facilityId
       - granularity
       - lastUpdate
       - uniqueProductIdentifier
@@ -874,7 +873,7 @@ components:
           type: array
       type: object
     Granularity:
-      description: EN 18223 DPP granularity value mapped to AAS AssetKind.
+      description: EN 18223 DPP granularity value.
       enum:
       - Item
       - Model
@@ -896,7 +895,7 @@ components:
       - $ref: "#/components/schemas/DataElementCollection"
       - $ref: "#/components/schemas/RelatedResource"
     CompressedDataElementValue:
-      description: Raw compressed DPP element value. The value may be a scalar, object, array, or null and is mapped to the target AAS SubmodelElement.
+      description: Raw compressed DPP element value. The value may be a scalar, object, array, or null.
       nullable: true
       oneOf:
       - type: string
@@ -917,7 +916,7 @@ components:
         value: ""
       properties:
         elementId:
-          description: DPP element identifier mapped to AAS Referable/idShort.
+          description: DPP element identifier.
           minLength: 1
           type: string
         objectType:
@@ -925,7 +924,7 @@ components:
           - SingleValuedDataElement
           type: string
         dictionaryReference:
-          description: DPP dictionary reference mapped to AAS semanticId.
+          description: DPP dictionary reference.
           type: string
         valueDataType:
           $ref: "#/components/schemas/XsdValueDataType"
@@ -941,7 +940,7 @@ components:
       additionalProperties: false
       properties:
         elementId:
-          description: DPP element identifier mapped to AAS Referable/idShort.
+          description: DPP element identifier.
           minLength: 1
           type: string
         objectType:
@@ -949,7 +948,7 @@ components:
           - MultiValuedDataElement
           type: string
         dictionaryReference:
-          description: DPP dictionary reference mapped to AAS semanticId.
+          description: DPP dictionary reference.
           type: string
         valueDataType:
           description: Scalar item datatype. Omitted for multi-valued elements whose children are collections, multilingual data, or related resources.
@@ -967,7 +966,7 @@ components:
       additionalProperties: false
       properties:
         elementId:
-          description: DPP element identifier mapped to AAS Referable/idShort.
+          description: DPP element identifier.
           minLength: 1
           type: string
         objectType:
@@ -975,7 +974,7 @@ components:
           - MultiLanguageDataElement
           type: string
         dictionaryReference:
-          description: DPP dictionary reference mapped to AAS semanticId.
+          description: DPP dictionary reference.
           type: string
         value:
           items:
@@ -991,7 +990,7 @@ components:
       additionalProperties: false
       properties:
         elementId:
-          description: DPP element identifier mapped to AAS Referable/idShort.
+          description: DPP element identifier.
           minLength: 1
           type: string
         objectType:
@@ -999,7 +998,7 @@ components:
           - DataElementCollection
           type: string
         dictionaryReference:
-          description: DPP dictionary reference mapped to AAS semanticId.
+          description: DPP dictionary reference.
           type: string
         elements:
           items:
@@ -1014,7 +1013,7 @@ components:
       additionalProperties: false
       properties:
         elementId:
-          description: DPP element identifier mapped to AAS Referable/idShort.
+          description: DPP element identifier.
           minLength: 1
           type: string
         objectType:
@@ -1022,7 +1021,7 @@ components:
           - RelatedResource
           type: string
         dictionaryReference:
-          description: DPP dictionary reference mapped to AAS semanticId.
+          description: DPP dictionary reference.
           type: string
         resourceTitle:
           type: string

--- a/cmd/dppapiservice/openapi.yaml
+++ b/cmd/dppapiservice/openapi.yaml
@@ -480,7 +480,7 @@ paths:
   /v1/dpps/{dppId}/elements/{elementIdPath}:
     get:
       description: |
-        Retrieves one DPP data element. The elementIdPath is an RFC 9535 Normalized Path selecting a single element inside the compressed DPP document and must be percent-encoded once as one path segment.
+        Retrieves one DPP data element. The elementIdPath is an RFC 9535 Normalized Path, the unique absolute path representation for one node, inside the compressed DPP document and must be percent-encoded once as one path segment. Query selectors that can address multiple nodes are not accepted.
       operationId: readDataElement
       parameters:
       - description: Percent-encoded Digital Product Passport identifier.
@@ -492,7 +492,7 @@ paths:
           minLength: 1
           type: string
         style: simple
-      - description: RFC 9535 Normalized Path selecting one DPP data element. Clients must percent-encode it once when placing it in a path segment.
+      - description: RFC 9535 Normalized Path, the unique absolute path representation selecting exactly one DPP data element. Multi-node query selectors are not accepted. Clients must percent-encode it once when placing it in a path segment.
         example: "$['https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0']['ProductCarbonFootprints']"
         explode: false
         in: path
@@ -555,7 +555,7 @@ paths:
       - DPP Fine Granular
     patch:
       description: |
-        Updates one DPP data element using its compressed JSON value and updates lastUpdate. The elementIdPath is an RFC 9535 Normalized Path selecting a single element inside the compressed DPP document and must be percent-encoded once as one path segment. Full representation writes are not supported.
+        Updates one DPP data element using its compressed JSON value and updates lastUpdate. The elementIdPath is an RFC 9535 Normalized Path, the unique absolute path representation for one node, inside the compressed DPP document and must be percent-encoded once as one path segment. Query selectors that can address multiple nodes are not accepted. Full representation writes are not supported.
       operationId: updateDataElement
       parameters:
       - description: Percent-encoded Digital Product Passport identifier.
@@ -567,7 +567,7 @@ paths:
           minLength: 1
           type: string
         style: simple
-      - description: RFC 9535 Normalized Path selecting one DPP data element. Clients must percent-encode it once when placing it in a path segment.
+      - description: RFC 9535 Normalized Path, the unique absolute path representation selecting exactly one DPP data element. Multi-node query selectors are not accepted. Clients must percent-encode it once when placing it in a path segment.
         example: "$['https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0']['ProductCarbonFootprints']"
         explode: false
         in: path
@@ -662,7 +662,7 @@ components:
         type: string
       style: simple
     ElementIdPath:
-      description: RFC 9535 Normalized Path selecting one DPP data element. Clients must percent-encode it once when placing it in a path segment.
+      description: RFC 9535 Normalized Path, the unique absolute path representation selecting exactly one DPP data element. Multi-node query selectors are not accepted. Clients must percent-encode it once when placing it in a path segment.
       example: "$['https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0']['ProductCarbonFootprints']"
       explode: false
       in: path

--- a/examples/BaSyxDPPAPIExample/BaSyx-DPP-API.postman_collection.json
+++ b/examples/BaSyxDPPAPIExample/BaSyx-DPP-API.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "f8b591ca-b837-4965-b4ad-9804d29b7419",
     "name": "BaSyx DPP API - Local",
-    "description": "Requests for the local Docker Compose setup. Create a local Postman environment with the variables documented in README.md, select it, start `docker compose up -d`, then run the lifecycle requests in order. Content sections are dynamic top-level DPP properties that are not header fields, for example `batteryPassport`, `carbonFootprint`, `materialComposition`, `circularity`, and `supplyChain`. The service stores each content section as its own content submodel.",
+    "description": "Requests for the local Docker Compose setup. The collection contains default variables, so it can be imported and run against `docker compose up -d` without a separate Postman environment. Change `baseUrl` to `http://localhost:8088` and set `bearerToken` when using the secured stack. The example DPP uses compressed EN 18223-style content: top-level content keys are contentSpecificationIds, full/expanded representation is requested separately with `representation=full`, and fine-grained element paths use RFC 9535 Normalized Path syntax.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "18591521"
   },
@@ -16,20 +16,25 @@
             {
               "listen": "test",
               "script": {
+                "type": "text/javascript",
                 "exec": [
+                  "const setVariable = (key, value) => {",
+                  "  pm.collectionVariables.set(key, value);",
+                  "  if (pm.environment && pm.environment.name) {",
+                  "    pm.environment.set(key, value);",
+                  "  }",
+                  "};",
+                  "const encodePath = (value) => encodeURIComponent(value).replace(/'/g, '%27');",
                   "pm.test('created or already exists', function () {",
                   "  pm.expect([201, 409]).to.include(pm.response.code);",
                   "});",
                   "if (pm.response.code === 201) {",
                   "  const body = pm.response.json();",
-                  "  pm.environment.set('dppId', body.digitalProductPassportId);",
-                  "  pm.environment.set('dppIdEncoded', encodeURIComponent(encodeURIComponent(body.digitalProductPassportId)));",
-                  "  pm.environment.set('historicalDate', new Date().toISOString());",
+                  "  setVariable('dppId', body.digitalProductPassportId);",
+                  "  setVariable('dppIdEncoded', encodePath(body.digitalProductPassportId));",
+                  "  setVariable('historicalDate', new Date().toISOString());",
                   "}"
-                ],
-                "type": "text/javascript",
-                "packages": {},
-                "requests": {}
+                ]
               }
             }
           ],
@@ -47,7 +52,12 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"digitalProductPassportId\": \"{{dppId}}\",\n  \"uniqueProductIdentifier\": \"{{productId}}\",\n  \"granularity\": \"Item\",\n  \"dppSchemaVersion\": \"EN18222:2026-v1.0\",\n  \"dppStatus\": \"Active\",\n  \"lastUpdate\": \"{{currentTimestamp}}\",\n  \"economicOperatorId\": \"did:example:operator:voltfabrik-gmbh\",\n  \"facilityId\": \"urn:epc:id:sgln:4012345.00001.0\",\n  \"contentSpecificationIds\": [\n    \"batteryPassport - IDTA-02029-1-0\",\n    \"carbonFootprint - IDTA-02023-1-0\",\n    \"materialComposition - IDTA-02030-1-0\",\n    \"circularity - IDTA-02031-1-0\",\n    \"supplyChain - IDTA-02032-1-0\"\n  ],\n  \"batteryPassport\": {\n    \"objectType\": \"DataElementCollection\",\n    \"dictionaryReference\": \"batteryPassport - IDTA-02029-1-0\",\n    \"productName\": \"BPX 92 kWh traction battery pack\",\n    \"manufacturerName\": \"VoltFabrik GmbH\",\n    \"manufacturingDate\": \"2026-05-18\",\n    \"batchNumber\": \"BPX-2026-W20-B17\",\n    \"serialNumbers\": [\n      \"BPX-2026-000184-A\",\n      \"BPX-2026-000184-B\",\n      \"BPX-2026-000184-C\",\n      \"BPX-2026-000184-D\"\n    ],\n    \"energyCapacityKWh\": 92.4,\n    \"nominalVoltageV\": 820,\n    \"cellChemistry\": \"NMC 811\",\n    \"massKg\": 612.8,\n    \"stateOfHealthPercent\": 99.1,\n    \"warrantyMonths\": 96,\n    \"operatingTemperatureRangeC\": {\n      \"minimum\": -30,\n      \"maximum\": 55\n    },\n    \"dimensionsMm\": {\n      \"length\": 2140,\n      \"width\": 1480,\n      \"height\": 165\n    },\n    \"safetyCertifications\": [\n      \"UN 38.3\",\n      \"IEC 62619\",\n      \"ISO 26262 ASIL-C\"\n    ],\n    \"manual\": {\n      \"url\": \"https://manufacturer.example/docs/bpx-92-installation-manual.pdf\",\n      \"contentType\": \"application/pdf\"\n    },\n    \"technicalDatasheet\": {\n      \"url\": \"https://manufacturer.example/docs/bpx-92-datasheet.json\",\n      \"contentType\": \"application/json\"\n    }\n  },\n  \"carbonFootprint\": {\n    \"objectType\": \"DataElementCollection\",\n    \"dictionaryReference\": \"carbonFootprint - IDTA-02023-1-0\",\n    \"declaredUnit\": \"1 battery pack\",\n    \"totalCarbonFootprintKgCO2e\": 4180.75,\n    \"calculationStandard\": \"ISO 14067:2018\",\n    \"verificationStatus\": \"third-party verified\",\n    \"lifecycleStages\": [\n      {\n        \"stage\": \"raw material extraction\",\n        \"valueKgCO2e\": 1210.4,\n        \"dataQuality\": \"measured and supplier-specific\"\n      },\n      {\n        \"stage\": \"cell manufacturing\",\n        \"valueKgCO2e\": 2195.9,\n        \"dataQuality\": \"primary site energy data\"\n      },\n      {\n        \"stage\": \"pack assembly\",\n        \"valueKgCO2e\": 512.2,\n        \"dataQuality\": \"metered facility allocation\"\n      },\n      {\n        \"stage\": \"inbound logistics\",\n        \"valueKgCO2e\": 262.25,\n        \"dataQuality\": \"distance-based calculation\"\n      }\n    ],\n    \"electricityMix\": {\n      \"renewableSharePercent\": 76.5,\n      \"country\": \"DE\",\n      \"referenceYear\": 2025\n    },\n    \"verificationReport\": {\n      \"url\": \"https://manufacturer.example/reports/bpx-2026-000184-carbon-verification.pdf\",\n      \"contentType\": \"application/pdf\"\n    }\n  },\n  \"materialComposition\": {\n    \"objectType\": \"DataElementCollection\",\n    \"dictionaryReference\": \"materialComposition - IDTA-02030-1-0\",\n    \"hazardousSubstancesPresent\": false,\n    \"criticalRawMaterials\": [\n      \"lithium\",\n      \"nickel\",\n      \"cobalt\",\n      \"natural graphite\"\n    ],\n    \"materials\": [\n      {\n        \"name\": \"aluminium\",\n        \"massKg\": 142.6,\n        \"recycledContentPercent\": 48.2,\n        \"supplierCountry\": \"DE\"\n      },\n      {\n        \"name\": \"copper\",\n        \"massKg\": 63.4,\n        \"recycledContentPercent\": 21.7,\n        \"supplierCountry\": \"PL\"\n      },\n      {\n        \"name\": \"nickel sulphate equivalent\",\n        \"massKg\": 71.8,\n        \"recycledContentPercent\": 6.1,\n        \"supplierCountry\": \"FI\"\n      },\n      {\n        \"name\": \"lithium carbonate equivalent\",\n        \"massKg\": 11.9,\n        \"recycledContentPercent\": 3.4,\n        \"supplierCountry\": \"PT\"\n      },\n      {\n        \"name\": \"polymer housing and separators\",\n        \"massKg\": 38.5,\n        \"recycledContentPercent\": 12.0,\n        \"supplierCountry\": \"CZ\"\n      }\n    ],\n    \"substanceCompliance\": {\n      \"reachCompliant\": true,\n      \"rohsCompliant\": true,\n      \"svhcAboveThreshold\": false\n    }\n  },\n  \"circularity\": {\n    \"objectType\": \"DataElementCollection\",\n    \"dictionaryReference\": \"circularity - IDTA-02031-1-0\",\n    \"repairabilityScore\": 8.1,\n    \"dismantlingTimeMinutes\": 46,\n    \"sparePartsAvailableUntil\": \"2036-12-31\",\n    \"recycledContentPercent\": 29.4,\n    \"recyclabilityPercent\": 87.2,\n    \"recommendedEndOfLifeRoute\": \"certified battery recycling with second-life assessment first\",\n    \"serviceOperations\": [\n      \"cell module replacement\",\n      \"battery management system firmware update\",\n      \"cooling plate reseal\",\n      \"high-voltage connector replacement\"\n    ],\n    \"dismantlingInstructions\": {\n      \"url\": \"https://manufacturer.example/docs/bpx-92-dismantling-instructions.pdf\",\n      \"contentType\": \"application/pdf\"\n    }\n  },\n  \"supplyChain\": {\n    \"objectType\": \"DataElementCollection\",\n    \"dictionaryReference\": \"supplyChain - IDTA-02032-1-0\",\n    \"finalAssemblySite\": \"VoltFabrik Plant Leipzig\",\n    \"tierOneSuppliers\": [\n      {\n        \"supplierId\": \"did:example:supplier:cellworks-fi\",\n        \"name\": \"CellWorks Finland Oy\",\n        \"component\": \"battery cells\",\n        \"country\": \"FI\",\n        \"auditStatus\": \"approved\"\n      },\n      {\n        \"supplierId\": \"did:example:supplier:thermoplate-cz\",\n        \"name\": \"ThermoPlate s.r.o.\",\n        \"component\": \"cooling plates\",\n        \"country\": \"CZ\",\n        \"auditStatus\": \"approved with findings\"\n      },\n      {\n        \"supplierId\": \"did:example:supplier:bmslogic-de\",\n        \"name\": \"BMS Logic GmbH\",\n        \"component\": \"battery management system\",\n        \"country\": \"DE\",\n        \"auditStatus\": \"approved\"\n      }\n    ],\n    \"dueDiligence\": {\n      \"policyVersion\": \"2026.2\",\n      \"riskAssessmentDate\": \"2026-04-28\",\n      \"highRiskFindingsOpen\": 0,\n      \"traceabilityCoveragePercent\": 94.7\n    },\n    \"transportRoutes\": [\n      {\n        \"from\": \"Tampere, FI\",\n        \"to\": \"Leipzig, DE\",\n        \"mode\": \"rail\",\n        \"distanceKm\": 1790\n      },\n      {\n        \"from\": \"Brno, CZ\",\n        \"to\": \"Leipzig, DE\",\n        \"mode\": \"truck\",\n        \"distanceKm\": 430\n      }\n    ]\n  }\n}\n"
+              "raw": "{\n  \"digitalProductPassportId\": \"{{dppId}}\",\n  \"uniqueProductIdentifier\": \"{{productId}}\",\n  \"granularity\": \"Item\",\n  \"dppSchemaVersion\": \"ENXXX:v1.0\",\n  \"dppStatus\": \"Active\",\n  \"lastUpdate\": \"{{currentTimestamp}}\",\n  \"economicOperatorId\": \"gxx:ppp456789\",\n  \"facilityId\": \"gxx:xxx987654\",\n  \"contentSpecificationIds\": [\n    \"https://admin-shell-io/idta/digitalproductpassport/Nameplate/1\",\n    \"https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0\",\n    \"https://admin-shell-io/idta/digitalproductpassport/HandoverDocumentation/2\",\n    \"https://admin-shell-io/idta/digitalproductpassport/Circularity/1\"\n  ],\n  \"https://admin-shell-io/idta/digitalproductpassport/Nameplate/1\": {\n    \"ManufacturerName\": \"VoltFabrik GmbH\",\n    \"ProductName\": [\n      {\n        \"value\": \"BPX 92 kWh traction battery pack\",\n        \"language\": \"en-GB\"\n      },\n      {\n        \"value\": \"BPX 92 kWh Traktionsbatterie\",\n        \"language\": \"de-DE\"\n      }\n    ],\n    \"ProductArticleNumber\": \"BPX-92-2026\",\n    \"SerialNumber\": \"BPX-2026-000184\",\n    \"ManufacturingDate\": \"2026-05-18\"\n  },\n  \"https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0\": {\n    \"ProductCarbonFootprints\": [\n      {\n        \"QuantityOfMeasureForCalculation\": 1.0,\n        \"PcfCo2eq\": 4180.75,\n        \"ReferenceImpactUnitForCalculation\": \"kg CO2e\",\n        \"WebLinkToPublicCarbonFootprintStudy\": [\n          \"https://manufacturer.example/reports/bpx-2026-000184-carbon-footprint.pdf\"\n        ],\n        \"PcfCalculationMethods\": [\n          \"ISO 14067\"\n        ],\n        \"PerformanceClass\": \"third-party verified\",\n        \"LifeCyclePhases\": [\n          \"raw material extraction\",\n          \"cell manufacturing\",\n          \"pack assembly\",\n          \"inbound logistics\"\n        ]\n      }\n    ]\n  },\n  \"https://admin-shell-io/idta/digitalproductpassport/HandoverDocumentation/2\": {\n    \"Documents\": [\n      {\n        \"DocumentIds\": [\n          {\n            \"DocumentIdentifier\": \"XF90-884\",\n            \"DocumentIsPrimary\": true,\n            \"DocumentDomainId\": \"1213455566\"\n          }\n        ],\n        \"DocumentVersions\": [\n          {\n            \"DigitalFiles\": [\n              {\n                \"resourceTitle\": \"User Manual for BPX 92 kWh traction battery pack\",\n                \"contentType\": \"application/pdf\",\n                \"url\": \"https://manufacturer.example/docs/bpx-92-user-manual.pdf\",\n                \"language\": \"en-GB\"\n              },\n              {\n                \"resourceTitle\": \"Benutzerhandbuch BPX 92 kWh Traktionsbatterie\",\n                \"contentType\": \"application/pdf\",\n                \"url\": \"https://manufacturer.example/docs/bpx-92-benutzerhandbuch.pdf\",\n                \"language\": \"de-DE\"\n              }\n            ],\n            \"Title\": [\n              {\n                \"value\": \"User Manual for BPX 92 kWh traction battery pack\",\n                \"language\": \"en-GB\"\n              },\n              {\n                \"value\": \"Benutzerhandbuch BPX 92 kWh Traktionsbatterie\",\n                \"language\": \"de-DE\"\n              }\n            ],\n            \"Description\": [\n              {\n                \"value\": \"Installation, operation and service information for the battery pack.\",\n                \"language\": \"en-GB\"\n              },\n              {\n                \"value\": \"Installations-, Betriebs- und Serviceinformationen fuer das Batteriepack.\",\n                \"language\": \"de-DE\"\n              }\n            ],\n            \"Language\": [\n              \"en-GB\",\n              \"de-DE\"\n            ],\n            \"Version\": \"V1.2\"\n          }\n        ],\n        \"DocumentClassifications\": [\n          {\n            \"ClassName\": [\n              {\n                \"value\": \"Operation\",\n                \"language\": \"en-GB\"\n              },\n              {\n                \"value\": \"Bedienung\",\n                \"language\": \"de-DE\"\n              }\n            ],\n            \"ClassId\": \"03-02\",\n            \"ClassificationSystem\": \"VDI2770 Blatt 1:2020\"\n          }\n        ]\n      }\n    ]\n  },\n  \"https://admin-shell-io/idta/digitalproductpassport/Circularity/1\": {\n    \"RecycledContentPercent\": 29.4,\n    \"RecyclabilityPercent\": 87.2,\n    \"RecommendedEndOfLifeRoute\": \"certified battery recycling with second-life assessment first\",\n    \"DismantlingInstructions\": {\n      \"resourceTitle\": \"Dismantling instructions for BPX 92 kWh traction battery pack\",\n      \"contentType\": \"application/pdf\",\n      \"url\": \"https://manufacturer.example/docs/bpx-92-dismantling-instructions.pdf\",\n      \"language\": \"en-GB\"\n    }\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
             },
             "url": {
               "raw": "{{baseUrl}}/v1/dpps",
@@ -131,10 +141,16 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
+                  "const setVariable = (key, value) => {",
+                  "  pm.collectionVariables.set(key, value);",
+                  "  if (pm.environment && pm.environment.name) {",
+                  "    pm.environment.set(key, value);",
+                  "  }",
+                  "};",
                   "pm.test('patched', function () {",
                   "  pm.response.to.have.status(200);",
                   "});",
-                  "pm.environment.set('updatedTimestamp', new Date().toISOString());"
+                  "setVariable('updatedTimestamp', new Date().toISOString());"
                 ]
               }
             }
@@ -153,7 +169,12 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"dppStatus\": \"Active - field updated\",\n  \"carbonFootprint\": {\n    \"totalCarbonFootprintKgCO2e\": 4098.3,\n    \"verificationStatus\": \"third-party verified after supplier update\",\n    \"electricityMix\": {\n      \"renewableSharePercent\": 81.2,\n      \"country\": \"DE\",\n      \"referenceYear\": 2026\n    }\n  },\n  \"circularity\": {\n    \"repairabilityScore\": 8.4,\n    \"serviceOperations\": [\n      \"cell module replacement\",\n      \"battery management system firmware update\",\n      \"cooling plate reseal\",\n      \"high-voltage connector replacement\",\n      \"state-of-health diagnostic refresh\"\n    ]\n  }\n}"
+              "raw": "{\n  \"dppStatus\": \"Active - field updated\",\n  \"https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0\": {\n    \"ProductCarbonFootprints\": [\n      {\n        \"QuantityOfMeasureForCalculation\": 1.0,\n        \"PcfCo2eq\": 4098.3,\n        \"ReferenceImpactUnitForCalculation\": \"kg CO2e\",\n        \"WebLinkToPublicCarbonFootprintStudy\": [\n          \"https://manufacturer.example/reports/bpx-2026-000184-carbon-footprint-v2.pdf\"\n        ],\n        \"PcfCalculationMethods\": [\n          \"ISO 14067\"\n        ],\n        \"PerformanceClass\": \"third-party verified after supplier update\",\n        \"LifeCyclePhases\": [\n          \"raw material extraction\",\n          \"cell manufacturing\",\n          \"pack assembly\",\n          \"inbound logistics\"\n        ]\n      }\n    ]\n  },\n  \"https://admin-shell-io/idta/digitalproductpassport/Circularity/1\": {\n    \"RecyclabilityPercent\": 88.1,\n    \"RecommendedEndOfLifeRoute\": \"certified battery recycling after second-life assessment\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
             },
             "url": {
               "raw": "{{baseUrl}}/v1/dpps/{{dppIdEncoded}}",
@@ -166,31 +187,6 @@
                 "{{dppIdEncoded}}"
               ]
             }
-          },
-          "response": []
-        },
-        {
-          "name": "Delete DPP",
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "Accept",
-                "value": "application/json"
-              }
-            ],
-            "url": {
-              "raw": "{{baseUrl}}/v1/dpps/{{dppIdEncoded}}",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "dpps",
-                "{{dppIdEncoded}}"
-              ]
-            },
-            "description": "Deletes the sample DPP. Run this last if you want to clean up the created resource."
           },
           "response": []
         }
@@ -278,7 +274,7 @@
                   "if (pm.response.code === 200) {",
                   "  const body = pm.response.json();",
                   "  if (body.cursor) {",
-                  "    pm.environment.set('cursor', body.cursor);",
+                  "    pm.collectionVariables.set('cursor', body.cursor);",
                   "  }",
                   "}"
                 ]
@@ -340,7 +336,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/dpps/{{dppIdEncoded}}/elements/{{elementPath}}?representation={{representation}}",
+              "raw": "{{baseUrl}}/v1/dpps/{{dppIdEncoded}}/elements/{{elementIdPathEncoded}}?representation={{representation}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -349,7 +345,7 @@
                 "dpps",
                 "{{dppIdEncoded}}",
                 "elements",
-                "{{elementPath}}"
+                "{{elementIdPathEncoded}}"
               ],
               "query": [
                 {
@@ -358,14 +354,14 @@
                 }
               ]
             },
-            "description": "Default element path reads `batteryPassport/energyCapacityKWh`. You can change `elementPath` to nested values such as `batteryPassport/dimensionsMm.length`."
+            "description": "Reads one DPP data element. Defaults to the carbon footprint list from the compressed example DPP."
           },
           "response": []
         },
         {
           "name": "Update Data Element - Scalar",
           "request": {
-            "method": "PUT",
+            "method": "PATCH",
             "header": [
               {
                 "key": "Content-Type",
@@ -378,10 +374,15 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "93.1"
+              "raw": "\"VoltFabrik GmbH - Example Update\"",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
             },
             "url": {
-              "raw": "{{baseUrl}}/v1/dpps/{{dppIdEncoded}}/elements/batteryPassport/energyCapacityKWh",
+              "raw": "{{baseUrl}}/v1/dpps/{{dppIdEncoded}}/elements/{{nameplateManufacturerPathEncoded}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -390,18 +391,17 @@
                 "dpps",
                 "{{dppIdEncoded}}",
                 "elements",
-                "batteryPassport",
-                "energyCapacityKWh"
+                "{{nameplateManufacturerPathEncoded}}"
               ]
             },
-            "description": "The implementation accepts raw JSON values for element updates. This updates a scalar number."
+            "description": "Replaces one scalar data element using the fine-grained DPP API."
           },
           "response": []
         },
         {
           "name": "Update Data Element - Collection",
           "request": {
-            "method": "PUT",
+            "method": "PATCH",
             "header": [
               {
                 "key": "Content-Type",
@@ -414,10 +414,15 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"minimum\": -35,\n  \"maximum\": 60,\n  \"testStandard\": \"IEC 60068-2\",\n  \"validatedAt\": \"{{currentTimestamp}}\"\n}"
+              "raw": "[\n  {\n    \"QuantityOfMeasureForCalculation\": 1.0,\n    \"PcfCo2eq\": 4075.6,\n    \"ReferenceImpactUnitForCalculation\": \"kg CO2e\",\n    \"WebLinkToPublicCarbonFootprintStudy\": [\n      \"https://manufacturer.example/reports/bpx-2026-000184-carbon-footprint-fine-grained.pdf\"\n    ],\n    \"PcfCalculationMethods\": [\n      \"ISO 14067\"\n    ],\n    \"PerformanceClass\": \"third-party verified fine-grained update\",\n    \"LifeCyclePhases\": [\n      \"raw material extraction\",\n      \"cell manufacturing\",\n      \"pack assembly\",\n      \"inbound logistics\"\n    ]\n  }\n]",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
             },
             "url": {
-              "raw": "{{baseUrl}}/v1/dpps/{{dppIdEncoded}}/elements/batteryPassport/operatingTemperatureRangeC",
+              "raw": "{{baseUrl}}/v1/dpps/{{dppIdEncoded}}/elements/{{carbonFootprintPathEncoded}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -426,11 +431,10 @@
                 "dpps",
                 "{{dppIdEncoded}}",
                 "elements",
-                "batteryPassport",
-                "operatingTemperatureRangeC"
+                "{{carbonFootprintPathEncoded}}"
               ]
             },
-            "description": "Updates a nested collection-style element with a larger JSON object."
+            "description": "Replaces the ProductCarbonFootprints multi-valued data element using the fine-grained DPP API."
           },
           "response": []
         }
@@ -464,6 +468,36 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Cleanup",
+      "item": [
+        {
+          "name": "Delete DPP",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/dpps/{{dppIdEncoded}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "dpps",
+                "{{dppIdEncoded}}"
+              ]
+            },
+            "description": "Deletes the sample DPP after the lifecycle, lookup, and fine-granular requests."
+          },
+          "response": []
+        }
+      ]
     }
   ],
   "auth": {
@@ -482,20 +516,131 @@
       "script": {
         "type": "text/javascript",
         "exec": [
-          "const dppId = pm.environment.get('dppId');",
-          "const productId = pm.environment.get('productId');",
+          "const setVariable = (key, value) => {",
+          "  pm.collectionVariables.set(key, value);",
+          "  if (pm.environment && pm.environment.name) {",
+          "    pm.environment.set(key, value);",
+          "  }",
+          "};",
+          "const encodePath = (value) => encodeURIComponent(value).replace(/'/g, '%27');",
+          "const dppId = pm.variables.get('dppId');",
+          "const productId = pm.variables.get('productId');",
+          "const elementIdPath = pm.variables.get('elementIdPath');",
+          "const nameplateManufacturerPath = pm.variables.get('nameplateManufacturerPath');",
+          "const carbonFootprintPath = pm.variables.get('carbonFootprintPath');",
           "if (dppId) {",
-          "  pm.environment.set('dppIdEncoded', encodeURIComponent(encodeURIComponent(dppId)));",
+          "  setVariable('dppIdEncoded', encodePath(dppId));",
           "}",
           "if (productId) {",
-          "  pm.environment.set('productIdEncoded', encodeURIComponent(encodeURIComponent(productId)));",
+          "  setVariable('productIdEncoded', encodePath(productId));",
           "}",
-          "pm.environment.set('currentTimestamp', new Date().toISOString());",
-          "if (!pm.environment.get('historicalDate')) {",
-          "  pm.environment.set('historicalDate', new Date().toISOString());",
+          "if (elementIdPath) {",
+          "  setVariable('elementIdPathEncoded', encodePath(elementIdPath));",
+          "}",
+          "if (nameplateManufacturerPath) {",
+          "  setVariable('nameplateManufacturerPathEncoded', encodePath(nameplateManufacturerPath));",
+          "}",
+          "if (carbonFootprintPath) {",
+          "  setVariable('carbonFootprintPathEncoded', encodePath(carbonFootprintPath));",
+          "}",
+          "setVariable('currentTimestamp', new Date().toISOString());",
+          "if (!pm.variables.get('historicalDate')) {",
+          "  setVariable('historicalDate', new Date().toISOString());",
           "}"
         ]
       }
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080",
+      "type": "string"
+    },
+    {
+      "key": "bearerToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "dppId",
+      "value": "https://www.example.org/batterypassport/1234545",
+      "type": "string"
+    },
+    {
+      "key": "dppIdEncoded",
+      "value": "https%3A%2F%2Fwww.example.org%2Fbatterypassport%2F1234545",
+      "type": "string"
+    },
+    {
+      "key": "productId",
+      "value": "https://www.example.org/1234545",
+      "type": "string"
+    },
+    {
+      "key": "productIdEncoded",
+      "value": "https%3A%2F%2Fwww.example.org%2F1234545",
+      "type": "string"
+    },
+    {
+      "key": "elementIdPath",
+      "value": "$['https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0']['ProductCarbonFootprints']",
+      "type": "string"
+    },
+    {
+      "key": "elementIdPathEncoded",
+      "value": "%24%5B%27https%3A%2F%2Fadmin-shell.io%2Fidta%2FCarbonFootprint%2FCarbonFootprint%2F1%2F0%27%5D%5B%27ProductCarbonFootprints%27%5D",
+      "type": "string"
+    },
+    {
+      "key": "nameplateManufacturerPath",
+      "value": "$['https://admin-shell-io/idta/digitalproductpassport/Nameplate/1']['ManufacturerName']",
+      "type": "string"
+    },
+    {
+      "key": "nameplateManufacturerPathEncoded",
+      "value": "%24%5B%27https%3A%2F%2Fadmin-shell-io%2Fidta%2Fdigitalproductpassport%2FNameplate%2F1%27%5D%5B%27ManufacturerName%27%5D",
+      "type": "string"
+    },
+    {
+      "key": "carbonFootprintPath",
+      "value": "$['https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0']['ProductCarbonFootprints']",
+      "type": "string"
+    },
+    {
+      "key": "carbonFootprintPathEncoded",
+      "value": "%24%5B%27https%3A%2F%2Fadmin-shell.io%2Fidta%2FCarbonFootprint%2FCarbonFootprint%2F1%2F0%27%5D%5B%27ProductCarbonFootprints%27%5D",
+      "type": "string"
+    },
+    {
+      "key": "representation",
+      "value": "compressed",
+      "type": "string"
+    },
+    {
+      "key": "historicalDate",
+      "value": "2026-06-11T12:00:00Z",
+      "type": "string"
+    },
+    {
+      "key": "currentTimestamp",
+      "value": "2026-06-11T12:00:00Z",
+      "type": "string"
+    },
+    {
+      "key": "updatedTimestamp",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "limit",
+      "value": "20",
+      "type": "string"
+    },
+    {
+      "key": "cursor",
+      "value": "",
+      "type": "string"
     }
   ]
 }

--- a/examples/BaSyxDPPAPIExample/README.md
+++ b/examples/BaSyxDPPAPIExample/README.md
@@ -91,13 +91,13 @@ Import `BaSyx-DPP-API.postman_collection.json` into Postman to run the example s
 - Read and update individual DPP elements
 - Delete the demo DPP when you are done
 
-No Postman environment file is currently committed. Create a local environment with these variables when you want to run the full collection:
+The collection contains default collection variables, so a separate Postman environment is not required for the default stack. Adjust these variables in the collection when needed:
 
 - `baseUrl`: `http://localhost:8080` for the default stack or `http://localhost:8088` for the secured stack
 - `bearerToken`: bearer token for secured requests
-- `dppId`, `dppIdEncoded`: demo DPP ID and its double-URL-encoded form
-- `productId`, `productIdEncoded`: demo product ID and its double-URL-encoded form
-- `elementPath`: DPP element path for the collection payload, such as `batteryPassport/energyCapacityKWh`
+- `dppId`, `dppIdEncoded`: demo DPP ID and its percent-encoded form
+- `productId`, `productIdEncoded`: demo product ID and its percent-encoded form
+- `elementIdPath`, `elementIdPathEncoded`: RFC 9535 Normalized Path for the collection payload, such as `$['https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0']['ProductCarbonFootprints']`
 - `representation`: `compressed` or `full`
 - `historicalDate`, `currentTimestamp`: ISO-8601 timestamps used by history requests
 - `limit`, `cursor`: pagination values
@@ -113,28 +113,28 @@ curl -i \
 
 ## Read The DPP
 
-The example DPP ID is `https://example.org/dpp/demo-product-001`.
+The example DPP ID is `https://www.example.org/batterypassport/1234545`.
 
 ```bash
-curl http://localhost:8080/v1/dpps/https%253A%252F%252Fexample.org%252Fdpp%252Fdemo-product-001
+curl http://localhost:8080/v1/dpps/https%3A%2F%2Fwww.example.org%2Fbatterypassport%2F1234545
 ```
 
 Read the full representation:
 
 ```bash
-curl "http://localhost:8080/v1/dpps/https%253A%252F%252Fexample.org%252Fdpp%252Fdemo-product-001?representation=full"
+curl "http://localhost:8080/v1/dpps/https%3A%2F%2Fwww.example.org%2Fbatterypassport%2F1234545?representation=full"
 ```
 
 Read by product ID:
 
 ```bash
-curl http://localhost:8080/v1/dppsByProductId/https%253A%252F%252Fexample.org%252Fproducts%252Fdemo-product-001
+curl http://localhost:8080/v1/dppsByProductId/https%3A%2F%2Fwww.example.org%2F1234545
 ```
 
 Read a single data element:
 
 ```bash
-curl http://localhost:8080/v1/dpps/https%253A%252F%252Fexample.org%252Fdpp%252Fdemo-product-001/elements/technicalData/manufacturerName
+curl http://localhost:8080/v1/dpps/https%3A%2F%2Fwww.example.org%2Fbatterypassport%2F1234545/elements/%24%5B%27https%3A%2F%2Fadmin-shell.io%2Fidta%2FCarbonFootprint%2FCarbonFootprint%2F1%2F0%27%5D%5B%27ProductCarbonFootprints%27%5D
 ```
 
 Update a single data element:
@@ -143,14 +143,14 @@ Update a single data element:
 curl -i \
   -X PATCH \
   -H "Content-Type: application/json" \
-  --data '"B"' \
-  http://localhost:8080/v1/dpps/https%253A%252F%252Fexample.org%252Fdpp%252Fdemo-product-001/elements/technicalData/energyClass
+  --data '"VoltFabrik GmbH - Curl Update"' \
+  http://localhost:8080/v1/dpps/https%3A%2F%2Fwww.example.org%2Fbatterypassport%2F1234545/elements/%24%5B%27https%3A%2F%2Fadmin-shell-io%2Fidta%2Fdigitalproductpassport%2FNameplate%2F1%27%5D%5B%27ManufacturerName%27%5D
 ```
 
 Read a historical DPP version:
 
 ```bash
-curl "http://localhost:8080/v1/dppsByIdAndDate/https%253A%252F%252Fexample.org%252Fdpp%252Fdemo-product-001?date=2026-06-11T12:00:00Z&representation=compressed"
+curl "http://localhost:8080/v1/dppsByIdAndDate/https%3A%2F%2Fwww.example.org%2Fbatterypassport%2F1234545?date=2026-06-11T12:00:00Z&representation=compressed"
 ```
 
 ## Service Endpoints
@@ -187,4 +187,6 @@ docker compose down -v
 - The DB schema is initialized by the BaSyx Configuration Service before the DPP API and AAS Environment start.
 - The DPP API and AAS Environment use the same PostgreSQL database, so DPP-created AAS and Submodels are visible through the AAS Environment APIs and UI.
 - The DPP API Service enables audit history internally, and the compose environment enables the same audit/history settings for both DPP API and AAS Environment.
-- Path parameters containing URLs must be URL-escaped twice for the generated router.
+- The sample uses compressed EN 18223-style content: top-level content keys are the `contentSpecificationIds`; full/expanded representation is available via `representation=full`.
+- Fine-grained element paths use RFC 9535 Normalized Path syntax, for example `$['<contentSpecificationId>']['<elementId>']`.
+- Path parameters containing URLs or Normalized Path expressions must be percent-encoded once so they stay one path segment.

--- a/examples/BaSyxDPPAPIExample/sample-dpp.json
+++ b/examples/BaSyxDPPAPIExample/sample-dpp.json
@@ -1,30 +1,137 @@
 {
-  "digitalProductPassportId": "https://example.org/dpp/demo-product-001",
-  "uniqueProductIdentifier": "https://example.org/products/demo-product-001",
+  "digitalProductPassportId": "https://www.example.org/batterypassport/1234545",
+  "uniqueProductIdentifier": "https://www.example.org/1234545",
   "granularity": "Item",
-  "dppSchemaVersion": "1.0.0",
-  "dppStatus": "active",
+  "dppSchemaVersion": "ENXXX:v1.0",
+  "dppStatus": "Active",
   "lastUpdate": "2026-06-11T12:00:00Z",
-  "economicOperatorId": "operator-123",
-  "facilityId": "facility-456",
+  "economicOperatorId": "gxx:ppp456789",
+  "facilityId": "gxx:xxx987654",
   "contentSpecificationIds": [
-    "technicalData-specification"
+    "https://admin-shell-io/idta/digitalproductpassport/Nameplate/1",
+    "https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0",
+    "https://admin-shell-io/idta/digitalproductpassport/HandoverDocumentation/2",
+    "https://admin-shell-io/idta/digitalproductpassport/Circularity/1"
   ],
-  "technicalData": {
-    "manufacturerName": "Example Manufacturing GmbH",
-    "warrantyMonths": 24,
-    "energyClass": "A",
-    "serialNumbers": [
-      "SN-001",
-      "SN-002"
+  "https://admin-shell-io/idta/digitalproductpassport/Nameplate/1": {
+    "ManufacturerName": "VoltFabrik GmbH",
+    "ProductName": [
+      {
+        "value": "BPX 92 kWh traction battery pack",
+        "language": "en-GB"
+      },
+      {
+        "value": "BPX 92 kWh Traktionsbatterie",
+        "language": "de-DE"
+      }
     ],
-    "dimensions": {
-      "widthMm": 120,
-      "heightMm": 80
-    },
-    "manual": {
-      "url": "https://example.org/manuals/demo-product-001.pdf",
-      "contentType": "application/pdf"
+    "ProductArticleNumber": "BPX-92-2026",
+    "SerialNumber": "BPX-2026-000184",
+    "ManufacturingDate": "2026-05-18"
+  },
+  "https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0": {
+    "ProductCarbonFootprints": [
+      {
+        "QuantityOfMeasureForCalculation": 1.0,
+        "PcfCo2eq": 4180.75,
+        "ReferenceImpactUnitForCalculation": "kg CO2e",
+        "WebLinkToPublicCarbonFootprintStudy": [
+          "https://manufacturer.example/reports/bpx-2026-000184-carbon-footprint.pdf"
+        ],
+        "PcfCalculationMethods": [
+          "ISO 14067"
+        ],
+        "PerformanceClass": "third-party verified",
+        "LifeCyclePhases": [
+          "raw material extraction",
+          "cell manufacturing",
+          "pack assembly",
+          "inbound logistics"
+        ]
+      }
+    ]
+  },
+  "https://admin-shell-io/idta/digitalproductpassport/HandoverDocumentation/2": {
+    "Documents": [
+      {
+        "DocumentIds": [
+          {
+            "DocumentIdentifier": "XF90-884",
+            "DocumentIsPrimary": true,
+            "DocumentDomainId": "1213455566"
+          }
+        ],
+        "DocumentVersions": [
+          {
+            "DigitalFiles": [
+              {
+                "resourceTitle": "User Manual for BPX 92 kWh traction battery pack",
+                "contentType": "application/pdf",
+                "url": "https://manufacturer.example/docs/bpx-92-user-manual.pdf",
+                "language": "en-GB"
+              },
+              {
+                "resourceTitle": "Benutzerhandbuch BPX 92 kWh Traktionsbatterie",
+                "contentType": "application/pdf",
+                "url": "https://manufacturer.example/docs/bpx-92-benutzerhandbuch.pdf",
+                "language": "de-DE"
+              }
+            ],
+            "Title": [
+              {
+                "value": "User Manual for BPX 92 kWh traction battery pack",
+                "language": "en-GB"
+              },
+              {
+                "value": "Benutzerhandbuch BPX 92 kWh Traktionsbatterie",
+                "language": "de-DE"
+              }
+            ],
+            "Description": [
+              {
+                "value": "Installation, operation and service information for the battery pack.",
+                "language": "en-GB"
+              },
+              {
+                "value": "Installations-, Betriebs- und Serviceinformationen fuer das Batteriepack.",
+                "language": "de-DE"
+              }
+            ],
+            "Language": [
+              "en-GB",
+              "de-DE"
+            ],
+            "Version": "V1.2"
+          }
+        ],
+        "DocumentClassifications": [
+          {
+            "ClassName": [
+              {
+                "value": "Operation",
+                "language": "en-GB"
+              },
+              {
+                "value": "Bedienung",
+                "language": "de-DE"
+              }
+            ],
+            "ClassId": "03-02",
+            "ClassificationSystem": "VDI2770 Blatt 1:2020"
+          }
+        ]
+      }
+    ]
+  },
+  "https://admin-shell-io/idta/digitalproductpassport/Circularity/1": {
+    "RecycledContentPercent": 29.4,
+    "RecyclabilityPercent": 87.2,
+    "RecommendedEndOfLifeRoute": "certified battery recycling with second-life assessment first",
+    "DismantlingInstructions": {
+      "resourceTitle": "Dismantling instructions for BPX 92 kWh traction battery pack",
+      "contentType": "application/pdf",
+      "url": "https://manufacturer.example/docs/bpx-92-dismantling-instructions.pdf",
+      "language": "en-GB"
     }
   }
 }

--- a/examples/CatenaXample/README.md
+++ b/examples/CatenaXample/README.md
@@ -5,7 +5,7 @@ Digital Twin Registry and Submodel Repository. The name combines "Catena-X"
 and "example"; the scenarios model Catena-X-style partner visibility with
 public markers and BPN-specific markers.
 
-This example builds the current repository code and runs:
+This example pulls the BaSyx `SNAPSHOT` images and runs:
 
 - a Digital Twin Registry on `http://localhost:5004/api/v3`;
 - a Submodel Repository on `http://localhost:5005`;
@@ -35,11 +35,15 @@ semantic ID marker rows.
 Run from this directory:
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 ```
 
 The BaSyx UI uses the `basyx-ui` OAuth2 auth-code client from the imported
 Keycloak realm and is configured through `basyx-infra.yml`.
+
+To run locally built BaSyx service images instead, build the same `SNAPSHOT`
+tags from the repository root first and start this compose stack with
+`docker compose up -d --pull never`.
 
 ## UI Setup
 

--- a/examples/CatenaXample/docker-compose.yml
+++ b/examples/CatenaXample/docker-compose.yml
@@ -36,9 +36,8 @@ services:
       retries: 20
 
   dtr-configuration:
-    build:
-      context: ../..
-      dockerfile: ./cmd/basyxconfigurationservice/Dockerfile
+    image: eclipsebasyx/basyxconfigurationservice-go:SNAPSHOT
+    pull_policy: always
     environment:
       POSTGRES_HOST: dtr-db
       POSTGRES_PORT: 5432
@@ -50,9 +49,8 @@ services:
         condition: service_healthy
 
   smrepo-configuration:
-    build:
-      context: ../..
-      dockerfile: ./cmd/basyxconfigurationservice/Dockerfile
+    image: eclipsebasyx/basyxconfigurationservice-go:SNAPSHOT
+    pull_policy: always
     environment:
       POSTGRES_HOST: smrepo-db
       POSTGRES_PORT: 5432
@@ -64,9 +62,8 @@ services:
         condition: service_healthy
 
   digital-twin-registry:
-    build:
-      context: ../..
-      dockerfile: ./cmd/digitaltwinregistryservice/Dockerfile
+    image: eclipsebasyx/digitaltwinregistry-go:SNAPSHOT
+    pull_policy: always
     environment:
       SERVER_PORT: 5004
       SERVER_CONTEXTPATH: /api/v3
@@ -99,9 +96,8 @@ services:
         condition: service_completed_successfully
 
   submodel-repository:
-    build:
-      context: ../..
-      dockerfile: ./cmd/submodelrepositoryservice/Dockerfile
+    image: eclipsebasyx/submodelrepository-go:SNAPSHOT
+    pull_policy: always
     environment:
       SERVER_PORT: 5004
       SERVER_STRICTVERIFICATION: "off"

--- a/internal/aasenvironment/marker_access_integration_tests/marker_access_integration_test.go
+++ b/internal/aasenvironment/marker_access_integration_tests/marker_access_integration_test.go
@@ -134,9 +134,14 @@ func markerComposeReplacements(
 	}
 	repositoryRoot := filepath.Clean(filepath.Join(absoluteExamplePath, "..", ".."))
 	replacements := markerReplacements(runtime)
+	configurationImage := "    image: eclipsebasyx/basyxconfigurationservice-go:SNAPSHOT\n    pull_policy: always"
+	digitalTwinRegistryImage := "    image: eclipsebasyx/digitaltwinregistry-go:SNAPSHOT\n    pull_policy: always"
+	submodelRepositoryImage := "    image: eclipsebasyx/submodelrepository-go:SNAPSHOT\n    pull_policy: always"
 	required := []string{
 		"    container_name: marker-access-aas-web-ui\n",
-		"context: ../..",
+		configurationImage,
+		digitalTwinRegistryImage,
+		submodelRepositoryImage,
 		"- ./security/dtr:/security:ro",
 		"- ./security/smrepo:/security:ro",
 		"- ./basyx-infra.yml:/basyx-infra.yml:ro",
@@ -147,16 +152,22 @@ func markerComposeReplacements(
 		`- "8080:8080"`,
 	}
 	replacements[required[0]] = ""
-	replacements[required[1]] = fmt.Sprintf("context: %q", repositoryRoot)
-	replacements[required[2]] = "- " + dtrSecurityEnv + ":/security:ro"
-	replacements[required[3]] = "- " + smSecurityEnv + ":/security:ro"
-	replacements[required[4]] = "- " + infraFile + ":/basyx-infra.yml:ro"
-	replacements[required[5]] = "- " + filepath.Join(absoluteExamplePath, "keycloak", "realm") + ":/opt/keycloak/data/import:ro"
-	replacements[required[6]] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("dtr"))
-	replacements[required[7]] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("sm"))
-	replacements[required[8]] = fmt.Sprintf(`- "127.0.0.1:%d:3000"`, runtime.Port("ui"))
-	replacements[required[9]] = fmt.Sprintf(`- "0.0.0.0:%d:8080"`, runtime.Port("keycloak"))
+	replacements[required[1]] = markerLocalBuild(repositoryRoot, "./cmd/basyxconfigurationservice/Dockerfile")
+	replacements[required[2]] = markerLocalBuild(repositoryRoot, "./cmd/digitaltwinregistryservice/Dockerfile")
+	replacements[required[3]] = markerLocalBuild(repositoryRoot, "./cmd/submodelrepositoryservice/Dockerfile")
+	replacements[required[4]] = "- " + dtrSecurityEnv + ":/security:ro"
+	replacements[required[5]] = "- " + smSecurityEnv + ":/security:ro"
+	replacements[required[6]] = "- " + infraFile + ":/basyx-infra.yml:ro"
+	replacements[required[7]] = "- " + filepath.Join(absoluteExamplePath, "keycloak", "realm") + ":/opt/keycloak/data/import:ro"
+	replacements[required[8]] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("dtr"))
+	replacements[required[9]] = fmt.Sprintf(`- "127.0.0.1:%d:5004"`, runtime.Port("sm"))
+	replacements[required[10]] = fmt.Sprintf(`- "127.0.0.1:%d:3000"`, runtime.Port("ui"))
+	replacements[required[11]] = fmt.Sprintf(`- "0.0.0.0:%d:8080"`, runtime.Port("keycloak"))
 	return replacements, required
+}
+
+func markerLocalBuild(repositoryRoot string, dockerfile string) string {
+	return fmt.Sprintf("    build:\n      context: %q\n      dockerfile: %s", repositoryRoot, dockerfile)
 }
 
 func prepareMarkerFile(

--- a/internal/common/security/abac_engine_methods.go
+++ b/internal/common/security/abac_engine_methods.go
@@ -260,7 +260,7 @@ var routeProbeMethods = []string{
 //   - mapped=false, routeFound=true when the route exists but has no rights mapping
 //   - mapped=true, routeFound=true with one or more rights alternatives
 func (m *AccessModel) mapMethodAndPathToRights(in EvalInput) ([][]grammar.RightsEnum, bool, bool) {
-	matchPath := stripBasePath(m.basePath, in.Path)
+	matchPath := stripBasePath(m.basePath, routePath(in))
 	if isNonRootTrailingSlashPath(matchPath) {
 		return nil, false, false
 	}
@@ -289,6 +289,13 @@ func (m *AccessModel) mapMethodAndPathToRights(in EvalInput) ([][]grammar.Rights
 	}
 
 	return nil, false, true
+}
+
+func routePath(in EvalInput) string {
+	if in.RoutePath != "" {
+		return in.RoutePath
+	}
+	return in.Path
 }
 
 func (m *AccessModel) routeExistsForAnyMethod(requestPath string) bool {

--- a/internal/common/security/abac_engine_methods_dpp_test.go
+++ b/internal/common/security/abac_engine_methods_dpp_test.go
@@ -57,6 +57,12 @@ func TestMapMethodAndPathToRights_DPPAPIRoutes(t *testing.T) {
 			want:   []grammar.RightsEnum{grammar.RightsEnumREAD},
 		},
 		{
+			name:   "read dpp by encoded URL id maps to read",
+			method: http.MethodGet,
+			path:   "/v1/dpps/https%3A%2F%2Fexample.org%2Fdpp%2F1",
+			want:   []grammar.RightsEnum{grammar.RightsEnumREAD},
+		},
+		{
 			name:   "delete dpp by id maps to delete",
 			method: http.MethodDelete,
 			path:   "/v1/dpps/demo",
@@ -104,6 +110,12 @@ func TestMapMethodAndPathToRights_DPPAPIRoutes(t *testing.T) {
 			path:   "/v1/dpps/demo/elements/technicalData/energyClass",
 			want:   []grammar.RightsEnum{grammar.RightsEnumUPDATE},
 		},
+		{
+			name:   "patch data element by encoded JSONPath maps to update",
+			method: http.MethodPatch,
+			path:   "/v1/dpps/https%3A%2F%2Fexample.org%2Fdpp%2F1/elements/%24%5B%27https%3A%2F%2Fexample.org%2Fspec%27%5D%5B%27energyClass%27%5D",
+			want:   []grammar.RightsEnum{grammar.RightsEnumUPDATE},
+		},
 	}
 
 	for _, tt := range tests {
@@ -121,6 +133,182 @@ func TestMapMethodAndPathToRights_DPPAPIRoutes(t *testing.T) {
 			assertRightsAlternative(t, rights, tt.want)
 		})
 	}
+}
+
+func TestABACMiddleware_DPPURLLikeIdentifierUsesEscapedPath(t *testing.T) {
+	router := chi.NewRouter()
+	common.ConfigureAPIRouter(router, "DPPAPIService")
+	model, err := ParseAccessModel([]byte(`{
+		"AllAccessPermissionRules": {
+			"DEFATTRIBUTES": [
+				{
+					"name": "sub_claim",
+					"attributes": [
+						{ "CLAIM": "sub" }
+					]
+				}
+			],
+			"DEFOBJECTS": [
+				{
+					"name": "dpp_api",
+					"objects": [
+						{ "ROUTE": "/v1/dpps/*" }
+					]
+				}
+			],
+			"DEFACLS": [
+				{
+					"name": "read",
+					"acl": {
+						"USEATTRIBUTES": "sub_claim",
+						"RIGHTS": [ "READ" ],
+						"ACCESS": "ALLOW"
+					}
+				}
+			],
+			"DEFFORMULAS": [
+				{
+					"name": "always_true",
+					"formula": { "$boolean": true }
+				}
+			],
+			"rules": [
+				{
+					"USEACL": "read",
+					"USEOBJECTS": [ "dpp_api" ],
+					"USEFORMULA": "always_true"
+				}
+			]
+		}
+	}`), router, "")
+	if err != nil {
+		t.Fatalf("ParseAccessModel() error = %v", err)
+	}
+
+	router.Use(ABACMiddleware(ABACSettings{
+		Enabled: true,
+		Model:   model,
+	}))
+	handlerCalled := false
+	router.Method(http.MethodGet, "/v1/dpps/{dppId}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/dpps/https%3A%2F%2Fexample.org%2Fdpp%2F1", nil)
+	ctx := context.WithValue(req.Context(), ClaimsKey, Claims{"sub": "tester"})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusNoContent, rec.Code, rec.Body.String())
+	}
+	if !handlerCalled {
+		t.Fatal("protected DPP handler was not called")
+	}
+}
+
+func TestABACMiddleware_EncodedSpaceUsesDecodedPathForPolicyMatching(t *testing.T) {
+	router := chi.NewRouter()
+	common.ConfigureAPIRouter(router, "DPPAPIService")
+	model, err := ParseAccessModel([]byte(`{
+		"AllAccessPermissionRules": {
+			"DEFATTRIBUTES": [
+				{
+					"name": "sub_claim",
+					"attributes": [
+						{ "CLAIM": "sub" }
+					]
+				}
+			],
+			"DEFOBJECTS": [
+				{
+					"name": "exact_dpp",
+					"objects": [
+						{ "ROUTE": "/v1/dpps/product one" }
+					]
+				}
+			],
+			"DEFACLS": [
+				{
+					"name": "read",
+					"acl": {
+						"USEATTRIBUTES": "sub_claim",
+						"RIGHTS": [ "READ" ],
+						"ACCESS": "ALLOW"
+					}
+				}
+			],
+			"DEFFORMULAS": [
+				{
+					"name": "always_true",
+					"formula": { "$boolean": true }
+				}
+			],
+			"rules": [
+				{
+					"USEACL": "read",
+					"USEOBJECTS": [ "exact_dpp" ],
+					"USEFORMULA": "always_true"
+				}
+			]
+		}
+	}`), router, "")
+	if err != nil {
+		t.Fatalf("ParseAccessModel() error = %v", err)
+	}
+
+	router.Use(ABACMiddleware(ABACSettings{
+		Enabled: true,
+		Model:   model,
+	}))
+	handlerCalled := false
+	router.Method(http.MethodGet, "/v1/dpps/{dppId}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/dpps/product%20one", nil)
+	ctx := context.WithValue(req.Context(), ClaimsKey, Claims{"sub": "tester"})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusNoContent, rec.Code, rec.Body.String())
+	}
+	if !handlerCalled {
+		t.Fatal("protected DPP handler was not called")
+	}
+}
+
+func TestABACMiddleware_DPPURLLikeIdentifierWrongMethodReturnsMethodNotAllowed(t *testing.T) {
+	router := chi.NewRouter()
+	common.ConfigureAPIRouter(router, "DPPAPIService")
+	model := &AccessModel{apiRouter: router, basePath: ""}
+
+	router.Use(ABACMiddleware(ABACSettings{
+		Enabled: true,
+		Model:   model,
+	}))
+	router.Method(http.MethodGet, "/v1/dpps/{dppId}", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/dpps/https%3A%2F%2Fexample.org%2Fdpp%2F1", nil)
+	ctx := context.WithValue(req.Context(), ClaimsKey, Claims{"sub": "tester"})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusMethodNotAllowed, rec.Code, rec.Body.String())
+	}
+	assertRouterErrorBody(t, rec.Body.Bytes(), "method not allowed", "DPPAPISERVICE-ROUTER-METHODNOTALLOWED")
 }
 
 func TestMapMethodAndPathToRights_DPPRejectsEmptyWildcardTrailingSlash(t *testing.T) {

--- a/internal/common/security/authorize.go
+++ b/internal/common/security/authorize.go
@@ -113,24 +113,30 @@ func ABACMiddleware(settings ABACSettings) func(http.Handler) http.Handler {
 
 			model := activeAccessModel(settings)
 			if model != nil {
+				policyPath := r.URL.Path
+				routePath := r.URL.Path
+				if r.URL.RawPath != "" {
+					routePath = r.URL.RawPath
+				}
 				opts := grammar.DefaultSimplifyOptions()
 				opts.EnableImplicitCasts = settings.EnableImplicitCasts
 				evaluation := model.AuthorizeWithFilterWithOptions(EvalInput{
-					Method: r.Method,
-					Path:   r.URL.Path,
-					Claims: claims,
+					Method:    r.Method,
+					Path:      policyPath,
+					RoutePath: routePath,
+					Claims:    claims,
 				}, opts)
 				if !evaluation.Allowed {
 					if evaluation.Reason == DecisionRouteNotFound {
 						component := routerErrorComponent(model)
-						if model.routeExistsForAnyMethod(r.URL.Path) {
+						if model.routeExistsForAnyMethod(routePath) {
 							common.WriteRouterMethodNotAllowed(w, component)
 							return
 						}
 						common.WriteRouterNotFound(w, component)
 						return
 					}
-					if denyAsNotFound(settings, r.URL.Path) {
+					if denyAsNotFound(settings, policyPath) {
 						common.WriteRouterNotFound(w, routerErrorComponent(model))
 						return
 					}

--- a/internal/common/security/input_eval.go
+++ b/internal/common/security/input_eval.go
@@ -29,9 +29,10 @@ package auth
 // EvalInput is the minimal set of request properties the ABAC engine needs to
 // evaluate a decision.
 type EvalInput struct {
-	Method string
-	Path   string
-	Claims Claims
+	Method    string
+	Path      string
+	RoutePath string
+	Claims    Claims
 }
 
 // Claims represents token claims extracted from a verified token.

--- a/internal/dppapiservice/integration_tests/dpp_api_validation_test.go
+++ b/internal/dppapiservice/integration_tests/dpp_api_validation_test.go
@@ -53,6 +53,13 @@ func TestDPPAPIRejectsInvalidQueryParameters(t *testing.T) {
 			errorCode:  "DPP-REPRESENTATION-INVALID",
 		},
 		{
+			name:       "read by encoded URL id rejects invalid representation",
+			method:     http.MethodGet,
+			target:     "/v1/dpps/" + encodedPathParam("https://example.org/dpp/1") + "?representation=invalid",
+			statusCode: http.StatusBadRequest,
+			errorCode:  "DPP-REPRESENTATION-INVALID",
+		},
+		{
 			name:       "read by product id rejects invalid representation",
 			method:     http.MethodGet,
 			target:     "/v1/dppsByProductId/product-1?representation=invalid",
@@ -76,7 +83,7 @@ func TestDPPAPIRejectsInvalidQueryParameters(t *testing.T) {
 		{
 			name:       "element read rejects invalid representation",
 			method:     http.MethodGet,
-			target:     "/v1/dpps/dpp-1/elements/technicalData/manufacturerName?representation=invalid",
+			target:     "/v1/dpps/dpp-1/elements/" + encodedPathParam("$['technicalData']['manufacturerName']") + "?representation=invalid",
 			statusCode: http.StatusBadRequest,
 			errorCode:  "DPP-REPRESENTATION-INVALID",
 		},
@@ -105,7 +112,7 @@ func TestDPPAPIRejectsInvalidQueryParameters(t *testing.T) {
 		{
 			name:       "element update rejects full write representation",
 			method:     http.MethodPatch,
-			target:     "/v1/dpps/dpp-1/elements/technicalData/manufacturerName?representation=full",
+			target:     "/v1/dpps/dpp-1/elements/" + encodedPathParam("$['technicalData']['manufacturerName']") + "?representation=full",
 			statusCode: http.StatusNotImplemented,
 			errorCode:  "DPP-UPDELEM-FULLWRITE",
 		},
@@ -174,14 +181,6 @@ func TestDPPAPIRejectsInvalidPayloadsBeforePersistence(t *testing.T) {
 			body:       withDPPField("granularity", `"item"`),
 			statusCode: http.StatusBadRequest,
 			errorCode:  "DPP-HEADER-GRANULARITY",
-		},
-		{
-			name:       "create rejects empty contentSpecificationIds",
-			method:     http.MethodPost,
-			target:     "/v1/dpps",
-			body:       withDPPField("contentSpecificationIds", `[]`),
-			statusCode: http.StatusBadRequest,
-			errorCode:  "DPP-HEADER-MISSING",
 		},
 		{
 			name:       "create rejects content section scalar",
@@ -282,7 +281,7 @@ func TestDPPAPIRejectsInvalidPayloadsBeforePersistence(t *testing.T) {
 		{
 			name:       "element update rejects malformed json",
 			method:     http.MethodPatch,
-			target:     "/v1/dpps/dpp-1/elements/technicalData/manufacturerName",
+			target:     "/v1/dpps/dpp-1/elements/" + encodedPathParam("$['technicalData']['manufacturerName']"),
 			body:       `{"value":`,
 			statusCode: http.StatusBadRequest,
 			errorCode:  "DPP-UPDELEM-DECODE",
@@ -290,15 +289,15 @@ func TestDPPAPIRejectsInvalidPayloadsBeforePersistence(t *testing.T) {
 		{
 			name:       "element update rejects expanded object",
 			method:     http.MethodPatch,
-			target:     "/v1/dpps/dpp-1/elements/technicalData/manufacturerName",
+			target:     "/v1/dpps/dpp-1/elements/" + encodedPathParam("$['technicalData']['manufacturerName']"),
 			body:       `{"elementId":"manufacturerName","objectType":"SingleValuedDataElement","value":"Acme"}`,
 			statusCode: http.StatusBadRequest,
 			errorCode:  "DPP-COMPACT-FULLWRITE",
 		},
 		{
-			name:       "element read rejects invalid path",
+			name:       "element read rejects legacy section path",
 			method:     http.MethodGet,
-			target:     "/v1/dpps/dpp-1/elements/technicalData",
+			target:     "/v1/dpps/dpp-1/elements/technicalData/manufacturerName",
 			statusCode: http.StatusBadRequest,
 			errorCode:  "DPP-ELEMPATH-INVALID",
 		},
@@ -314,7 +313,7 @@ func TestDPPAPIRejectsInvalidPayloadsBeforePersistence(t *testing.T) {
 func TestDPPAPIUpdateDataElementDoesNotRegisterPUT(t *testing.T) {
 	service := dppapi.NewDPPRepositoryService(nil, nil)
 	router := dppapi.NewRouter(dppapi.NewDPPRepositoryRouter(service))
-	request := httptest.NewRequest(http.MethodPut, "/v1/dpps/dpp-1/elements/technicalData/manufacturerName", strings.NewReader(`"Acme"`))
+	request := httptest.NewRequest(http.MethodPut, "/v1/dpps/dpp-1/elements/"+encodedPathParam("$['technicalData']['manufacturerName']"), strings.NewReader(`"Acme"`))
 	response := httptest.NewRecorder()
 
 	router.ServeHTTP(response, request)

--- a/internal/dppapiservice/integration_tests/dpp_lifecycle_integration_test.go
+++ b/internal/dppapiservice/integration_tests/dpp_lifecycle_integration_test.go
@@ -42,7 +42,11 @@ import (
 	"time"
 )
 
-const dppComposeTestTimeout = 8 * time.Minute
+const (
+	dppComposeTestTimeout        = 8 * time.Minute
+	lifecycleTechnicalDataSpec   = "urn:example:semantic:technical-data"
+	lifecycleCarbonFootprintSpec = "https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0"
+)
 
 func TestDPPLifecycleWithDockerCompose(t *testing.T) {
 	if testing.Short() {
@@ -78,29 +82,42 @@ func TestDPPLifecycleWithDockerCompose(t *testing.T) {
 	createBody := doJSON(t, client, http.MethodPost, baseURL+"/v1/dpps", document, http.StatusCreated)
 	assertJSONPathEquals(t, createBody, "digitalProductPassportId", dppID)
 
+	optionalDPPID := "https://www.example.org/dpp/optional/" + idSuffix
+	optionalDocument := lifecycleDPPDocument(optionalDPPID, "https://www.example.org/optional/"+idSuffix, now)
+	delete(optionalDocument, "facilityId")
+	delete(optionalDocument, "contentSpecificationIds")
+	optionalCreateBody := doJSON(t, client, http.MethodPost, baseURL+"/v1/dpps", optionalDocument, http.StatusCreated)
+	assertJSONPathEquals(t, optionalCreateBody, "digitalProductPassportId", optionalDPPID)
+	optionalReadBody := doJSON(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedPathParam(optionalDPPID), nil, http.StatusOK)
+	assertJSONFieldMissing(t, optionalReadBody, "facilityId")
+	assertJSONFieldMissing(t, optionalReadBody, "contentSpecificationIds")
+
 	readBody := doJSON(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID, nil, http.StatusOK)
 	assertJSONPathEquals(t, readBody, "digitalProductPassportId", dppID)
 	assertJSONPathEquals(t, readBody, "uniqueProductIdentifier", productID)
-	assertJSONPathEquals(t, readBody, "technicalData.manufacturerName", "Acme GmbH")
-	assertJSONPathEquals(t, readBody, "technicalData.manual.url", "https://example.test/manual.pdf")
-	assertJSONPathEquals(t, readBody, "technicalData.manual.resourceTitle", "User Manual")
+	assertDPPSectionPathEquals(t, readBody, lifecycleTechnicalDataSpec, "manufacturerName", "Acme GmbH")
+	assertDPPSectionPathEquals(t, readBody, lifecycleTechnicalDataSpec, "manual.url", "https://example.test/manual.pdf")
+	assertDPPSectionPathEquals(t, readBody, lifecycleTechnicalDataSpec, "manual.resourceTitle", "User Manual")
+	assertDPPSectionPathEquals(t, readBody, lifecycleCarbonFootprintSpec, "PcfCo2eq", "4180.75")
 
 	time.Sleep(30 * time.Millisecond)
 	createdVersionDate := time.Now().UTC()
 	time.Sleep(30 * time.Millisecond)
 	createdVersionBody := doJSON(t, client, http.MethodGet, historyURL(baseURL, encodedDPPID, createdVersionDate, "compressed"), nil, http.StatusOK)
-	assertJSONPathEquals(t, createdVersionBody, "technicalData.manufacturerName", "Acme GmbH")
+	assertDPPSectionPathEquals(t, createdVersionBody, lifecycleTechnicalDataSpec, "manufacturerName", "Acme GmbH")
 
 	fullBody := doJSON(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID+"?representation=full", nil, http.StatusOK)
-	assertFullDPPSectionObjectType(t, fullBody, "technicalData", "DataElementCollection")
-	assertDPPElementObjectType(t, fullBody, "technicalData", "dimensions", "DataElementCollection")
-	assertDPPElementObjectType(t, fullBody, "technicalData", "manufacturerName", "SingleValuedDataElement")
-	assertDPPElementObjectType(t, fullBody, "technicalData", "manual", "RelatedResource")
-	assertDPPElementObjectType(t, fullBody, "technicalData", "productDescription", "MultiLanguageDataElement")
-	assertDPPElementObjectType(t, fullBody, "technicalData", "serialNumbers", "MultiValuedDataElement")
-	assertDPPElementValue(t, fullBody, "technicalData", "warrantyMonths", "valueDataType", "xsd:long")
-	assertDPPElementValue(t, fullBody, "technicalData", "manual", "resourceTitle", "User Manual")
-	assertDPPElementValue(t, fullBody, "technicalData", "manual", "language", "en-GB")
+	assertFullDPPSectionObjectType(t, fullBody, lifecycleTechnicalDataSpec, "DataElementCollection")
+	assertDPPElementObjectType(t, fullBody, lifecycleTechnicalDataSpec, "dimensions", "DataElementCollection")
+	assertDPPElementObjectType(t, fullBody, lifecycleTechnicalDataSpec, "manufacturerName", "SingleValuedDataElement")
+	assertDPPElementObjectType(t, fullBody, lifecycleTechnicalDataSpec, "manual", "RelatedResource")
+	assertDPPElementObjectType(t, fullBody, lifecycleTechnicalDataSpec, "productDescription", "MultiLanguageDataElement")
+	assertDPPElementObjectType(t, fullBody, lifecycleTechnicalDataSpec, "serialNumbers", "MultiValuedDataElement")
+	assertDPPElementValue(t, fullBody, lifecycleTechnicalDataSpec, "warrantyMonths", "valueDataType", "xsd:long")
+	assertDPPElementValue(t, fullBody, lifecycleTechnicalDataSpec, "manual", "resourceTitle", "User Manual")
+	assertDPPElementValue(t, fullBody, lifecycleTechnicalDataSpec, "manual", "language", "en-GB")
+	assertFullDPPSectionObjectType(t, fullBody, lifecycleCarbonFootprintSpec, "DataElementCollection")
+	assertDPPElementObjectType(t, fullBody, lifecycleCarbonFootprintSpec, "PcfCo2eq", "SingleValuedDataElement")
 
 	productBody := doJSON(t, client, http.MethodGet, baseURL+"/v1/dppsByProductId/"+encodedProductID, nil, http.StatusOK)
 	assertJSONPathEquals(t, productBody, "digitalProductPassportId", dppID)
@@ -114,48 +131,56 @@ func TestDPPLifecycleWithDockerCompose(t *testing.T) {
 	beforePatchDate := time.Now().UTC()
 	time.Sleep(30 * time.Millisecond)
 	patchBody := doJSON(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID, map[string]any{
-		"technicalData": map[string]any{
+		lifecycleTechnicalDataSpec: map[string]any{
 			"manufacturerName": "Acme Updated GmbH",
 			"warrantyMonths":   36,
 		},
 	}, http.StatusOK)
-	assertJSONPathEquals(t, patchBody, "technicalData.manufacturerName", "Acme Updated GmbH")
-	assertJSONPathEquals(t, patchBody, "technicalData.warrantyMonths", "36")
+	assertDPPSectionPathEquals(t, patchBody, lifecycleTechnicalDataSpec, "manufacturerName", "Acme Updated GmbH")
+	assertDPPSectionPathEquals(t, patchBody, lifecycleTechnicalDataSpec, "warrantyMonths", "36")
 
 	prePatchVersionBody := doJSON(t, client, http.MethodGet, historyURL(baseURL, encodedDPPID, beforePatchDate, "compressed"), nil, http.StatusOK)
-	assertJSONPathEquals(t, prePatchVersionBody, "technicalData.manufacturerName", "Acme GmbH")
+	assertDPPSectionPathEquals(t, prePatchVersionBody, lifecycleTechnicalDataSpec, "manufacturerName", "Acme GmbH")
 
 	time.Sleep(30 * time.Millisecond)
 	updatedVersionDate := time.Now().UTC()
 	time.Sleep(30 * time.Millisecond)
 	updatedVersionBody := doJSON(t, client, http.MethodGet, historyURL(baseURL, encodedDPPID, updatedVersionDate, "compressed"), nil, http.StatusOK)
-	assertJSONPathEquals(t, updatedVersionBody, "technicalData.manufacturerName", "Acme Updated GmbH")
+	assertDPPSectionPathEquals(t, updatedVersionBody, lifecycleTechnicalDataSpec, "manufacturerName", "Acme Updated GmbH")
 
 	fullVersionBody := doJSON(t, client, http.MethodGet, historyURL(baseURL, encodedDPPID, updatedVersionDate, "full"), nil, http.StatusOK)
-	assertFullDPPSectionObjectType(t, fullVersionBody, "technicalData", "DataElementCollection")
-	assertDPPElementObjectType(t, fullVersionBody, "technicalData", "dimensions", "DataElementCollection")
-	assertDPPElementObjectType(t, fullVersionBody, "technicalData", "manufacturerName", "SingleValuedDataElement")
+	assertFullDPPSectionObjectType(t, fullVersionBody, lifecycleTechnicalDataSpec, "DataElementCollection")
+	assertDPPElementObjectType(t, fullVersionBody, lifecycleTechnicalDataSpec, "dimensions", "DataElementCollection")
+	assertDPPElementObjectType(t, fullVersionBody, lifecycleTechnicalDataSpec, "manufacturerName", "SingleValuedDataElement")
 
-	elementBody := doJSONAny(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/technicalData/manufacturerName", nil, http.StatusOK)
+	elementIDPath := encodedPathParam(dppElementJSONPath(lifecycleTechnicalDataSpec, "manufacturerName"))
+	elementBody := doJSONAny(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/"+elementIDPath, nil, http.StatusOK)
 	assertScalarEquals(t, elementBody, "Acme Updated GmbH")
 
-	fullElementBody := doJSONAny(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/technicalData/manufacturerName?representation=full", nil, http.StatusOK)
+	fullElementBody := doJSONAny(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/"+elementIDPath+"?representation=full", nil, http.StatusOK)
 	assertDataElementObjectType(t, fullElementBody, "manufacturerName", "SingleValuedDataElement")
 
-	updatedElementBody := doJSONAny(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/technicalData/energyClass", "B", http.StatusOK)
+	carbonPath := encodedPathParam(dppElementJSONPath(lifecycleCarbonFootprintSpec, "PcfCo2eq"))
+	updatedCarbonBody := doJSONAny(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/"+carbonPath, 4200.5, http.StatusOK)
+	assertScalarEquals(t, updatedCarbonBody, "4200.5")
+
+	energyClassPath := encodedPathParam(dppElementJSONPath(lifecycleTechnicalDataSpec, "energyClass"))
+	updatedElementBody := doJSONAny(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/"+energyClassPath, "B", http.StatusOK)
 	assertScalarEquals(t, updatedElementBody, "B")
 
 	readAfterElementUpdate := doJSON(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID, nil, http.StatusOK)
-	assertJSONPathEquals(t, readAfterElementUpdate, "technicalData.energyClass", "B")
+	assertDPPSectionPathEquals(t, readAfterElementUpdate, lifecycleTechnicalDataSpec, "energyClass", "B")
+	assertDPPSectionPathEquals(t, readAfterElementUpdate, lifecycleCarbonFootprintSpec, "PcfCo2eq", "4200.5")
 
 	time.Sleep(30 * time.Millisecond)
 	beforeDeleteDate := time.Now().UTC()
 	time.Sleep(30 * time.Millisecond)
 	doJSON(t, client, http.MethodDelete, baseURL+"/v1/dpps/"+encodedDPPID, nil, http.StatusNoContent)
 	preDeleteVersionBody := doJSON(t, client, http.MethodGet, historyURL(baseURL, encodedDPPID, beforeDeleteDate, "compressed"), nil, http.StatusOK)
-	assertJSONPathEquals(t, preDeleteVersionBody, "technicalData.energyClass", "B")
+	assertDPPSectionPathEquals(t, preDeleteVersionBody, lifecycleTechnicalDataSpec, "energyClass", "B")
 	doJSON(t, client, http.MethodGet, historyURL(baseURL, encodedDPPID, time.Now().UTC(), "compressed"), nil, http.StatusNotFound)
 	doJSON(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID, nil, http.StatusNotFound)
+	doJSON(t, client, http.MethodDelete, baseURL+"/v1/dpps/"+encodedPathParam(optionalDPPID), nil, http.StatusNoContent)
 }
 
 func lifecycleDPPDocument(dppID string, productID string, now time.Time) map[string]any {
@@ -168,8 +193,8 @@ func lifecycleDPPDocument(dppID string, productID string, now time.Time) map[str
 		"lastUpdate":               now.Format(time.RFC3339Nano),
 		"economicOperatorId":       "operator-123",
 		"facilityId":               "facility-456",
-		"contentSpecificationIds":  []string{"technicalData-specification"},
-		"technicalData": map[string]any{
+		"contentSpecificationIds":  []string{lifecycleTechnicalDataSpec, lifecycleCarbonFootprintSpec},
+		lifecycleTechnicalDataSpec: map[string]any{
 			"manufacturerName": "Acme GmbH",
 			"warrantyMonths":   24,
 			"energyClass":      "A",
@@ -188,6 +213,11 @@ func lifecycleDPPDocument(dppID string, productID string, now time.Time) map[str
 				"language":      "en-GB",
 				"resourceTitle": "User Manual",
 			},
+		},
+		lifecycleCarbonFootprintSpec: map[string]any{
+			"PcfCo2eq":                          4180.75,
+			"ReferenceImpactUnitForCalculation": "kg CO2e",
+			"PcfCalculationMethods":             []string{"ISO 14067"},
 		},
 	}
 }
@@ -350,7 +380,21 @@ func encodeBody(body any) ([]byte, error) {
 }
 
 func encodedPathParam(value string) string {
-	return url.PathEscape(url.PathEscape(value))
+	return url.PathEscape(value)
+}
+
+func dppElementJSONPath(sectionName string, elementNames ...string) string {
+	var builder strings.Builder
+	builder.WriteString("$")
+	builder.WriteString(jsonPathMember(sectionName))
+	for _, elementName := range elementNames {
+		builder.WriteString(jsonPathMember(elementName))
+	}
+	return builder.String()
+}
+
+func jsonPathMember(value string) string {
+	return "['" + strings.ReplaceAll(value, "'", "\\'") + "']"
 }
 
 func historyURL(baseURL string, encodedDPPID string, date time.Time, representation string) string {
@@ -368,6 +412,28 @@ func assertJSONPathEquals(t *testing.T, body map[string]any, path string, expect
 	}
 	if value != expected {
 		t.Fatalf("%s = %#v, want %q", path, value, expected)
+	}
+}
+
+func assertJSONFieldMissing(t *testing.T, body map[string]any, field string) {
+	t.Helper()
+	if _, ok := body[field]; ok {
+		t.Fatalf("%s unexpectedly present in %#v", field, body)
+	}
+}
+
+func assertDPPSectionPathEquals(t *testing.T, body map[string]any, sectionName string, path string, expected string) {
+	t.Helper()
+	section, ok := body[sectionName].(map[string]any)
+	if !ok {
+		t.Fatalf("%s section = %#v, want object", sectionName, body[sectionName])
+	}
+	value, err := valueAtPath(section, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != expected {
+		t.Fatalf("%s.%s = %#v, want %q", sectionName, path, value, expected)
 	}
 }
 
@@ -415,6 +481,9 @@ func fullDPPSection(t *testing.T, body map[string]any, sectionName string) map[s
 	if !ok {
 		t.Fatalf("elements = %#v, want array", body["elements"])
 	}
+	if section, ok := findFullElementByDictionaryReference(elements, sectionName); ok {
+		return section
+	}
 	if section, ok := findFullElement(elements, upperFirst(sectionName)); ok {
 		return section
 	}
@@ -429,6 +498,19 @@ func findFullElement(elements []any, elementID string) (map[string]any, bool) {
 			continue
 		}
 		if element["elementId"] == elementID {
+			return element, true
+		}
+	}
+	return nil, false
+}
+
+func findFullElementByDictionaryReference(elements []any, dictionaryReference string) (map[string]any, bool) {
+	for _, item := range elements {
+		element, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if element["dictionaryReference"] == dictionaryReference {
 			return element, true
 		}
 	}

--- a/internal/dppapiservice/integration_tests/dpp_lifecycle_integration_test.go
+++ b/internal/dppapiservice/integration_tests/dpp_lifecycle_integration_test.go
@@ -167,9 +167,17 @@ func TestDPPLifecycleWithDockerCompose(t *testing.T) {
 	energyClassPath := encodedPathParam(dppElementJSONPath(lifecycleTechnicalDataSpec, "energyClass"))
 	updatedElementBody := doJSONAny(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/"+energyClassPath, "B", http.StatusOK)
 	assertScalarEquals(t, updatedElementBody, "B")
+	serialNumberPath := encodedPathParam(dppElementJSONPath(lifecycleTechnicalDataSpec, "serialNumbers") + "[0]")
+	serialNumberBody := doJSONAny(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/"+serialNumberPath, nil, http.StatusOK)
+	assertScalarEquals(t, serialNumberBody, "SN-001")
+	fullSerialNumberBody := doJSONAny(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/"+serialNumberPath+"?representation=full", nil, http.StatusOK)
+	assertDataElementObjectType(t, fullSerialNumberBody, "serialNumbers0", "SingleValuedDataElement")
+	updatedSerialNumberBody := doJSONAny(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/"+serialNumberPath, "SN-UPDATED", http.StatusOK)
+	assertScalarEquals(t, updatedSerialNumberBody, "SN-UPDATED")
 
 	readAfterElementUpdate := doJSON(t, client, http.MethodGet, baseURL+"/v1/dpps/"+encodedDPPID, nil, http.StatusOK)
 	assertDPPSectionPathEquals(t, readAfterElementUpdate, lifecycleTechnicalDataSpec, "energyClass", "B")
+	assertDPPSectionArrayValue(t, readAfterElementUpdate, lifecycleTechnicalDataSpec, "serialNumbers", 0, "SN-UPDATED")
 	assertDPPSectionPathEquals(t, readAfterElementUpdate, lifecycleCarbonFootprintSpec, "PcfCo2eq", "4200.5")
 
 	time.Sleep(30 * time.Millisecond)
@@ -433,6 +441,25 @@ func assertDPPSectionPathEquals(t *testing.T, body map[string]any, sectionName s
 	}
 	if value != expected {
 		t.Fatalf("%s.%s = %#v, want %q", sectionName, path, value, expected)
+	}
+}
+
+func assertDPPSectionArrayValue(t *testing.T, body map[string]any, sectionName string, path string, index int, expected string) {
+	t.Helper()
+	section, ok := body[sectionName].(map[string]any)
+	if !ok {
+		t.Fatalf("%s section = %#v, want object", sectionName, body[sectionName])
+	}
+	value, err := valueAtPath(section, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, ok := value.([]any)
+	if !ok || index < 0 || index >= len(items) {
+		t.Fatalf("%s.%s = %#v, want array containing index %d", sectionName, path, value, index)
+	}
+	if items[index] != expected {
+		t.Fatalf("%s.%s[%d] = %#v, want %q", sectionName, path, index, items[index], expected)
 	}
 }
 

--- a/internal/dppapiservice/integration_tests/dpp_lifecycle_integration_test.go
+++ b/internal/dppapiservice/integration_tests/dpp_lifecycle_integration_test.go
@@ -384,13 +384,12 @@ func encodedPathParam(value string) string {
 }
 
 func dppElementJSONPath(sectionName string, elementNames ...string) string {
-	var builder strings.Builder
-	builder.WriteString("$")
-	builder.WriteString(jsonPathMember(sectionName))
+	parts := make([]string, 0, len(elementNames)+2)
+	parts = append(parts, "$", jsonPathMember(sectionName))
 	for _, elementName := range elementNames {
-		builder.WriteString(jsonPathMember(elementName))
+		parts = append(parts, jsonPathMember(elementName))
 	}
-	return builder.String()
+	return strings.Join(parts, "")
 }
 
 func jsonPathMember(value string) string {

--- a/internal/dppapiservice/integration_tests/dpp_security_integration_test.go
+++ b/internal/dppapiservice/integration_tests/dpp_security_integration_test.go
@@ -80,7 +80,7 @@ func TestDPPSecurityWithDockerCompose(t *testing.T) {
 	viewerToken := passwordGrantToken(t, client, tokenEndpoint, "usera", "pwd")
 	editorToken := passwordGrantToken(t, client, tokenEndpoint, "userx", "pwd")
 
-	dppID := "https://www.example.org/dpp/security-" + strings.ReplaceAll(projectName, "-", "")
+	dppID := "https://www.example.org/dpp/security%2F" + strings.ReplaceAll(projectName, "-", "")
 	productID := "https://www.example.org/products/security-" + strings.ReplaceAll(projectName, "-", "")
 	encodedDPPID := encodedPathParam(dppID)
 	document := lifecycleDPPDocument(dppID, productID, time.Now().UTC())

--- a/internal/dppapiservice/integration_tests/dpp_security_integration_test.go
+++ b/internal/dppapiservice/integration_tests/dpp_security_integration_test.go
@@ -96,19 +96,20 @@ func TestDPPSecurityWithDockerCompose(t *testing.T) {
 	assertJSONPathEquals(t, readBody, "digitalProductPassportId", dppID)
 
 	doJSONAnyAuth(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID, viewerToken, map[string]any{
-		"technicalData": map[string]any{
+		lifecycleTechnicalDataSpec: map[string]any{
 			"manufacturerName": "Denied GmbH",
 		},
 	}, http.StatusForbidden)
 
 	patchBody := doJSONAuth(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID, editorToken, map[string]any{
-		"technicalData": map[string]any{
+		lifecycleTechnicalDataSpec: map[string]any{
 			"manufacturerName": "Secured Updated GmbH",
 		},
 	}, http.StatusOK)
-	assertJSONPathEquals(t, patchBody, "technicalData.manufacturerName", "Secured Updated GmbH")
+	assertDPPSectionPathEquals(t, patchBody, lifecycleTechnicalDataSpec, "manufacturerName", "Secured Updated GmbH")
 
-	elementBody := doJSONAnyAuth(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/technicalData/energyClass", editorToken, "B", http.StatusOK)
+	energyClassPath := encodedPathParam(dppElementJSONPath(lifecycleTechnicalDataSpec, "energyClass"))
+	elementBody := doJSONAnyAuth(t, client, http.MethodPatch, baseURL+"/v1/dpps/"+encodedDPPID+"/elements/"+energyClassPath, editorToken, "B", http.StatusOK)
 	assertScalarEquals(t, elementBody, "B")
 
 	doJSONAnyAuth(t, client, http.MethodDelete, baseURL+"/v1/dpps/"+encodedDPPID, editorToken, nil, http.StatusNoContent)

--- a/pkg/dppapiservice/go/api_dpp_fine_granular.go
+++ b/pkg/dppapiservice/go/api_dpp_fine_granular.go
@@ -120,12 +120,12 @@ func (c *DPPFineGranularAPIController) ReadDataElement(w http.ResponseWriter, r 
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
+	dppIdParam := decodePathParam(r, chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
 	}
-	elementIdPathParam := decodePathParam(chi.URLParam(r, "elementIdPath"))
+	elementIdPathParam := decodePathParam(r, chi.URLParam(r, "elementIdPath"))
 	if elementIdPathParam == "" {
 		c.errorHandler(w, r, &RequiredError{"elementIdPath"}, nil)
 		return
@@ -149,12 +149,12 @@ func (c *DPPFineGranularAPIController) ReadDataElement(w http.ResponseWriter, r 
 
 // UpdateDataElement - Update single DPP data element
 func (c *DPPFineGranularAPIController) UpdateDataElement(w http.ResponseWriter, r *http.Request) {
-	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
+	dppIdParam := decodePathParam(r, chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
 	}
-	elementIdPathParam := decodePathParam(chi.URLParam(r, "elementIdPath"))
+	elementIdPathParam := decodePathParam(r, chi.URLParam(r, "elementIdPath"))
 	if elementIdPathParam == "" {
 		c.errorHandler(w, r, &RequiredError{"elementIdPath"}, nil)
 		return

--- a/pkg/dppapiservice/go/api_dpp_fine_granular.go
+++ b/pkg/dppapiservice/go/api_dpp_fine_granular.go
@@ -83,13 +83,13 @@ func (c *DPPFineGranularAPIController) Routes() Routes {
 		"ReadDataElement": Route{
 			"ReadDataElement",
 			strings.ToUpper("Get"),
-			"/v1/dpps/{dppId}/elements/{elementPath}",
+			"/v1/dpps/{dppId}/elements/{elementIdPath}",
 			c.ReadDataElement,
 		},
 		"UpdateDataElement": Route{
 			"UpdateDataElement",
 			strings.ToUpper("Patch"),
-			"/v1/dpps/{dppId}/elements/{elementPath}",
+			"/v1/dpps/{dppId}/elements/{elementIdPath}",
 			c.UpdateDataElement,
 		},
 	}
@@ -101,13 +101,13 @@ func (c *DPPFineGranularAPIController) OrderedRoutes() []Route {
 		Route{
 			"ReadDataElement",
 			strings.ToUpper("Get"),
-			"/v1/dpps/{dppId}/elements/{elementPath}",
+			"/v1/dpps/{dppId}/elements/{elementIdPath}",
 			c.ReadDataElement,
 		},
 		Route{
 			"UpdateDataElement",
 			strings.ToUpper("Patch"),
-			"/v1/dpps/{dppId}/elements/{elementPath}",
+			"/v1/dpps/{dppId}/elements/{elementIdPath}",
 			c.UpdateDataElement,
 		},
 	}
@@ -120,14 +120,14 @@ func (c *DPPFineGranularAPIController) ReadDataElement(w http.ResponseWriter, r 
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	dppIdParam := chi.URLParam(r, "dppId")
+	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
 	}
-	elementPathParam := chi.URLParam(r, "elementPath")
-	if elementPathParam == "" {
-		c.errorHandler(w, r, &RequiredError{"elementPath"}, nil)
+	elementIdPathParam := decodePathParam(chi.URLParam(r, "elementIdPath"))
+	if elementIdPathParam == "" {
+		c.errorHandler(w, r, &RequiredError{"elementIdPath"}, nil)
 		return
 	}
 	var representationParam Representation
@@ -137,7 +137,7 @@ func (c *DPPFineGranularAPIController) ReadDataElement(w http.ResponseWriter, r 
 		representationParam = param
 	} else {
 	}
-	result, err := c.service.ReadDataElement(r.Context(), dppIdParam, elementPathParam, representationParam)
+	result, err := c.service.ReadDataElement(r.Context(), dppIdParam, elementIdPathParam, representationParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -149,14 +149,14 @@ func (c *DPPFineGranularAPIController) ReadDataElement(w http.ResponseWriter, r 
 
 // UpdateDataElement - Update single DPP data element
 func (c *DPPFineGranularAPIController) UpdateDataElement(w http.ResponseWriter, r *http.Request) {
-	dppIdParam := chi.URLParam(r, "dppId")
+	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
 	}
-	elementPathParam := chi.URLParam(r, "elementPath")
-	if elementPathParam == "" {
-		c.errorHandler(w, r, &RequiredError{"elementPath"}, nil)
+	elementIdPathParam := decodePathParam(chi.URLParam(r, "elementIdPath"))
+	if elementIdPathParam == "" {
+		c.errorHandler(w, r, &RequiredError{"elementIdPath"}, nil)
 		return
 	}
 	var dataElementParam DataElement
@@ -174,7 +174,7 @@ func (c *DPPFineGranularAPIController) UpdateDataElement(w http.ResponseWriter, 
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.UpdateDataElement(r.Context(), dppIdParam, elementPathParam, dataElementParam)
+	result, err := c.service.UpdateDataElement(r.Context(), dppIdParam, elementIdPathParam, dataElementParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/pkg/dppapiservice/go/api_dpp_fine_granular_service.go
+++ b/pkg/dppapiservice/go/api_dpp_fine_granular_service.go
@@ -61,15 +61,15 @@ func NewDPPFineGranularAPIServiceWithDelegate(delegate DPPFineGranularAPIService
 // Parameters:
 //   - ctx: Request context used by the delegate
 //   - dppID: Identifier of the DPP that owns the element
-//   - elementPath: Content section and idShort path in <section>/<path> form
+//   - elementIDPath: RFC 9535 Normalized Path selecting a single DPP data element
 //   - representation: Requested compressed or full element representation
 //
 // Returns:
 //   - ImplResponse: Delegate response or not-configured response
 //   - error: Delegate error, if one is returned
-func (s *DPPFineGranularAPIService) ReadDataElement(ctx context.Context, dppID string, elementPath string, representation Representation) (ImplResponse, error) {
+func (s *DPPFineGranularAPIService) ReadDataElement(ctx context.Context, dppID string, elementIDPath string, representation Representation) (ImplResponse, error) {
 	if s.delegate != nil {
-		return s.delegate.ReadDataElement(ctx, dppID, elementPath, representation)
+		return s.delegate.ReadDataElement(ctx, dppID, elementIDPath, representation)
 	}
 	return serviceNotConfigured("ReadDataElement"), nil
 }
@@ -79,15 +79,15 @@ func (s *DPPFineGranularAPIService) ReadDataElement(ctx context.Context, dppID s
 // Parameters:
 //   - ctx: Request context used by the delegate
 //   - dppID: Identifier of the DPP that owns the element
-//   - elementPath: Content section and idShort path in <section>/<path> form
+//   - elementIDPath: RFC 9535 Normalized Path selecting a single DPP data element
 //   - dataElement: Generated DPP data element model used as replacement content
 //
 // Returns:
 //   - ImplResponse: Delegate response or not-configured response
 //   - error: Delegate error, if one is returned
-func (s *DPPFineGranularAPIService) UpdateDataElement(ctx context.Context, dppID string, elementPath string, dataElement DataElement) (ImplResponse, error) {
+func (s *DPPFineGranularAPIService) UpdateDataElement(ctx context.Context, dppID string, elementIDPath string, dataElement DataElement) (ImplResponse, error) {
 	if s.delegate != nil {
-		return s.delegate.UpdateDataElement(ctx, dppID, elementPath, dataElement)
+		return s.delegate.UpdateDataElement(ctx, dppID, elementIDPath, dataElement)
 	}
 	return serviceNotConfigured("UpdateDataElement"), nil
 }

--- a/pkg/dppapiservice/go/api_dpp_life_cycle.go
+++ b/pkg/dppapiservice/go/api_dpp_life_cycle.go
@@ -181,7 +181,7 @@ func (c *DPPLifeCycleAPIController) ReadDPPById(w http.ResponseWriter, r *http.R
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
+	dppIdParam := decodePathParam(r, chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
@@ -205,7 +205,7 @@ func (c *DPPLifeCycleAPIController) ReadDPPById(w http.ResponseWriter, r *http.R
 
 // DeleteDPPById - Delete DPP by DPP ID
 func (c *DPPLifeCycleAPIController) DeleteDPPById(w http.ResponseWriter, r *http.Request) {
-	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
+	dppIdParam := decodePathParam(r, chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
@@ -222,7 +222,7 @@ func (c *DPPLifeCycleAPIController) DeleteDPPById(w http.ResponseWriter, r *http
 
 // UpdateDPPById - Update DPP by DPP ID
 func (c *DPPLifeCycleAPIController) UpdateDPPById(w http.ResponseWriter, r *http.Request) {
-	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
+	dppIdParam := decodePathParam(r, chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
@@ -286,7 +286,7 @@ func (c *DPPLifeCycleAPIController) ReadDPPByProductId(w http.ResponseWriter, r 
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	productIdParam := decodePathParam(chi.URLParam(r, "productId"))
+	productIdParam := decodePathParam(r, chi.URLParam(r, "productId"))
 	if productIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"productId"}, nil)
 		return
@@ -315,7 +315,7 @@ func (c *DPPLifeCycleAPIController) ReadDPPVersionByIdAndDate(w http.ResponseWri
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
+	dppIdParam := decodePathParam(r, chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return

--- a/pkg/dppapiservice/go/api_dpp_life_cycle.go
+++ b/pkg/dppapiservice/go/api_dpp_life_cycle.go
@@ -181,7 +181,7 @@ func (c *DPPLifeCycleAPIController) ReadDPPById(w http.ResponseWriter, r *http.R
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	dppIdParam := chi.URLParam(r, "dppId")
+	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
@@ -205,7 +205,7 @@ func (c *DPPLifeCycleAPIController) ReadDPPById(w http.ResponseWriter, r *http.R
 
 // DeleteDPPById - Delete DPP by DPP ID
 func (c *DPPLifeCycleAPIController) DeleteDPPById(w http.ResponseWriter, r *http.Request) {
-	dppIdParam := chi.URLParam(r, "dppId")
+	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
@@ -222,7 +222,7 @@ func (c *DPPLifeCycleAPIController) DeleteDPPById(w http.ResponseWriter, r *http
 
 // UpdateDPPById - Update DPP by DPP ID
 func (c *DPPLifeCycleAPIController) UpdateDPPById(w http.ResponseWriter, r *http.Request) {
-	dppIdParam := chi.URLParam(r, "dppId")
+	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return
@@ -286,7 +286,7 @@ func (c *DPPLifeCycleAPIController) ReadDPPByProductId(w http.ResponseWriter, r 
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	productIdParam := chi.URLParam(r, "productId")
+	productIdParam := decodePathParam(chi.URLParam(r, "productId"))
 	if productIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"productId"}, nil)
 		return
@@ -315,7 +315,7 @@ func (c *DPPLifeCycleAPIController) ReadDPPVersionByIdAndDate(w http.ResponseWri
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	dppIdParam := chi.URLParam(r, "dppId")
+	dppIdParam := decodePathParam(chi.URLParam(r, "dppId"))
 	if dppIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"dppId"}, nil)
 		return

--- a/pkg/dppapiservice/go/dpp_aas_builder.go
+++ b/pkg/dppapiservice/go/dpp_aas_builder.go
@@ -38,22 +38,64 @@ func buildMetadataSubmodel(dppID string, header dppHeader) types.ISubmodel {
 	submodel.SetIDShort(&idShort)
 	submodel.SetSemanticID(globalReference(dppMetadataSemanticID))
 	elements := []types.ISubmodelElement{
-		stringProperty(headerDigitalProductPassportID, header.DigitalProductPassportID),
-		stringProperty(headerUniqueProductIdentifier, header.UniqueProductIdentifier),
-		stringProperty(headerGranularity, header.Granularity),
-		stringProperty(headerDppSchemaVersion, header.DppSchemaVersion),
-		stringProperty(headerDppStatus, header.DppStatus),
-		stringProperty(headerLastUpdate, header.LastUpdate.UTC().Format(time.RFC3339Nano)),
-		stringProperty(headerEconomicOperatorID, header.EconomicOperatorID),
+		metadataProperty(headerDigitalProductPassportID, dppIDSemanticID, header.DigitalProductPassportID, types.DataTypeDefXSDString),
+		metadataProperty(headerUniqueProductIdentifier, dppProductIDSemanticID, header.UniqueProductIdentifier, types.DataTypeDefXSDString),
+		metadataPropertyWithSupplementalSemanticID(headerGranularity, dppGranularitySemanticID, header.Granularity, types.DataTypeDefXSDString, dppGranularitySupplementalSemanticID),
+		metadataProperty(headerDppSchemaVersion, dppSchemaVersionSemanticID, header.DppSchemaVersion, types.DataTypeDefXSDString),
+		metadataProperty(headerDppStatus, dppStatusSemanticID, header.DppStatus, types.DataTypeDefXSDString),
+		metadataPropertyWithSupplementalSemanticID(headerLastUpdate, dppLastUpdateSemanticID, header.LastUpdate.UTC().Format(time.RFC3339Nano), types.DataTypeDefXSDDateTime, dppAdministrativeUpdateSupplementalSemanticID),
+		metadataProperty(headerEconomicOperatorID, dppEconomicOperatorIDSemanticID, header.EconomicOperatorID, types.DataTypeDefXSDString),
 	}
 	if header.FacilityID != "" {
-		elements = append(elements, stringProperty(headerFacilityID, header.FacilityID))
+		elements = append(elements, metadataProperty(headerFacilityID, dppFacilityIDSemanticID, header.FacilityID, types.DataTypeDefXSDString))
 	}
 	if len(header.ContentSpecificationIDs) > 0 {
-		elements = append(elements, stringList(headerContentSpecificationIDs, header.ContentSpecificationIDs))
+		elements = append(elements, metadataContentSpecificationIDs(header.ContentSpecificationIDs))
 	}
 	submodel.SetSubmodelElements(elements)
+	setNewDPPSubmodelAdministration(submodel, header.LastUpdate)
 	return submodel
+}
+
+func metadataProperty(idShort string, semanticID string, value string, valueType types.DataTypeDefXSD) types.ISubmodelElement {
+	property := scalarProperty(idShort, value, valueType)
+	property.SetSemanticID(globalReference(semanticID))
+	return property
+}
+
+func metadataPropertyWithSupplementalSemanticID(idShort string, semanticID string, value string, valueType types.DataTypeDefXSD, supplementalSemanticID string) types.ISubmodelElement {
+	property := metadataProperty(idShort, semanticID, value, valueType)
+	property.SetSupplementalSemanticIDs([]types.IReference{globalReference(supplementalSemanticID)})
+	return property
+}
+
+func metadataContentSpecificationIDs(values []string) types.ISubmodelElement {
+	list := types.NewSubmodelElementList(types.AASSubmodelElementsProperty)
+	idShort := headerContentSpecificationIDs
+	list.SetIDShort(&idShort)
+	list.SetSemanticID(globalReference(dppContentSpecificationIDsSemanticID))
+	list.SetSemanticIDListElement(globalReference(dppContentSpecificationIDSemanticID))
+	orderRelevant := false
+	list.SetOrderRelevant(&orderRelevant)
+	valueType := types.DataTypeDefXSDString
+	list.SetValueTypeListElement(&valueType)
+
+	items := make([]types.ISubmodelElement, 0, len(values))
+	for _, value := range values {
+		item := metadataProperty("", dppContentSpecificationIDSemanticID, value, types.DataTypeDefXSDString)
+		item.SetIDShort(nil)
+		items = append(items, item)
+	}
+	list.SetValue(items)
+	return list
+}
+
+func setNewDPPSubmodelAdministration(submodel types.ISubmodel, timestamp time.Time) {
+	formatted := timestamp.UTC().Format(time.RFC3339Nano)
+	administration := types.NewAdministrativeInformation()
+	administration.SetCreatedAt(&formatted)
+	administration.SetUpdatedAt(&formatted)
+	submodel.SetAdministration(administration)
 }
 
 func buildContentSubmodel(dppID string, sectionName string, semanticID string, value any) (types.ISubmodel, error) {

--- a/pkg/dppapiservice/go/dpp_aas_builder.go
+++ b/pkg/dppapiservice/go/dpp_aas_builder.go
@@ -37,7 +37,7 @@ func buildMetadataSubmodel(dppID string, header dppHeader) types.ISubmodel {
 	idShort := dppMetadataIDShort
 	submodel.SetIDShort(&idShort)
 	submodel.SetSemanticID(globalReference(dppMetadataSemanticID))
-	submodel.SetSubmodelElements([]types.ISubmodelElement{
+	elements := []types.ISubmodelElement{
 		stringProperty(headerDigitalProductPassportID, header.DigitalProductPassportID),
 		stringProperty(headerUniqueProductIdentifier, header.UniqueProductIdentifier),
 		stringProperty(headerGranularity, header.Granularity),
@@ -45,15 +45,20 @@ func buildMetadataSubmodel(dppID string, header dppHeader) types.ISubmodel {
 		stringProperty(headerDppStatus, header.DppStatus),
 		stringProperty(headerLastUpdate, header.LastUpdate.UTC().Format(time.RFC3339Nano)),
 		stringProperty(headerEconomicOperatorID, header.EconomicOperatorID),
-		stringProperty(headerFacilityID, header.FacilityID),
-		stringList(headerContentSpecificationIDs, header.ContentSpecificationIDs),
-	})
+	}
+	if header.FacilityID != "" {
+		elements = append(elements, stringProperty(headerFacilityID, header.FacilityID))
+	}
+	if len(header.ContentSpecificationIDs) > 0 {
+		elements = append(elements, stringList(headerContentSpecificationIDs, header.ContentSpecificationIDs))
+	}
+	submodel.SetSubmodelElements(elements)
 	return submodel
 }
 
 func buildContentSubmodel(dppID string, sectionName string, semanticID string, value any) (types.ISubmodel, error) {
 	submodel := types.NewSubmodel(contentSubmodelID(dppID, sectionName))
-	idShort := upperFirst(sectionName)
+	idShort := contentSectionIDShort(sectionName)
 	submodel.SetIDShort(&idShort)
 	if semanticID != "" {
 		submodel.SetSemanticID(globalReference(semanticID))

--- a/pkg/dppapiservice/go/dpp_aas_builder_test.go
+++ b/pkg/dppapiservice/go/dpp_aas_builder_test.go
@@ -1,0 +1,155 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+// Author: Aaron Zielstorff ( Fraunhofer IESE )
+
+package dppapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/FriedJannik/aas-go-sdk/verification"
+)
+
+func TestBuildMetadataSubmodelConformsToIDTA02099(t *testing.T) {
+	lastUpdate := time.Date(2026, time.July, 9, 10, 11, 12, 123000000, time.UTC)
+	//nolint:gosec // The values describe a standards-conformance fixture, not credentials.
+	header := dppHeader{
+		DigitalProductPassportID: "https://example.org/dpps/1",
+		UniqueProductIdentifier:  "https://example.org/products/1",
+		Granularity:              "Item",
+		DppSchemaVersion:         "EN18223:v1.0",
+		DppStatus:                "Active",
+		LastUpdate:               lastUpdate,
+		EconomicOperatorID:       "operator-1",
+		FacilityID:               "facility-1",
+		ContentSpecificationIDs:  []string{"urn:example:specification:one", "urn:example:specification:two"},
+	}
+
+	metadata := buildMetadataSubmodel(header.DigitalProductPassportID, header)
+	expectedProperties := map[string]struct {
+		semanticID string
+		valueType  types.DataTypeDefXSD
+	}{
+		headerDigitalProductPassportID: {dppIDSemanticID, types.DataTypeDefXSDString},
+		headerUniqueProductIdentifier:  {dppProductIDSemanticID, types.DataTypeDefXSDString},
+		headerGranularity:              {dppGranularitySemanticID, types.DataTypeDefXSDString},
+		headerDppSchemaVersion:         {dppSchemaVersionSemanticID, types.DataTypeDefXSDString},
+		headerDppStatus:                {dppStatusSemanticID, types.DataTypeDefXSDString},
+		headerLastUpdate:               {dppLastUpdateSemanticID, types.DataTypeDefXSDDateTime},
+		headerEconomicOperatorID:       {dppEconomicOperatorIDSemanticID, types.DataTypeDefXSDString},
+		headerFacilityID:               {dppFacilityIDSemanticID, types.DataTypeDefXSDString},
+	}
+	for idShort, expected := range expectedProperties {
+		element := metadataElementByIDShort(t, metadata, idShort)
+		property, ok := element.(*types.Property)
+		if !ok {
+			t.Fatalf("metadata element %s has type %T, want Property", idShort, element)
+		}
+		if got := referenceToString(property.SemanticID()); got != expected.semanticID {
+			t.Fatalf("metadata element %s semantic ID = %q, want %q", idShort, got, expected.semanticID)
+		}
+		if property.ValueType() != expected.valueType {
+			t.Fatalf("metadata element %s value type = %v, want %v", idShort, property.ValueType(), expected.valueType)
+		}
+	}
+
+	assertSupplementalSemanticID(t, metadataElementByIDShort(t, metadata, headerGranularity), dppGranularitySupplementalSemanticID)
+	assertSupplementalSemanticID(t, metadataElementByIDShort(t, metadata, headerLastUpdate), dppAdministrativeUpdateSupplementalSemanticID)
+	assertMetadataContentSpecificationIDs(t, metadata)
+	assertSubmodelTimestamp(t, metadata, lastUpdate)
+	assertValidSubmodel(t, metadata)
+}
+
+func assertMetadataContentSpecificationIDs(t *testing.T, metadata types.ISubmodel) {
+	t.Helper()
+	element := metadataElementByIDShort(t, metadata, headerContentSpecificationIDs)
+	list, ok := element.(*types.SubmodelElementList)
+	if !ok {
+		t.Fatalf("metadata element %s has type %T, want SubmodelElementList", headerContentSpecificationIDs, element)
+	}
+	if got := referenceToString(list.SemanticID()); got != dppContentSpecificationIDsSemanticID {
+		t.Fatalf("contentSpecificationIds semantic ID = %q", got)
+	}
+	if list.OrderRelevant() == nil || *list.OrderRelevant() {
+		t.Fatalf("contentSpecificationIds orderRelevant = %#v, want false", list.OrderRelevant())
+	}
+	if list.TypeValueListElement() != types.AASSubmodelElementsProperty {
+		t.Fatalf("contentSpecificationIds element type = %v", list.TypeValueListElement())
+	}
+	if list.ValueTypeListElement() == nil || *list.ValueTypeListElement() != types.DataTypeDefXSDString {
+		t.Fatalf("contentSpecificationIds value type = %#v", list.ValueTypeListElement())
+	}
+	if got := referenceToString(list.SemanticIDListElement()); got != dppContentSpecificationIDSemanticID {
+		t.Fatalf("contentSpecificationIds list element semantic ID = %q", got)
+	}
+	for index, item := range list.Value() {
+		if got := referenceToString(item.SemanticID()); got != dppContentSpecificationIDSemanticID {
+			t.Fatalf("contentSpecificationIds item %d semantic ID = %q", index, got)
+		}
+	}
+}
+
+func metadataElementByIDShort(t *testing.T, metadata types.ISubmodel, idShort string) types.ISubmodelElement {
+	t.Helper()
+	for _, element := range metadata.SubmodelElements() {
+		if element.IDShort() != nil && *element.IDShort() == idShort {
+			return element
+		}
+	}
+	t.Fatalf("metadata element %s not found", idShort)
+	return nil
+}
+
+func assertSupplementalSemanticID(t *testing.T, element types.ISubmodelElement, expected string) {
+	t.Helper()
+	if len(element.SupplementalSemanticIDs()) != 1 || referenceToString(element.SupplementalSemanticIDs()[0]) != expected {
+		t.Fatalf("element supplemental semantic IDs = %#v, want %q", element.SupplementalSemanticIDs(), expected)
+	}
+}
+
+func assertSubmodelTimestamp(t *testing.T, submodel types.ISubmodel, expected time.Time) {
+	t.Helper()
+	if submodel.Administration() == nil || submodel.Administration().CreatedAt() == nil || submodel.Administration().UpdatedAt() == nil {
+		t.Fatalf("submodel administration = %#v, want createdAt and updatedAt", submodel.Administration())
+	}
+	want := expected.UTC().Format(time.RFC3339Nano)
+	if *submodel.Administration().CreatedAt() != want || *submodel.Administration().UpdatedAt() != want {
+		t.Fatalf("submodel timestamps = (%q, %q), want %q", *submodel.Administration().CreatedAt(), *submodel.Administration().UpdatedAt(), want)
+	}
+}
+
+func assertValidSubmodel(t *testing.T, submodel types.ISubmodel) {
+	t.Helper()
+	verificationErrors := make([]string, 0)
+	verification.VerifySubmodel(submodel, func(err *verification.VerificationError) bool {
+		verificationErrors = append(verificationErrors, err.Error())
+		return false
+	})
+	if len(verificationErrors) != 0 {
+		t.Fatalf("VerifySubmodel() errors = %#v", verificationErrors)
+	}
+}

--- a/pkg/dppapiservice/go/dpp_document.go
+++ b/pkg/dppapiservice/go/dpp_document.go
@@ -136,7 +136,7 @@ func parseDPPHeader(doc dppDocument, requireHeaders bool) (dppHeader, error) {
 	if err != nil {
 		return header, err
 	}
-	header.FacilityID, err = stringField(doc, headerFacilityID, requireHeaders)
+	header.FacilityID, err = stringField(doc, headerFacilityID, false)
 	if err != nil {
 		return header, err
 	}
@@ -144,7 +144,7 @@ func parseDPPHeader(doc dppDocument, requireHeaders bool) (dppHeader, error) {
 	if err != nil {
 		return header, err
 	}
-	header.ContentSpecificationIDs, err = stringSliceField(doc, headerContentSpecificationIDs, requireHeaders)
+	header.ContentSpecificationIDs, err = stringSliceField(doc, headerContentSpecificationIDs, false)
 	if err != nil {
 		return header, err
 	}

--- a/pkg/dppapiservice/go/dpp_document_test.go
+++ b/pkg/dppapiservice/go/dpp_document_test.go
@@ -61,6 +61,92 @@ func TestDecodeDPPDocumentPreservesContentSections(t *testing.T) {
 	}
 }
 
+func TestDecodeDPPDocumentAcceptsOptionalHeaderFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "omitted",
+			body: `{
+				"digitalProductPassportId":"dpp-1",
+				"uniqueProductIdentifier":"product-1",
+				"granularity":"Item",
+				"dppSchemaVersion":"EN18223:v1",
+				"dppStatus":"Active",
+				"lastUpdate":"2026-06-10T10:00:00Z",
+				"economicOperatorId":"operator-1"
+			}`,
+		},
+		{
+			name: "empty content specification IDs",
+			body: `{
+				"digitalProductPassportId":"dpp-1",
+				"uniqueProductIdentifier":"product-1",
+				"granularity":"Item",
+				"dppSchemaVersion":"EN18223:v1",
+				"dppStatus":"Active",
+				"lastUpdate":"2026-06-10T10:00:00Z",
+				"economicOperatorId":"operator-1",
+				"contentSpecificationIds":[]
+			}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, header, err := decodeDPPDocument([]byte(test.body), true)
+			if err != nil {
+				t.Fatalf("decodeDPPDocument() error = %v", err)
+			}
+			if header.FacilityID != "" {
+				t.Fatalf("facility ID = %q, want empty", header.FacilityID)
+			}
+			if len(header.ContentSpecificationIDs) != 0 {
+				t.Fatalf("content specification IDs = %#v, want none", header.ContentSpecificationIDs)
+			}
+
+			metadata := buildMetadataSubmodel(header.DigitalProductPassportID, header)
+			composed, err := composeHeader(metadata)
+			if err != nil {
+				t.Fatalf("composeHeader() error = %v", err)
+			}
+			if _, ok := composed[headerFacilityID]; ok {
+				t.Fatalf("composed header unexpectedly contains %s: %#v", headerFacilityID, composed)
+			}
+			if _, ok := composed[headerContentSpecificationIDs]; ok {
+				t.Fatalf("composed header unexpectedly contains %s: %#v", headerContentSpecificationIDs, composed)
+			}
+		})
+	}
+}
+
+func TestDecodeDPPDocumentRejectsInvalidOptionalHeaderValues(t *testing.T) {
+	validHeader := `{
+		"digitalProductPassportId":"dpp-1",
+		"uniqueProductIdentifier":"product-1",
+		"granularity":"Item",
+		"dppSchemaVersion":"EN18223:v1",
+		"dppStatus":"Active",
+		"lastUpdate":"2026-06-10T10:00:00Z",
+		"economicOperatorId":"operator-1"`
+	tests := []struct {
+		name  string
+		field string
+	}{
+		{name: "blank facility ID", field: `,"facilityId":""`},
+		{name: "blank content specification ID", field: `,"contentSpecificationIds":[""]`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := decodeDPPDocument([]byte(validHeader+test.field+`}`), true)
+			if err == nil || !strings.Contains(err.Error(), "DPP-HEADER-INVALID") {
+				t.Fatalf("decodeDPPDocument() error = %v, want DPP-HEADER-INVALID", err)
+			}
+		})
+	}
+}
+
 func TestApplyMergePatchRemovesAndUpdatesFields(t *testing.T) {
 	target := map[string]any{
 		"dppStatus": "Active",

--- a/pkg/dppapiservice/go/dpp_element_inference.go
+++ b/pkg/dppapiservice/go/dpp_element_inference.go
@@ -185,15 +185,6 @@ func numberProperty(idShort string, value json.Number) types.ISubmodelElement {
 	return scalarProperty(idShort, value.String(), numberValueType(value))
 }
 
-func stringList(idShort string, values []string) types.ISubmodelElement {
-	items := make([]any, 0, len(values))
-	for _, value := range values {
-		items = append(items, value)
-	}
-	element, _ := listElement(idShort, items)
-	return element
-}
-
 func multiLanguageElement(idShort string, values []any) (types.ISubmodelElement, error) {
 	property := types.NewMultiLanguageProperty()
 	property.SetIDShort(&idShort)

--- a/pkg/dppapiservice/go/dpp_element_inference_test.go
+++ b/pkg/dppapiservice/go/dpp_element_inference_test.go
@@ -92,6 +92,26 @@ func TestInferElementRejectsAmbiguousArrays(t *testing.T) {
 	}
 }
 
+func TestPreserveElementMetadataKeepsArrayItemIDShort(t *testing.T) {
+	list, err := inferElement("items", []any{map[string]any{"name": "old"}})
+	if err != nil {
+		t.Fatalf("inferElement() list error = %v", err)
+	}
+	existing := list.(*types.SubmodelElementList).Value()[0]
+	if existing.IDShort() == nil || *existing.IDShort() != "items0" {
+		t.Fatalf("existing list item idShort = %v, want items0", existing.IDShort())
+	}
+
+	replacement, err := inferElement("items[0]", map[string]any{"name": "new"})
+	if err != nil {
+		t.Fatalf("inferElement() replacement error = %v", err)
+	}
+	preserveElementMetadata(existing, replacement)
+	if replacement.IDShort() == nil || *replacement.IDShort() != "items0" {
+		t.Fatalf("replacement list item idShort = %v, want items0", replacement.IDShort())
+	}
+}
+
 func TestBuildAASMapsGranularityToAssetKind(t *testing.T) {
 	tests := []struct {
 		granularity string

--- a/pkg/dppapiservice/go/dpp_element_path.go
+++ b/pkg/dppapiservice/go/dpp_element_path.go
@@ -238,9 +238,9 @@ func dppElementIDFromJSONPathSegments(segments []dppJSONPathSegment) (string, er
 		return "", invalidDPPElementIDPathError()
 	}
 	var elementID strings.Builder
-	elementID.WriteString(segments[nameIndex].name)
+	_, _ = elementID.WriteString(segments[nameIndex].name)
 	for index := nameIndex + 1; index <= last; index++ {
-		elementID.WriteString(strconv.Itoa(segments[index].index))
+		_, _ = elementID.WriteString(strconv.Itoa(segments[index].index))
 	}
 	return elementID.String(), nil
 }

--- a/pkg/dppapiservice/go/dpp_element_path.go
+++ b/pkg/dppapiservice/go/dpp_element_path.go
@@ -91,14 +91,14 @@ func parseDPPJSONPathBracketSegment(value string, index int) (dppJSONPathSegment
 func parseDPPJSONPathQuotedSegment(value string, index int) (dppJSONPathSegment, int, error) {
 	quote := value[index]
 	index++
-	var builder strings.Builder
+	name := make([]rune, 0)
 	for index < len(value) {
 		if value[index] == '\\' {
 			escaped, next, err := parseDPPJSONPathEscape(value, index)
 			if err != nil {
 				return dppJSONPathSegment{}, 0, err
 			}
-			builder.WriteRune(escaped)
+			name = append(name, escaped)
 			index = next
 			continue
 		}
@@ -106,17 +106,16 @@ func parseDPPJSONPathQuotedSegment(value string, index int) (dppJSONPathSegment,
 			if index+1 >= len(value) || value[index+1] != ']' {
 				return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
 			}
-			name := builder.String()
-			if name == "" {
+			if len(name) == 0 {
 				return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
 			}
-			return dppJSONPathSegment{name: name}, index + 2, nil
+			return dppJSONPathSegment{name: string(name)}, index + 2, nil
 		}
 		r, width := utf8.DecodeRuneInString(value[index:])
 		if r == utf8.RuneError && width == 1 || r < 0x20 {
 			return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
 		}
-		builder.WriteRune(r)
+		name = append(name, r)
 		index += width
 	}
 	return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
@@ -197,29 +196,25 @@ func parseDPPJSONPathIndexSegment(value string, index int) (dppJSONPathSegment, 
 }
 
 func dppIDShortPathFromJSONPathSegments(segments []dppJSONPathSegment) (string, error) {
-	var builder strings.Builder
+	parts := make([]string, 0, len(segments))
 	for _, segment := range segments {
 		if segment.isIndex {
-			if builder.Len() == 0 {
+			if len(parts) == 0 {
 				return "", invalidDPPElementIDPathError()
 			}
-			builder.WriteString("[")
-			builder.WriteString(strconv.Itoa(segment.index))
-			builder.WriteString("]")
+			last := len(parts) - 1
+			parts[last] += "[" + strconv.Itoa(segment.index) + "]"
 			continue
 		}
 		if segment.name == "" {
 			return "", invalidDPPElementIDPathError()
 		}
-		if builder.Len() > 0 {
-			builder.WriteString(".")
-		}
-		builder.WriteString(segment.name)
+		parts = append(parts, segment.name)
 	}
-	if builder.Len() == 0 {
+	if len(parts) == 0 {
 		return "", invalidDPPElementIDPathError()
 	}
-	return builder.String(), nil
+	return strings.Join(parts, "."), nil
 }
 
 func invalidDPPElementIDPathError() error {

--- a/pkg/dppapiservice/go/dpp_element_path.go
+++ b/pkg/dppapiservice/go/dpp_element_path.go
@@ -36,6 +36,7 @@ import (
 type dppElementPath struct {
 	sectionName string
 	idShortPath string
+	elementID   string
 }
 
 type dppJSONPathSegment struct {
@@ -56,7 +57,11 @@ func parseDPPJSONElementPath(elementIDPath string) (dppElementPath, error) {
 	if err != nil {
 		return dppElementPath{}, err
 	}
-	return dppElementPath{sectionName: segments[0].name, idShortPath: idShortPath}, nil
+	elementID, err := dppElementIDFromJSONPathSegments(segments[1:])
+	if err != nil {
+		return dppElementPath{}, err
+	}
+	return dppElementPath{sectionName: segments[0].name, idShortPath: idShortPath, elementID: elementID}, nil
 }
 
 func parseDPPJSONPathSegments(value string) ([]dppJSONPathSegment, error) {
@@ -215,6 +220,29 @@ func dppIDShortPathFromJSONPathSegments(segments []dppJSONPathSegment) (string, 
 		return "", invalidDPPElementIDPathError()
 	}
 	return strings.Join(parts, "."), nil
+}
+
+func dppElementIDFromJSONPathSegments(segments []dppJSONPathSegment) (string, error) {
+	if len(segments) == 0 {
+		return "", invalidDPPElementIDPathError()
+	}
+	last := len(segments) - 1
+	if !segments[last].isIndex {
+		return segments[last].name, nil
+	}
+	nameIndex := last
+	for nameIndex >= 0 && segments[nameIndex].isIndex {
+		nameIndex--
+	}
+	if nameIndex < 0 || segments[nameIndex].name == "" {
+		return "", invalidDPPElementIDPathError()
+	}
+	var elementID strings.Builder
+	elementID.WriteString(segments[nameIndex].name)
+	for index := nameIndex + 1; index <= last; index++ {
+		elementID.WriteString(strconv.Itoa(segments[index].index))
+	}
+	return elementID.String(), nil
 }
 
 func invalidDPPElementIDPathError() error {

--- a/pkg/dppapiservice/go/dpp_element_path.go
+++ b/pkg/dppapiservice/go/dpp_element_path.go
@@ -1,0 +1,227 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+// Author: Jannik Fried ( Fraunhofer IESE ), Aaron Zielstorff ( Fraunhofer IESE )
+
+package dppapi
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+type dppElementPath struct {
+	sectionName string
+	idShortPath string
+}
+
+type dppJSONPathSegment struct {
+	name    string
+	index   int
+	isIndex bool
+}
+
+func parseDPPJSONElementPath(elementIDPath string) (dppElementPath, error) {
+	segments, err := parseDPPJSONPathSegments(elementIDPath)
+	if err != nil {
+		return dppElementPath{}, err
+	}
+	if len(segments) < 2 || segments[0].isIndex {
+		return dppElementPath{}, invalidDPPElementIDPathError()
+	}
+	idShortPath, err := dppIDShortPathFromJSONPathSegments(segments[1:])
+	if err != nil {
+		return dppElementPath{}, err
+	}
+	return dppElementPath{sectionName: segments[0].name, idShortPath: idShortPath}, nil
+}
+
+func parseDPPJSONPathSegments(value string) ([]dppJSONPathSegment, error) {
+	if value == "" || value[0] != '$' {
+		return nil, invalidDPPElementIDPathError()
+	}
+	segments := make([]dppJSONPathSegment, 0)
+	for index := 1; index < len(value); {
+		if value[index] != '[' {
+			return nil, invalidDPPElementIDPathError()
+		}
+		segment, next, err := parseDPPJSONPathBracketSegment(value, index+1)
+		if err != nil {
+			return nil, err
+		}
+		segments = append(segments, segment)
+		index = next
+	}
+	return segments, nil
+}
+
+func parseDPPJSONPathBracketSegment(value string, index int) (dppJSONPathSegment, int, error) {
+	if index >= len(value) || value[index] == '"' {
+		return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
+	}
+	if value[index] == '\'' {
+		return parseDPPJSONPathQuotedSegment(value, index)
+	}
+	return parseDPPJSONPathIndexSegment(value, index)
+}
+
+func parseDPPJSONPathQuotedSegment(value string, index int) (dppJSONPathSegment, int, error) {
+	quote := value[index]
+	index++
+	var builder strings.Builder
+	for index < len(value) {
+		if value[index] == '\\' {
+			escaped, next, err := parseDPPJSONPathEscape(value, index)
+			if err != nil {
+				return dppJSONPathSegment{}, 0, err
+			}
+			builder.WriteRune(escaped)
+			index = next
+			continue
+		}
+		if value[index] == quote {
+			if index+1 >= len(value) || value[index+1] != ']' {
+				return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
+			}
+			name := builder.String()
+			if name == "" {
+				return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
+			}
+			return dppJSONPathSegment{name: name}, index + 2, nil
+		}
+		r, width := utf8.DecodeRuneInString(value[index:])
+		if r == utf8.RuneError && width == 1 || r < 0x20 {
+			return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
+		}
+		builder.WriteRune(r)
+		index += width
+	}
+	return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
+}
+
+func parseDPPJSONPathEscape(value string, index int) (rune, int, error) {
+	if index+1 >= len(value) {
+		return 0, 0, invalidDPPElementIDPathError()
+	}
+	switch value[index+1] {
+	case 'b':
+		return '\b', index + 2, nil
+	case 'f':
+		return '\f', index + 2, nil
+	case 'n':
+		return '\n', index + 2, nil
+	case 'r':
+		return '\r', index + 2, nil
+	case 't':
+		return '\t', index + 2, nil
+	case '\'', '\\':
+		return rune(value[index+1]), index + 2, nil
+	case 'u':
+		return parseDPPJSONPathUnicodeEscape(value, index)
+	default:
+		return 0, 0, invalidDPPElementIDPathError()
+	}
+}
+
+func parseDPPJSONPathUnicodeEscape(value string, index int) (rune, int, error) {
+	if index+6 > len(value) {
+		return 0, 0, invalidDPPElementIDPathError()
+	}
+	hex := value[index+2 : index+6]
+	if !isDPPJSONPathNormalHex(hex) {
+		return 0, 0, invalidDPPElementIDPathError()
+	}
+	parsed, err := strconv.ParseInt(hex, 16, 32)
+	if err != nil {
+		return 0, 0, invalidDPPElementIDPathError()
+	}
+	return rune(parsed), index + 6, nil
+}
+
+func isDPPJSONPathNormalHex(value string) bool {
+	if len(value) != 4 || value[0] != '0' || value[1] != '0' {
+		return false
+	}
+	if value[2] == '0' {
+		return value[3] >= '0' && value[3] <= '7' || value[3] == 'b' || value[3] == 'e' || value[3] == 'f'
+	}
+	if value[2] != '1' {
+		return false
+	}
+	return value[3] >= '0' && value[3] <= '9' || value[3] >= 'a' && value[3] <= 'f'
+}
+
+func parseDPPJSONPathIndexSegment(value string, index int) (dppJSONPathSegment, int, error) {
+	start := index
+	if value[index] == '0' {
+		index++
+	} else {
+		if value[index] < '1' || value[index] > '9' {
+			return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
+		}
+		for index < len(value) && value[index] >= '0' && value[index] <= '9' {
+			index++
+		}
+	}
+	if start == index || index >= len(value) || value[index] != ']' {
+		return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
+	}
+	parsed, err := strconv.Atoi(value[start:index])
+	if err != nil {
+		return dppJSONPathSegment{}, 0, invalidDPPElementIDPathError()
+	}
+	return dppJSONPathSegment{index: parsed, isIndex: true}, index + 1, nil
+}
+
+func dppIDShortPathFromJSONPathSegments(segments []dppJSONPathSegment) (string, error) {
+	var builder strings.Builder
+	for _, segment := range segments {
+		if segment.isIndex {
+			if builder.Len() == 0 {
+				return "", invalidDPPElementIDPathError()
+			}
+			builder.WriteString("[")
+			builder.WriteString(strconv.Itoa(segment.index))
+			builder.WriteString("]")
+			continue
+		}
+		if segment.name == "" {
+			return "", invalidDPPElementIDPathError()
+		}
+		if builder.Len() > 0 {
+			builder.WriteString(".")
+		}
+		builder.WriteString(segment.name)
+	}
+	if builder.Len() == 0 {
+		return "", invalidDPPElementIDPathError()
+	}
+	return builder.String(), nil
+}
+
+func invalidDPPElementIDPathError() error {
+	return fmt.Errorf("DPP-ELEMPATH-INVALID elementIdPath must be an RFC 9535 Normalized Path selecting a DPP data element")
+}

--- a/pkg/dppapiservice/go/dpp_filtering_test.go
+++ b/pkg/dppapiservice/go/dpp_filtering_test.go
@@ -48,12 +48,12 @@ func TestComposeResolvedDPPFiltersCompressedContentByContentSpecificationIDs(t *
 		t.Fatalf("composeResolvedDPP() error = %v", err)
 	}
 
-	nameplate, ok := doc["digitalNameplate"].(map[string]any)
+	nameplate, ok := doc[filteringNameplateSemantic].(map[string]any)
 	if !ok {
-		t.Fatalf("digitalNameplate section = %#v, want object", doc["digitalNameplate"])
+		t.Fatalf("%s section = %#v, want object", filteringNameplateSemantic, doc[filteringNameplateSemantic])
 	}
 	if nameplate["manufacturerName"] != "Acme GmbH" {
-		t.Fatalf("digitalNamePlate.manufacturerName = %#v", nameplate["manufacturerName"])
+		t.Fatalf("%s.manufacturerName = %#v", filteringNameplateSemantic, nameplate["manufacturerName"])
 	}
 	if _, ok := doc["technicalData"]; ok {
 		t.Fatalf("technicalData section was included despite missing contentSpecificationIds match: %#v", doc["technicalData"])
@@ -86,7 +86,7 @@ func TestComposeResolvedDPPFiltersFullContentByContentSpecificationIDs(t *testin
 func TestResolveDPPElementPathFiltersByContentSpecificationIDs(t *testing.T) {
 	resolved := filteringResolvedDPP()
 
-	submodelID, idShortPath, err := resolveDPPElementPath(resolved, "digitalNameplate/manufacturerName")
+	submodelID, idShortPath, err := resolveDPPElementPath(resolved, "$['"+filteringNameplateSemantic+"']['manufacturerName']")
 	if err != nil {
 		t.Fatalf("resolveDPPElementPath() error = %v", err)
 	}
@@ -97,9 +97,177 @@ func TestResolveDPPElementPathFiltersByContentSpecificationIDs(t *testing.T) {
 		t.Fatalf("idShortPath = %q", idShortPath)
 	}
 
-	_, _, err = resolveDPPElementPath(resolved, "technicalData/internalNote")
+	_, _, err = resolveDPPElementPath(resolved, "$['"+filteringTechnicalSemantic+"']['internalNote']")
 	if err == nil || !strings.Contains(err.Error(), "DPP-ELEMPATH-NOTFOUND") {
 		t.Fatalf("resolveDPPElementPath() error = %v, want DPP-ELEMPATH-NOTFOUND", err)
+	}
+}
+
+func TestComposeAndResolveDPPUseNewestContentSubmodelForSharedSemanticID(t *testing.T) {
+	resolved := filteringResolvedDPP()
+	older := filteringContentSubmodel("olderNameplate", "OlderNameplate", filteringNameplateSemantic, stringProperty("manufacturerName", "Older GmbH"))
+	newer := filteringContentSubmodel("newerNameplate", "NewerNameplate", filteringNameplateSemantic, stringProperty("manufacturerName", "Newer GmbH"))
+	setContentSubmodelUpdatedAt(older, "2026-06-22T12:00:00Z")
+	setContentSubmodelUpdatedAt(newer, "2026-06-23T12:00:00Z")
+	resolved.submodels = []types.ISubmodel{resolved.metadata, newer, older}
+
+	compressed, err := composeResolvedDPP(resolved, REPRESENTATION_COMPRESSED)
+	if err != nil {
+		t.Fatalf("composeResolvedDPP() compressed error = %v", err)
+	}
+	section := compressed[filteringNameplateSemantic].(map[string]any)
+	if section["manufacturerName"] != "Newer GmbH" {
+		t.Fatalf("compressed section = %#v, want newest submodel content", section)
+	}
+
+	full, err := composeResolvedDPP(resolved, REPRESENTATION_FULL)
+	if err != nil {
+		t.Fatalf("composeResolvedDPP() full error = %v", err)
+	}
+	elements := full["elements"].([]map[string]any)
+	if len(elements) != 1 {
+		t.Fatalf("full elements = %#v, want exactly one newest content submodel", elements)
+	}
+	fullElement := elements[0]["elements"].([]map[string]any)[0]
+	if fullElement["value"] != "Newer GmbH" {
+		t.Fatalf("full element = %#v, want newest submodel content", fullElement)
+	}
+
+	submodelID, _, err := resolveDPPElementPath(resolved, "$['"+filteringNameplateSemantic+"']['manufacturerName']")
+	if err != nil {
+		t.Fatalf("resolveDPPElementPath() error = %v", err)
+	}
+	if submodelID != newer.ID() {
+		t.Fatalf("resolved submodel ID = %q, want newest submodel %q", submodelID, newer.ID())
+	}
+}
+
+func TestResolveDPPElementPathRejectsIDShortAliasForSemanticContentSection(t *testing.T) {
+	_, _, err := resolveDPPElementPath(filteringResolvedDPP(), "$['digitalNameplate']['manufacturerName']")
+	if err == nil || !strings.Contains(err.Error(), "DPP-ELEMPATH-NOTFOUND") {
+		t.Fatalf("resolveDPPElementPath() error = %v, want DPP-ELEMPATH-NOTFOUND", err)
+	}
+}
+
+func TestResolveDPPElementPathRejectsLegacySectionPath(t *testing.T) {
+	_, _, err := resolveDPPElementPath(filteringResolvedDPP(), "digitalNameplate/manufacturerName")
+	if err == nil {
+		t.Fatal("resolveDPPElementPath() error = nil, want invalid legacy path")
+	}
+	if !strings.Contains(err.Error(), "DPP-ELEMPATH-INVALID") {
+		t.Fatalf("resolveDPPElementPath() error = %v, want DPP-ELEMPATH-INVALID", err)
+	}
+}
+
+func TestResolveDPPElementPathSupportsContentSpecificationIDSectionNames(t *testing.T) {
+	semanticID := "https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0"
+	header := dppHeader{
+		DigitalProductPassportID: filteringDPPID,
+		UniqueProductIdentifier:  "https://example.org/products/filtering",
+		Granularity:              "Item",
+		DppSchemaVersion:         "1.0.0",
+		DppStatus:                "active",
+		LastUpdate:               time.Date(2026, time.June, 23, 12, 0, 0, 0, time.UTC),
+		EconomicOperatorID:       "operator-123",
+		FacilityID:               "facility-456",
+		ContentSpecificationIDs:  []string{semanticID},
+	}
+	metadata := buildMetadataSubmodel(filteringDPPID, header)
+	content := filteringContentSubmodel(semanticID, contentSectionIDShort(semanticID), semanticID, stringProperty("ProductCarbonFootprints", "17.2"))
+	resolved := resolvedDPP{
+		metadata:  metadata,
+		submodels: []types.ISubmodel{metadata, content},
+	}
+	if idShort := idShortOrID(content); idShort == semanticID {
+		t.Fatalf("content submodel idShort = %q, want AAS-safe idShort", idShort)
+	}
+
+	submodelID, idShortPath, err := resolveDPPElementPath(resolved, "$['"+semanticID+"']['ProductCarbonFootprints']")
+	if err != nil {
+		t.Fatalf("resolveDPPElementPath() error = %v", err)
+	}
+	if submodelID != contentSubmodelID(filteringDPPID, semanticID) {
+		t.Fatalf("submodelID = %q", submodelID)
+	}
+	if idShortPath != "ProductCarbonFootprints" {
+		t.Fatalf("idShortPath = %q", idShortPath)
+	}
+}
+
+func TestResolveDPPElementPathConvertsJSONPathIndexes(t *testing.T) {
+	semanticID := "https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0"
+	header := dppHeader{
+		DigitalProductPassportID: filteringDPPID,
+		UniqueProductIdentifier:  "https://example.org/products/filtering",
+		Granularity:              "Item",
+		DppSchemaVersion:         "1.0.0",
+		DppStatus:                "active",
+		LastUpdate:               time.Date(2026, time.June, 23, 12, 0, 0, 0, time.UTC),
+		EconomicOperatorID:       "operator-123",
+		FacilityID:               "facility-456",
+		ContentSpecificationIDs:  []string{semanticID},
+	}
+	metadata := buildMetadataSubmodel(filteringDPPID, header)
+	content := filteringContentSubmodel(semanticID, contentSectionIDShort(semanticID), semanticID, stringProperty("ProductCarbonFootprints", "17.2"))
+	resolved := resolvedDPP{
+		metadata:  metadata,
+		submodels: []types.ISubmodel{metadata, content},
+	}
+
+	submodelID, idShortPath, err := resolveDPPElementPath(resolved, "$['"+semanticID+"']['ProductCarbonFootprints'][0]['PcfCo2eq']")
+	if err != nil {
+		t.Fatalf("resolveDPPElementPath() error = %v", err)
+	}
+	if submodelID != contentSubmodelID(filteringDPPID, semanticID) {
+		t.Fatalf("submodelID = %q", submodelID)
+	}
+	if idShortPath != "ProductCarbonFootprints[0].PcfCo2eq" {
+		t.Fatalf("idShortPath = %q", idShortPath)
+	}
+}
+
+func TestParseDPPJSONElementPathAcceptsRFC9535NormalizedPath(t *testing.T) {
+	parsed, err := parseDPPJSONElementPath(`$['sec\u0000tion']['line\nfeed'][0]['quote\'and\\slash']`)
+	if err != nil {
+		t.Fatalf("parseDPPJSONElementPath() error = %v", err)
+	}
+	if parsed.sectionName != "sec\x00tion" {
+		t.Fatalf("sectionName = %q, want escaped control character", parsed.sectionName)
+	}
+	if parsed.idShortPath != "line\nfeed[0].quote'and\\slash" {
+		t.Fatalf("idShortPath = %q", parsed.idShortPath)
+	}
+}
+
+func TestParseDPPJSONElementPathRejectsNonNormalizedPath(t *testing.T) {
+	paths := []string{
+		`$.section.property`,
+		`$["section"]["property"]`,
+		`$['section']['bad\q']`,
+		`$['section']['bad\u0061']`,
+		`$['section']['bad\/slash']`,
+		`$['section'][01]`,
+		`$['section'][-1]`,
+		`$['section'][*]`,
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			_, err := parseDPPJSONElementPath(path)
+			if err == nil || !strings.Contains(err.Error(), "DPP-ELEMPATH-INVALID") {
+				t.Fatalf("parseDPPJSONElementPath(%q) error = %v, want DPP-ELEMPATH-INVALID", path, err)
+			}
+		})
+	}
+}
+
+func TestResolveDPPElementPathRejectsNonSingularJSONPath(t *testing.T) {
+	_, _, err := resolveDPPElementPath(filteringResolvedDPP(), "$['https://admin-shell.io/idta/nameplate/3/0/Nameplate'][*]")
+	if err == nil {
+		t.Fatal("resolveDPPElementPath() error = nil, want invalid JSONPath")
+	}
+	if !strings.Contains(err.Error(), "DPP-ELEMPATH-INVALID") {
+		t.Fatalf("resolveDPPElementPath() error = %v, want DPP-ELEMPATH-INVALID", err)
 	}
 }
 
@@ -199,6 +367,12 @@ func filteringContentSubmodel(sectionName string, idShort string, semanticID str
 	submodel.SetSemanticID(globalReference(semanticID))
 	submodel.SetSubmodelElements(elements)
 	return submodel
+}
+
+func setContentSubmodelUpdatedAt(submodel types.ISubmodel, updatedAt string) {
+	administration := types.NewAdministrativeInformation()
+	administration.SetUpdatedAt(&updatedAt)
+	submodel.SetAdministration(administration)
 }
 
 func assertDPPContentSectionExists(t *testing.T, doc dppDocument, sectionName string) {

--- a/pkg/dppapiservice/go/dpp_filtering_test.go
+++ b/pkg/dppapiservice/go/dpp_filtering_test.go
@@ -339,6 +339,61 @@ func TestAppendUnselectedContentSubmodelReferencesPreservesBaseSubmodelRefs(t *t
 	}
 }
 
+func TestDPPUpdateReplacementRemainsNewestForSharedSemanticID(t *testing.T) {
+	resolved := filteringResolvedDPP()
+	current := filteringContentSubmodel("currentNameplate", "CurrentNameplate", filteringNameplateSemantic, stringProperty("manufacturerName", "Current GmbH"))
+	older := filteringContentSubmodel("olderNameplate", "OlderNameplate", filteringNameplateSemantic, stringProperty("manufacturerName", "Older GmbH"))
+	setContentSubmodelUpdatedAt(current, "2026-07-10T12:00:00Z")
+	setContentSubmodelUpdatedAt(older, "2026-07-07T12:00:00Z")
+	resolved.submodels = []types.ISubmodel{resolved.metadata, current, older}
+
+	currentDocument, err := composeResolvedDPP(resolved, REPRESENTATION_COMPRESSED)
+	if err != nil {
+		t.Fatalf("composeResolvedDPP() error = %v", err)
+	}
+	updatedAt, err := nextDPPUpdateTimestamp(
+		time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC),
+		currentDocument,
+		[]types.ISubmodel{current},
+	)
+	if err != nil {
+		t.Fatalf("nextDPPUpdateTimestamp() error = %v", err)
+	}
+	if !updatedAt.After(time.Date(2026, time.July, 10, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("updatedAt = %s, want timestamp after current content", updatedAt)
+	}
+
+	replacement := filteringContentSubmodel("replacementNameplate", "ReplacementNameplate", filteringNameplateSemantic, stringProperty("manufacturerName", "Replacement GmbH"))
+	replacementMetadata := buildMetadataSubmodel(filteringDPPID, dppHeader{
+		DigitalProductPassportID: filteringDPPID,
+		UniqueProductIdentifier:  "https://example.org/products/filtering",
+		Granularity:              "Item",
+		DppSchemaVersion:         "1.0.0",
+		DppStatus:                "active",
+		LastUpdate:               updatedAt,
+		EconomicOperatorID:       "operator-123",
+		ContentSpecificationIDs:  []string{filteringNameplateSemantic},
+	})
+	applyDPPUpdateAdministration(
+		[]types.ISubmodel{replacementMetadata, replacement},
+		resolved.metadata,
+		[]types.ISubmodel{current},
+		updatedAt,
+	)
+
+	updated := resolvedDPP{
+		metadata:  replacementMetadata,
+		submodels: []types.ISubmodel{replacementMetadata, older, replacement},
+	}
+	selected, err := selectedResolvedContentSubmodels(updated)
+	if err != nil {
+		t.Fatalf("selectedResolvedContentSubmodels() error = %v", err)
+	}
+	if len(selected) != 1 || selected[0].ID() != replacement.ID() {
+		t.Fatalf("selected content = %#v, want replacement %q", selected, replacement.ID())
+	}
+}
+
 func filteringResolvedDPP() resolvedDPP {
 	header := dppHeader{
 		DigitalProductPassportID: filteringDPPID,

--- a/pkg/dppapiservice/go/dpp_id_helpers.go
+++ b/pkg/dppapiservice/go/dpp_id_helpers.go
@@ -27,7 +27,9 @@
 package dppapi
 
 import (
+	"hash/fnv"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/FriedJannik/aas-go-sdk/types"
@@ -38,7 +40,50 @@ func metadataSubmodelID(dppID string) string {
 }
 
 func contentSubmodelID(dppID string, sectionName string) string {
-	return dppID + "/submodels/" + upperFirst(sectionName)
+	idShort := contentSectionIDShort(sectionName)
+	if idShort == upperFirst(sectionName) {
+		return dppID + "/submodels/" + idShort
+	}
+	return dppID + "/submodels/" + idShort + "-" + contentSectionHash(sectionName)
+}
+
+func contentSectionIDShort(sectionName string) string {
+	if semanticName := semanticIDLocalName(sectionName); semanticName != "" {
+		return sanitizeIDShort(upperFirst(semanticName), "Content")
+	}
+	return sanitizeIDShort(upperFirst(sectionName), "Content")
+}
+
+func semanticIDLocalName(value string) string {
+	if !strings.Contains(value, "://") && !strings.HasPrefix(value, "urn:") {
+		return ""
+	}
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == '/' || r == ':' || r == '#' || r == '?'
+	})
+	for index := len(parts) - 1; index >= 0; index-- {
+		part := strings.TrimSpace(parts[index])
+		if part == "" || !containsLetter(part) {
+			continue
+		}
+		return part
+	}
+	return ""
+}
+
+func containsLetter(value string) bool {
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' {
+			return true
+		}
+	}
+	return false
+}
+
+func contentSectionHash(value string) string {
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(value))
+	return strconv.FormatUint(hash.Sum64(), 16)
 }
 
 func submodelReference(submodelID string) types.IReference {

--- a/pkg/dppapiservice/go/dpp_mapping.go
+++ b/pkg/dppapiservice/go/dpp_mapping.go
@@ -14,7 +14,19 @@
 package dppapi
 
 const (
-	dppMetadataIDShort     = "DppMetadata"
-	dppMetadataSemanticID  = "https://admin-shell.io/idta/cds/dppMetadata/1"
-	dppMetadataSemanticURN = "urn:samm:io.admin-shell.idta.dpp_meta:1.0.0#DppMetadata"
+	dppMetadataIDShort                            = "DppMetadata"
+	dppMetadataSemanticID                         = "https://admin-shell.io/idta/cds/dppMetadata/1"
+	dppMetadataSemanticURN                        = "urn:samm:io.admin-shell.idta.dpp_meta:1.0.0#DppMetadata"
+	dppIDSemanticID                               = "https://admin-shell.io/idta/cds/digitalProductPassportId/1"
+	dppProductIDSemanticID                        = "https://admin-shell.io/idta/cds/uniqueProductIdentifier/1"
+	dppGranularitySemanticID                      = "https://admin-shell.io/idta/cds/granularity/1"
+	dppSchemaVersionSemanticID                    = "https://admin-shell.io/idta/cds/dppSchemaVersion/1"
+	dppStatusSemanticID                           = "https://admin-shell.io/idta/cds/dppStatus/1"
+	dppLastUpdateSemanticID                       = "https://admin-shell.io/idta/cds/lastUpdate/1"
+	dppEconomicOperatorIDSemanticID               = "https://admin-shell.io/idta/cds/economicOperatorId/1"
+	dppFacilityIDSemanticID                       = "https://admin-shell.io/idta/cds/facilityId/1"
+	dppContentSpecificationIDsSemanticID          = "https://admin-shell.io/idta/cds/contentSpecificationIds/1"
+	dppContentSpecificationIDSemanticID           = "https://admin-shell.io/idta/cds/contentSpecificationId/1"
+	dppGranularitySupplementalSemanticID          = "https://admin-shell.io/aas/3/2/AssetKind"
+	dppAdministrativeUpdateSupplementalSemanticID = "https://admin-shell.io/aas/3/2/AdministrativeInformation/updatedAt"
 )

--- a/pkg/dppapiservice/go/dpp_repository_service.go
+++ b/pkg/dppapiservice/go/dpp_repository_service.go
@@ -144,8 +144,12 @@ func (s *DPPRepositoryService) UpdateDPPFromJSON(ctx context.Context, dppID stri
 	if merged == nil {
 		return errorResponse(http.StatusBadRequest, errors.New("DPP-UPDDPP-MERGE merged DPP must be a JSON object")), nil
 	}
+	updatedAt, err := nextDPPUpdateTimestamp(time.Now().UTC(), current, currentContentSubmodels)
+	if err != nil {
+		return errorResponse(http.StatusInternalServerError, err), nil
+	}
 	merged[headerDigitalProductPassportID] = dppID
-	merged[headerLastUpdate] = time.Now().UTC().Format(time.RFC3339Nano)
+	merged[headerLastUpdate] = updatedAt.Format(time.RFC3339Nano)
 
 	raw, err := json.Marshal(merged)
 	if err != nil {
@@ -161,6 +165,7 @@ func (s *DPPRepositoryService) UpdateDPPFromJSON(ctx context.Context, dppID stri
 	if err != nil {
 		return errorResponse(http.StatusBadRequest, err), nil
 	}
+	applyDPPUpdateAdministration(submodels, currentResolved.metadata, currentContentSubmodels, header.LastUpdate)
 	refs = appendUnselectedContentSubmodelReferences(refs, currentResolved, currentContentSubmodels)
 	aas := buildAAS(header, refs)
 	staleSubmodelIDs := staleContentSubmodelIDs(currentContentSubmodels, submodels)
@@ -227,6 +232,72 @@ func appendUnselectedContentSubmodelReferences(refs []types.IReference, resolved
 		includedIDs[submodel.ID()] = struct{}{}
 	}
 	return refs
+}
+
+func applyDPPUpdateAdministration(replacements []types.ISubmodel, currentMetadata types.ISubmodel, currentContent []types.ISubmodel, timestamp time.Time) {
+	currentByID := make(map[string]types.ISubmodel, len(currentContent)+1)
+	currentByID[currentMetadata.ID()] = currentMetadata
+	currentBySemanticID := make(map[string]types.ISubmodel, len(currentContent))
+	for _, submodel := range currentContent {
+		currentByID[submodel.ID()] = submodel
+		if semanticID := referenceToString(submodel.SemanticID()); semanticID != "" {
+			currentBySemanticID[semanticID] = submodel
+		}
+	}
+
+	for _, replacement := range replacements {
+		current := currentByID[replacement.ID()]
+		if current == nil {
+			current = currentBySemanticID[referenceToString(replacement.SemanticID())]
+		}
+		replacement.SetAdministration(updatedDPPAdministration(current, timestamp))
+	}
+}
+
+func updatedDPPAdministration(current types.ISubmodel, timestamp time.Time) types.IAdministrativeInformation {
+	administration := types.NewAdministrativeInformation()
+	if current != nil && current.Administration() != nil {
+		existing := current.Administration()
+		administration.SetEmbeddedDataSpecifications(existing.EmbeddedDataSpecifications())
+		administration.SetVersion(existing.Version())
+		administration.SetRevision(existing.Revision())
+		administration.SetCreator(existing.Creator())
+		administration.SetCreatedAt(existing.CreatedAt())
+		administration.SetTemplateID(existing.TemplateID())
+	}
+
+	formatted := timestamp.UTC().Format(time.RFC3339Nano)
+	if administration.CreatedAt() == nil || strings.TrimSpace(*administration.CreatedAt()) == "" {
+		administration.SetCreatedAt(&formatted)
+	}
+	administration.SetUpdatedAt(&formatted)
+	return administration
+}
+
+func nextDPPUpdateTimestamp(now time.Time, current dppDocument, currentContent []types.ISubmodel) (time.Time, error) {
+	latest := now.UTC()
+	if rawLastUpdate, ok := current[headerLastUpdate].(string); ok && strings.TrimSpace(rawLastUpdate) != "" {
+		lastUpdate, err := common.ParseISO8601DateTime(rawLastUpdate)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("DPP-UPDDPP-LASTUPDATE parse current lastUpdate: %w", err)
+		}
+		latest = timestampAfter(latest, lastUpdate)
+	}
+	for _, submodel := range currentContent {
+		contentTimestamp, err := dppContentSubmodelTimestamp(submodel)
+		if err != nil {
+			return time.Time{}, err
+		}
+		latest = timestampAfter(latest, contentTimestamp)
+	}
+	return latest, nil
+}
+
+func timestampAfter(candidate time.Time, current time.Time) time.Time {
+	if candidate.After(current) {
+		return candidate
+	}
+	return current.Add(time.Nanosecond)
 }
 
 func dppObjectFromAny(value any) map[string]any {
@@ -419,7 +490,7 @@ func (s *DPPRepositoryService) ReadDataElement(ctx context.Context, dppID string
 	if err != nil {
 		return mapPersistenceError(err, http.StatusNotFound), nil
 	}
-	body, err := elementResponse(element, normalizeRepresentation(representation))
+	body, err := elementResponse(element, normalizeRepresentation(representation), elementIDPath)
 	if err != nil {
 		return errorResponse(http.StatusInternalServerError, err), nil
 	}
@@ -831,6 +902,7 @@ func (s *DPPRepositoryService) buildSubmodels(header dppHeader, sections map[str
 		if err != nil {
 			return nil, nil, err
 		}
+		setNewDPPSubmodelAdministration(submodel, header.LastUpdate)
 		submodels = append(submodels, submodel)
 		refs = append(refs, submodelReference(submodel.ID()))
 	}
@@ -903,40 +975,42 @@ func (s *DPPRepositoryService) updatedMetadata(ctx context.Context, dppID string
 	if err != nil {
 		return nil, fmt.Errorf("DPP-TOUCHMETA-GET get metadata: %w", err)
 	}
+	header, err := composeHeader(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("DPP-TOUCHMETA-COMPOSE compose current metadata: %w", err)
+	}
+	updatedAt, err := nextDPPUpdateTimestamp(time.Now().UTC(), header, []types.ISubmodel{metadata})
+	if err != nil {
+		return nil, fmt.Errorf("DPP-TOUCHMETA-TIMESTAMP determine next update timestamp: %w", err)
+	}
 	for _, element := range metadata.SubmodelElements() {
 		if element.IDShort() != nil && *element.IDShort() == headerLastUpdate {
-			value := time.Now().UTC().Format(time.RFC3339Nano)
+			value := updatedAt.Format(time.RFC3339Nano)
 			if property, ok := element.(*types.Property); ok {
 				property.SetValue(&value)
 			}
 		}
 	}
+	metadata.SetAdministration(updatedDPPAdministration(metadata, updatedAt))
 	return metadata, nil
 }
 
-func elementResponse(element types.ISubmodelElement, representation Representation) (any, error) {
+func elementResponse(element types.ISubmodelElement, representation Representation, elementIDPath string) (any, error) {
 	if representation == REPRESENTATION_FULL {
 		response, err := dppElementFromAAS(element)
 		if err != nil {
 			return nil, fmt.Errorf("DPP-ELEM-FULL convert element to DPP expanded representation: %w", err)
 		}
+		if response["elementId"] == "" {
+			parsed, err := parseDPPJSONElementPath(elementIDPath)
+			if err != nil {
+				return nil, err
+			}
+			response["elementId"] = parsed.elementID
+		}
 		return response, nil
 	}
-	idShort := element.IDShort()
-	if idShort == nil || *idShort == "" {
-		return nil, fmt.Errorf("DPP-ELEM-COMPRESSED element has no idShort")
-	}
-	submodel := types.NewSubmodel("dpp-element-response")
-	submodel.SetSubmodelElements([]types.ISubmodelElement{element})
-	content, err := compressedContent(submodel)
-	if err != nil {
-		return nil, err
-	}
-	object, ok := content.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("DPP-ELEM-COMPRESSED compressed element response is not an object")
-	}
-	return object[*idShort], nil
+	return compressedElementValue(element)
 }
 
 func idShortOrID(submodel types.ISubmodel) string {

--- a/pkg/dppapiservice/go/dpp_repository_service.go
+++ b/pkg/dppapiservice/go/dpp_repository_service.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/FriedJannik/aas-go-sdk/types"
 	aasrepositorydb "github.com/eclipse-basyx/basyx-go-components/internal/aasrepository/persistence"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	submodelrepositorydb "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence"
 )
 
@@ -398,19 +399,19 @@ func isDPPShell(shell types.IAssetAdministrationShell) bool {
 	return false
 }
 
-// ReadDataElement reads one DPP data element by content section and idShort path.
+// ReadDataElement reads one DPP data element by elementIdPath.
 //
 // Parameters:
 //   - ctx: Request context used for repository read calls
 //   - dppID: Identifier of the DPP that owns the element
-//   - elementPath: Content section and idShort path in <section>/<path> form
+//   - elementIDPath: RFC 9535 Normalized Path selecting a single DPP data element
 //   - representation: Requested compressed or full element representation
 //
 // Returns:
 //   - ImplResponse: HTTP-style response containing the DPP data element or mapped error payload
 //   - error: Unexpected service error, if one occurs outside normal response mapping
-func (s *DPPRepositoryService) ReadDataElement(ctx context.Context, dppID string, elementPath string, representation Representation) (ImplResponse, error) {
-	submodelID, idShortPath, err := s.resolveElementPath(ctx, dppID, elementPath)
+func (s *DPPRepositoryService) ReadDataElement(ctx context.Context, dppID string, elementIDPath string, representation Representation) (ImplResponse, error) {
+	submodelID, idShortPath, err := s.resolveElementPath(ctx, dppID, elementIDPath)
 	if err != nil {
 		return errorResponse(http.StatusBadRequest, err), nil
 	}
@@ -430,23 +431,23 @@ func (s *DPPRepositoryService) ReadDataElement(ctx context.Context, dppID string
 // Parameters:
 //   - ctx: Request context used for repository persistence calls
 //   - dppID: Identifier of the DPP that owns the element
-//   - elementPath: Content section and idShort path in <section>/<path> form
+//   - elementIDPath: RFC 9535 Normalized Path selecting a single DPP data element
 //   - data: Compressed JSON value used as the replacement element content
 //
 // Returns:
 //   - ImplResponse: HTTP-style response containing the updated DPP data element or mapped error payload
 //   - error: Unexpected service error, if one occurs outside normal response mapping
-func (s *DPPRepositoryService) UpdateDataElementFromJSON(ctx context.Context, dppID string, elementPath string, data []byte) (ImplResponse, error) {
+func (s *DPPRepositoryService) UpdateDataElementFromJSON(ctx context.Context, dppID string, elementIDPath string, data []byte) (ImplResponse, error) {
 	decoder := json.NewDecoder(strings.NewReader(string(data)))
 	decoder.UseNumber()
 	var value any
 	if err := decoder.Decode(&value); err != nil {
 		return errorResponse(http.StatusBadRequest, fmt.Errorf("DPP-UPDELEM-DECODE decode element body: %w", err)), nil
 	}
-	if err := rejectExpandedDataElementShape(elementPath, value); err != nil {
+	if err := rejectExpandedDataElementShape(elementIDPath, value); err != nil {
 		return errorResponse(http.StatusBadRequest, err), nil
 	}
-	submodelID, idShortPath, err := s.resolveElementPath(ctx, dppID, elementPath)
+	submodelID, idShortPath, err := s.resolveElementPath(ctx, dppID, elementIDPath)
 	if err != nil {
 		return errorResponse(http.StatusBadRequest, err), nil
 	}
@@ -478,10 +479,11 @@ func (s *DPPRepositoryService) UpdateDataElementFromJSON(ctx context.Context, dp
 		return mapPersistenceError(err, http.StatusConflict), nil
 	}
 
-	return s.ReadDataElement(ctx, dppID, elementPath, REPRESENTATION_COMPRESSED)
+	return s.ReadDataElement(ctx, dppID, elementIDPath, REPRESENTATION_COMPRESSED)
 }
 
 func preserveElementMetadata(existing types.ISubmodelElement, replacement types.ISubmodelElement) {
+	replacement.SetIDShort(existing.IDShort())
 	replacement.SetExtensions(mergeElementExtensions(existing.Extensions(), replacement.Extensions()))
 	replacement.SetCategory(existing.Category())
 	replacement.SetDisplayName(existing.DisplayName())
@@ -525,18 +527,18 @@ func mergeElementExtensions(existing []types.IExtension, replacement []types.IEx
 // Parameters:
 //   - ctx: Request context used for repository persistence calls
 //   - dppID: Identifier of the DPP that owns the element
-//   - elementPath: Content section and idShort path in <section>/<path> form
+//   - elementIDPath: RFC 9535 Normalized Path selecting a single DPP data element
 //   - dataElement: Generated DPP data element model used as replacement content
 //
 // Returns:
 //   - ImplResponse: HTTP-style response containing the updated DPP data element or mapped error payload
 //   - error: Unexpected service error, if one occurs outside normal response mapping
-func (s *DPPRepositoryService) UpdateDataElement(ctx context.Context, dppID string, elementPath string, dataElement DataElement) (ImplResponse, error) {
+func (s *DPPRepositoryService) UpdateDataElement(ctx context.Context, dppID string, elementIDPath string, dataElement DataElement) (ImplResponse, error) {
 	raw, err := json.Marshal(dataElement)
 	if err != nil {
 		return errorResponse(http.StatusBadRequest, fmt.Errorf("DPP-UPDELEM-MARSHAL marshal generated data element: %w", err)), nil
 	}
-	return s.UpdateDataElementFromJSON(ctx, dppID, elementPath, raw)
+	return s.UpdateDataElementFromJSON(ctx, dppID, elementIDPath, raw)
 }
 
 // CreateDPP creates a DPP from the generated OpenAPI model.
@@ -592,6 +594,10 @@ func composeResolvedDPP(resolved resolvedDPP, representation Representation) (dp
 	if err != nil {
 		return nil, err
 	}
+	specificationSet, err := contentSpecificationSetFromHeader(doc)
+	if err != nil {
+		return nil, err
+	}
 	contentSubmodels, err := selectedContentSubmodelsForHeader(doc, resolved.metadata.ID(), resolved.submodels)
 	if err != nil {
 		return nil, err
@@ -613,7 +619,7 @@ func composeResolvedDPP(resolved resolvedDPP, representation Representation) (dp
 		return doc, nil
 	}
 	for _, submodel := range contentSubmodels {
-		sectionName := lowerFirst(idShortOrID(submodel))
+		sectionName := compressedContentSectionName(submodel, specificationSet)
 		content, err := compressedContent(submodel)
 		if err != nil {
 			return nil, err
@@ -671,6 +677,96 @@ func selectedResolvedContentSubmodels(resolved resolvedDPP) ([]types.ISubmodel, 
 }
 
 func selectedContentSubmodelsForHeader(header dppDocument, metadataID string, submodels []types.ISubmodel) ([]types.ISubmodel, error) {
+	specificationSet, err := contentSpecificationSetFromHeader(header)
+	if err != nil {
+		return nil, err
+	}
+	selectedBySemanticID := make(map[string]types.ISubmodel)
+	selectedWithoutSemanticID := make([]types.ISubmodel, 0, len(submodels))
+	for _, submodel := range submodels {
+		if submodel.ID() == metadataID {
+			continue
+		}
+		semanticID := referenceToString(submodel.SemanticID())
+		if len(specificationSet) > 0 {
+			if _, included := specificationSet[semanticID]; !included {
+				continue
+			}
+		}
+		if semanticID == "" {
+			selectedWithoutSemanticID = append(selectedWithoutSemanticID, submodel)
+			continue
+		}
+		current, found := selectedBySemanticID[semanticID]
+		if !found {
+			selectedBySemanticID[semanticID] = submodel
+			continue
+		}
+		newer, err := isNewerDPPContentSubmodel(submodel, current)
+		if err != nil {
+			return nil, err
+		}
+		if newer {
+			selectedBySemanticID[semanticID] = submodel
+		}
+	}
+	selected := make([]types.ISubmodel, 0, len(selectedBySemanticID)+len(selectedWithoutSemanticID))
+	for _, submodel := range selectedBySemanticID {
+		selected = append(selected, submodel)
+	}
+	selected = append(selected, selectedWithoutSemanticID...)
+	sort.Slice(selected, func(left int, right int) bool {
+		return contentSubmodelSortKey(selected[left]) < contentSubmodelSortKey(selected[right])
+	})
+	return selected, nil
+}
+
+func isNewerDPPContentSubmodel(candidate types.ISubmodel, current types.ISubmodel) (bool, error) {
+	candidateUpdatedAt, err := dppContentSubmodelTimestamp(candidate)
+	if err != nil {
+		return false, err
+	}
+	currentUpdatedAt, err := dppContentSubmodelTimestamp(current)
+	if err != nil {
+		return false, err
+	}
+	if !candidateUpdatedAt.Equal(currentUpdatedAt) {
+		return candidateUpdatedAt.After(currentUpdatedAt), nil
+	}
+	return candidate.ID() > current.ID(), nil
+}
+
+func dppContentSubmodelTimestamp(submodel types.ISubmodel) (time.Time, error) {
+	administration := submodel.Administration()
+	if administration == nil {
+		return time.Time{}, nil
+	}
+	if updatedAt := administration.UpdatedAt(); updatedAt != nil && strings.TrimSpace(*updatedAt) != "" {
+		parsed, err := common.ParseISO8601DateTime(*updatedAt)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("DPP-FILTER-UPDATEDAT parse updatedAt for submodel %s: %w", submodel.ID(), err)
+		}
+		return parsed, nil
+	}
+	if createdAt := administration.CreatedAt(); createdAt != nil && strings.TrimSpace(*createdAt) != "" {
+		parsed, err := common.ParseISO8601DateTime(*createdAt)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("DPP-FILTER-CREATEDAT parse createdAt for submodel %s: %w", submodel.ID(), err)
+		}
+		return parsed, nil
+	}
+	return time.Time{}, nil
+}
+
+func contentSubmodelSortKey(submodel types.ISubmodel) string {
+	semanticID := referenceToString(submodel.SemanticID())
+	if semanticID != "" {
+		return semanticID
+	}
+	return submodel.ID()
+}
+
+func contentSpecificationSetFromHeader(header dppDocument) (map[string]struct{}, error) {
 	specificationIDs, err := contentSpecificationIDsFromHeader(header)
 	if err != nil {
 		return nil, err
@@ -679,20 +775,7 @@ func selectedContentSubmodelsForHeader(header dppDocument, metadataID string, su
 	for _, specificationID := range specificationIDs {
 		specificationSet[specificationID] = struct{}{}
 	}
-	selected := make([]types.ISubmodel, 0, len(submodels))
-	for _, submodel := range submodels {
-		if submodel.ID() == metadataID {
-			continue
-		}
-		if len(specificationSet) == 0 {
-			selected = append(selected, submodel)
-			continue
-		}
-		if _, included := specificationSet[referenceToString(submodel.SemanticID())]; included {
-			selected = append(selected, submodel)
-		}
-	}
-	return selected, nil
+	return specificationSet, nil
 }
 
 func contentSpecificationIDsFromHeader(header dppDocument) ([]string, error) {
@@ -754,45 +837,65 @@ func (s *DPPRepositoryService) buildSubmodels(header dppHeader, sections map[str
 	return submodels, refs, nil
 }
 
-func (s *DPPRepositoryService) resolveElementPath(ctx context.Context, dppID string, elementPath string) (string, string, error) {
-	sectionName, idShortPath, err := splitDPPElementPath(elementPath)
-	if err != nil {
+func (s *DPPRepositoryService) resolveElementPath(ctx context.Context, dppID string, elementIDPath string) (string, string, error) {
+	if err := validateDPPElementPath(elementIDPath); err != nil {
 		return "", "", err
 	}
 	resolved, err := s.resolveSubmodels(ctx, dppID, time.Time{})
 	if err != nil {
 		return "", "", err
 	}
-	return resolveDPPElementPathParts(resolved, sectionName, idShortPath)
+	return resolveDPPElementPathParts(resolved, elementIDPath)
 }
 
-func resolveDPPElementPath(resolved resolvedDPP, elementPath string) (string, string, error) {
-	sectionName, idShortPath, err := splitDPPElementPath(elementPath)
+func resolveDPPElementPath(resolved resolvedDPP, elementIDPath string) (string, string, error) {
+	if err := validateDPPElementPath(elementIDPath); err != nil {
+		return "", "", err
+	}
+	return resolveDPPElementPathParts(resolved, elementIDPath)
+}
+
+func validateDPPElementPath(elementIDPath string) error {
+	_, err := parseDPPJSONElementPath(elementIDPath)
+	return err
+}
+
+func resolveDPPElementPathParts(resolved resolvedDPP, elementIDPath string) (string, string, error) {
+	header, err := composeHeader(resolved.metadata)
 	if err != nil {
 		return "", "", err
 	}
-	return resolveDPPElementPathParts(resolved, sectionName, idShortPath)
-}
-
-func splitDPPElementPath(elementPath string) (string, string, error) {
-	parts := strings.SplitN(elementPath, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("DPP-ELEMPATH-INVALID elementPath must be <contentSection>/<idShort.path>")
+	specificationSet, err := contentSpecificationSetFromHeader(header)
+	if err != nil {
+		return "", "", err
 	}
-	return parts[0], parts[1], nil
+	contentSubmodels, err := selectedContentSubmodelsForHeader(header, resolved.metadata.ID(), resolved.submodels)
+	if err != nil {
+		return "", "", err
+	}
+	return resolveDPPJSONElementPathParts(contentSubmodels, specificationSet, elementIDPath)
 }
 
-func resolveDPPElementPathParts(resolved resolvedDPP, sectionName string, idShortPath string) (string, string, error) {
-	contentSubmodels, err := selectedResolvedContentSubmodels(resolved)
+func resolveDPPJSONElementPathParts(contentSubmodels []types.ISubmodel, specificationSet map[string]struct{}, elementIDPath string) (string, string, error) {
+	parsed, err := parseDPPJSONElementPath(elementIDPath)
 	if err != nil {
 		return "", "", err
 	}
 	for _, submodel := range contentSubmodels {
-		if lowerFirst(idShortOrID(submodel)) == sectionName {
-			return submodel.ID(), idShortPath, nil
+		if parsed.sectionName == compressedContentSectionName(submodel, specificationSet) {
+			return submodel.ID(), parsed.idShortPath, nil
 		}
 	}
-	return "", "", fmt.Errorf("DPP-ELEMPATH-NOTFOUND content section %s not found", sectionName)
+	return "", "", fmt.Errorf("DPP-ELEMPATH-NOTFOUND content section %s not found", parsed.sectionName)
+}
+
+func compressedContentSectionName(submodel types.ISubmodel, specificationSet map[string]struct{}) string {
+	if semanticID := referenceToString(submodel.SemanticID()); semanticID != "" {
+		if _, selected := specificationSet[semanticID]; selected {
+			return semanticID
+		}
+	}
+	return lowerFirst(idShortOrID(submodel))
 }
 
 func (s *DPPRepositoryService) updatedMetadata(ctx context.Context, dppID string) (types.ISubmodel, error) {

--- a/pkg/dppapiservice/go/dpp_repository_service_test.go
+++ b/pkg/dppapiservice/go/dpp_repository_service_test.go
@@ -1,0 +1,59 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+// Author: Aaron Zielstorff ( Fraunhofer IESE )
+
+package dppapi
+
+import (
+	"testing"
+
+	"github.com/FriedJannik/aas-go-sdk/types"
+)
+
+func TestElementResponseSupportsScalarSubmodelElementListItems(t *testing.T) {
+	item := scalarProperty("", "A", types.DataTypeDefXSDString)
+	item.SetIDShort(nil)
+	elementIDPath := "$['technicalData']['energyClasses'][0]"
+
+	compressed, err := elementResponse(item, REPRESENTATION_COMPRESSED, elementIDPath)
+	if err != nil {
+		t.Fatalf("elementResponse() compressed error = %v", err)
+	}
+	if compressed != "A" {
+		t.Fatalf("elementResponse() compressed = %#v, want A", compressed)
+	}
+
+	full, err := elementResponse(item, REPRESENTATION_FULL, elementIDPath)
+	if err != nil {
+		t.Fatalf("elementResponse() full error = %v", err)
+	}
+	fullElement, ok := full.(map[string]any)
+	if !ok {
+		t.Fatalf("elementResponse() full = %#v, want object", full)
+	}
+	if fullElement["elementId"] != "energyClasses0" {
+		t.Fatalf("elementResponse() full elementId = %#v, want energyClasses0", fullElement["elementId"])
+	}
+}

--- a/pkg/dppapiservice/go/dpp_request.go
+++ b/pkg/dppapiservice/go/dpp_request.go
@@ -63,18 +63,14 @@ func pathParam(req *http.Request, name string) string {
 	return decodePathParam(chi.URLParam(req, name))
 }
 
-func elementPathParam(req *http.Request) string {
+func elementIdPathParam(req *http.Request) string {
 	return strings.TrimPrefix(decodePathParam(chi.URLParam(req, "*")), "/")
 }
 
 func decodePathParam(value string) string {
-	decoded := value
-	for range 3 {
-		next, err := url.PathUnescape(decoded)
-		if err != nil || next == decoded {
-			return decoded
-		}
-		decoded = next
+	decoded, err := url.PathUnescape(value)
+	if err != nil {
+		return value
 	}
 	return decoded
 }

--- a/pkg/dppapiservice/go/dpp_request.go
+++ b/pkg/dppapiservice/go/dpp_request.go
@@ -60,14 +60,17 @@ func isRequestBodyTooLarge(err error) bool {
 }
 
 func pathParam(req *http.Request, name string) string {
-	return decodePathParam(chi.URLParam(req, name))
+	return decodePathParam(req, chi.URLParam(req, name))
 }
 
 func elementIdPathParam(req *http.Request) string {
-	return strings.TrimPrefix(decodePathParam(chi.URLParam(req, "*")), "/")
+	return strings.TrimPrefix(decodePathParam(req, chi.URLParam(req, "*")), "/")
 }
 
-func decodePathParam(value string) string {
+func decodePathParam(req *http.Request, value string) string {
+	if req.URL.RawPath == "" {
+		return value
+	}
 	decoded, err := url.PathUnescape(value)
 	if err != nil {
 		return value

--- a/pkg/dppapiservice/go/dpp_request_test.go
+++ b/pkg/dppapiservice/go/dpp_request_test.go
@@ -1,0 +1,67 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+// Author: Aaron Zielstorff ( Fraunhofer IESE )
+
+package dppapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestPathParamDecodesCanonicalEscapingExactlyOnce(t *testing.T) {
+	req := requestWithChiParam("https://example.org/v1/dpps/literal%252Fid", "dppId", "literal%2Fid")
+
+	if got := pathParam(req, "dppId"); got != "literal%2Fid" {
+		t.Fatalf("pathParam() = %q, want literal %%2F to remain part of the identifier", got)
+	}
+}
+
+func TestPathParamDecodesEscapedSlashExactlyOnce(t *testing.T) {
+	req := requestWithChiParam("https://example.org/v1/dpps/literal%2Fid", "dppId", "literal%2Fid")
+
+	if got := pathParam(req, "dppId"); got != "literal/id" {
+		t.Fatalf("pathParam() = %q, want decoded slash", got)
+	}
+}
+
+func TestElementIDPathParamPreservesCanonicalPercentEscape(t *testing.T) {
+	req := requestWithChiParam("https://example.org/v1/dpps/dpp/elements/%2524", "*", "/%24")
+
+	if got := elementIdPathParam(req); got != "%24" {
+		t.Fatalf("elementIdPathParam() = %q, want literal %%24", got)
+	}
+}
+
+func requestWithChiParam(target string, name string, value string) *http.Request {
+	req := httptest.NewRequest("GET", target, nil)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add(name, value)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+}

--- a/pkg/dppapiservice/go/dpp_router.go
+++ b/pkg/dppapiservice/go/dpp_router.go
@@ -206,26 +206,26 @@ func (r *DPPRepositoryRouter) ReadDPPIdsByProductIds(w http.ResponseWriter, req 
 	r.write(w, response, err)
 }
 
-// ReadDataElement handles GET /v1/dpps/{dppId}/elements/{elementPath}.
+// ReadDataElement handles GET /v1/dpps/{dppId}/elements/{elementIdPath}.
 //
 // Parameters:
 //   - w: HTTP response writer used to encode the element response
-//   - req: HTTP request containing dppId, elementPath, and representation values
+//   - req: HTTP request containing dppId, elementIdPath, and representation values
 func (r *DPPRepositoryRouter) ReadDataElement(w http.ResponseWriter, req *http.Request) {
 	representation, invalid := queryRepresentation(req)
 	if invalid != nil {
 		r.write(w, *invalid, nil)
 		return
 	}
-	response, err := r.service.ReadDataElement(req.Context(), pathParam(req, "dppId"), elementPathParam(req), representation)
+	response, err := r.service.ReadDataElement(req.Context(), pathParam(req, "dppId"), elementIdPathParam(req), representation)
 	r.write(w, response, err)
 }
 
-// UpdateDataElement handles PATCH /v1/dpps/{dppId}/elements/{elementPath}.
+// UpdateDataElement handles PATCH /v1/dpps/{dppId}/elements/{elementIdPath}.
 //
 // Parameters:
 //   - w: HTTP response writer used to encode the element response
-//   - req: HTTP request containing dppId, elementPath, and replacement element body
+//   - req: HTTP request containing dppId, elementIdPath, and replacement element body
 func (r *DPPRepositoryRouter) UpdateDataElement(w http.ResponseWriter, req *http.Request) {
 	if invalid := queryCompressedWriteRepresentation(req, "UPDELEM"); invalid != nil {
 		r.write(w, *invalid, nil)
@@ -236,7 +236,7 @@ func (r *DPPRepositoryRouter) UpdateDataElement(w http.ResponseWriter, req *http
 		r.write(w, requestBodyErrorResponse("UPDELEM", err), nil)
 		return
 	}
-	response, err := r.service.UpdateDataElementFromJSON(req.Context(), pathParam(req, "dppId"), elementPathParam(req), body)
+	response, err := r.service.UpdateDataElementFromJSON(req.Context(), pathParam(req, "dppId"), elementIdPathParam(req), body)
 	r.write(w, response, err)
 }
 

--- a/pkg/dppapiservice/go/dpp_semantics.go
+++ b/pkg/dppapiservice/go/dpp_semantics.go
@@ -57,6 +57,10 @@ func semanticIDsForSections(sections map[string]any, contentSpecificationIDs []s
 		contentSpecificationSet[id] = struct{}{}
 	}
 	for sectionName, section := range sections {
+		if _, ok := contentSpecificationSet[sectionName]; ok {
+			semanticIDs[sectionName] = sectionName
+			continue
+		}
 		semanticID, hasExplicitMapping, err := explicitSemanticIDForSection(sectionName, section)
 		if err != nil {
 			return nil, err

--- a/pkg/dppapiservice/go/dpp_semantics_test.go
+++ b/pkg/dppapiservice/go/dpp_semantics_test.go
@@ -16,6 +16,8 @@ package dppapi
 import (
 	"strings"
 	"testing"
+
+	"github.com/FriedJannik/aas-go-sdk/verification"
 )
 
 func TestSemanticIDsForSectionsDoesNotInferFromSectionNames(t *testing.T) {
@@ -64,6 +66,65 @@ func TestSemanticIDsForSectionsUsesExpandedDictionaryReference(t *testing.T) {
 	}
 	if semanticIDs["technicalData"] != "urn:example:semantic:technical-data" {
 		t.Fatalf("technicalData semantic ID = %q", semanticIDs["technicalData"])
+	}
+}
+
+func TestSemanticIDsForSectionsUsesContentSpecificationIDSectionNames(t *testing.T) {
+	carbonFootprintSemanticID := "https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0"
+	handoverDocumentationSemanticID := "https://admin-shell-io/idta/digitalproductpassport/HandoverDocumentation/2"
+	sections := map[string]any{
+		carbonFootprintSemanticID: map[string]any{
+			"ProductCarbonFootprints": []any{
+				map[string]any{"PcfCo2eq": "17.2"},
+			},
+		},
+		handoverDocumentationSemanticID: map[string]any{
+			"Documents": []any{
+				map[string]any{"Version": "V1.2"},
+			},
+		},
+	}
+
+	semanticIDs, err := semanticIDsForSections(sections, []string{
+		carbonFootprintSemanticID,
+		handoverDocumentationSemanticID,
+	})
+	if err != nil {
+		t.Fatalf("semanticIDsForSections() error = %v", err)
+	}
+	if semanticIDs[carbonFootprintSemanticID] != carbonFootprintSemanticID {
+		t.Fatalf("carbonFootprint semantic ID = %q", semanticIDs[carbonFootprintSemanticID])
+	}
+	if semanticIDs[handoverDocumentationSemanticID] != handoverDocumentationSemanticID {
+		t.Fatalf("handoverDocumentation semantic ID = %q", semanticIDs[handoverDocumentationSemanticID])
+	}
+}
+
+func TestBuildContentSubmodelUsesSafeIDShortForContentSpecificationIDSectionName(t *testing.T) {
+	semanticID := "https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/1/0"
+
+	submodel, err := buildContentSubmodel("dpp-1", semanticID, semanticID, map[string]any{
+		"PcfCo2eq": "17.2",
+	})
+	if err != nil {
+		t.Fatalf("buildContentSubmodel() error = %v", err)
+	}
+	if submodel.IDShort() == nil {
+		t.Fatal("submodel idShort = nil")
+	}
+	if *submodel.IDShort() != "CarbonFootprint" {
+		t.Fatalf("submodel idShort = %q, want CarbonFootprint", *submodel.IDShort())
+	}
+	if referenceToString(submodel.SemanticID()) != semanticID {
+		t.Fatalf("submodel semantic ID = %q, want %q", referenceToString(submodel.SemanticID()), semanticID)
+	}
+	verificationErrors := make([]string, 0)
+	verification.VerifySubmodel(submodel, func(err *verification.VerificationError) bool {
+		verificationErrors = append(verificationErrors, err.Error())
+		return false
+	})
+	if len(verificationErrors) != 0 {
+		t.Fatalf("VerifySubmodel() errors = %#v", verificationErrors)
 	}
 }
 

--- a/pkg/dppapiservice/go/dpp_serializer.go
+++ b/pkg/dppapiservice/go/dpp_serializer.go
@@ -69,6 +69,24 @@ func compressedContent(submodel types.ISubmodel) (any, error) {
 	return content, nil
 }
 
+func compressedElementValue(element types.ISubmodelElement) (any, error) {
+	valueOnly, err := basyxmodel.SubmodelElementToValueOnly(element)
+	if err != nil {
+		return nil, fmt.Errorf("DPP-ELEM-COMPRESSED convert element value-only: %w", err)
+	}
+	raw, err := json.Marshal(valueOnly)
+	if err != nil {
+		return nil, fmt.Errorf("DPP-ELEM-COMPRESSED-MARSHAL marshal element value-only: %w", err)
+	}
+	var content any
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return nil, fmt.Errorf("DPP-ELEM-COMPRESSED-UNMARSHAL unmarshal element value-only: %w", err)
+	}
+	normalizeValueOnly(content)
+	enrichCompressedElementValue(content, element)
+	return content, nil
+}
+
 func fullContent(submodel types.ISubmodel) (any, error) {
 	content, err := dppCollectionFromSubmodel(submodel)
 	if err != nil {

--- a/pkg/dppapiservice/go/model_data_element.go
+++ b/pkg/dppapiservice/go/model_data_element.go
@@ -38,12 +38,12 @@ package dppapi
 
 type DataElement struct {
 
-	// DPP element identifier mapped to AAS Referable/idShort.
+	// DPP element identifier.
 	ElementId string `json:"elementId"`
 
 	ObjectType string `json:"objectType"`
 
-	// DPP dictionary reference mapped to AAS semanticId.
+	// DPP dictionary reference.
 	DictionaryReference string `json:"dictionaryReference,omitempty"`
 
 	ValueDataType XsdValueDataType `json:"valueDataType,omitempty"`

--- a/pkg/dppapiservice/go/model_data_element_collection.go
+++ b/pkg/dppapiservice/go/model_data_element_collection.go
@@ -38,12 +38,12 @@ package dppapi
 
 type DataElementCollection struct {
 
-	// DPP element identifier mapped to AAS Referable/idShort.
+	// DPP element identifier.
 	ElementId string `json:"elementId"`
 
 	ObjectType string `json:"objectType"`
 
-	// DPP dictionary reference mapped to AAS semanticId.
+	// DPP dictionary reference.
 	DictionaryReference string `json:"dictionaryReference,omitempty"`
 
 	Elements []DataElement `json:"elements"`

--- a/pkg/dppapiservice/go/model_digital_product_passport.go
+++ b/pkg/dppapiservice/go/model_digital_product_passport.go
@@ -40,13 +40,13 @@ import (
 	"time"
 )
 
-// DigitalProductPassport - A single DPP JSON document composed from the DppMetadata header and DPP content.
+// DigitalProductPassport - A single DPP JSON document composed from DPP header fields and content sections.
 type DigitalProductPassport struct {
 
-	// DPP identifier. Similar to, but not necessarily identical to, the AAS id.
+	// Digital Product Passport identifier.
 	DigitalProductPassportId string `json:"digitalProductPassportId"`
 
-	// Product identifier corresponding to the AAS AssetInformation globalAssetId.
+	// Unique product identifier associated with the DPP.
 	UniqueProductIdentifier string `json:"uniqueProductIdentifier"`
 
 	Granularity Granularity `json:"granularity"`
@@ -55,17 +55,17 @@ type DigitalProductPassport struct {
 
 	DppStatus string `json:"dppStatus"`
 
-	// Timestamp corresponding to AAS AdministrativeInformation updatedAt.
+	// Timestamp of the latest DPP update.
 	LastUpdate time.Time `json:"lastUpdate"`
 
 	// Economic operator identifier as specified by EN 18219.
 	EconomicOperatorId string `json:"economicOperatorId"`
 
 	// Facility identifier as specified by EN 18219.
-	FacilityId string `json:"facilityId"`
+	FacilityId string `json:"facilityId,omitempty"`
 
-	// Semantic identifiers of contributing content Submodels. The DPP document shall contain matching top-level content sections.
-	ContentSpecificationIds []string `json:"contentSpecificationIds"`
+	// Identifiers of content specifications contributing DPP content sections.
+	ContentSpecificationIds []string `json:"contentSpecificationIds,omitempty"`
 
 	// Expanded read-only DPP DataElements returned when representation=full.
 	Elements []DataElement `json:"elements,omitempty"`
@@ -81,8 +81,6 @@ func AssertDigitalProductPassportRequired(obj DigitalProductPassport) error {
 		"dppStatus":                obj.DppStatus,
 		"lastUpdate":               obj.LastUpdate,
 		"economicOperatorId":       obj.EconomicOperatorId,
-		"facilityId":               obj.FacilityId,
-		"contentSpecificationIds":  obj.ContentSpecificationIds,
 	}
 	for name, el := range elements {
 		if isZero := IsZeroValue(el); isZero {

--- a/pkg/dppapiservice/go/model_granularity.go
+++ b/pkg/dppapiservice/go/model_granularity.go
@@ -40,7 +40,7 @@ import (
 	"fmt"
 )
 
-// Granularity : EN 18223 DPP granularity value mapped to AAS AssetKind.
+// Granularity : EN 18223 DPP granularity value.
 type Granularity string
 
 // List of Granularity

--- a/pkg/dppapiservice/go/model_multi_language_data_element.go
+++ b/pkg/dppapiservice/go/model_multi_language_data_element.go
@@ -38,12 +38,12 @@ package dppapi
 
 type MultiLanguageDataElement struct {
 
-	// DPP element identifier mapped to AAS Referable/idShort.
+	// DPP element identifier.
 	ElementId string `json:"elementId"`
 
 	ObjectType string `json:"objectType"`
 
-	// DPP dictionary reference mapped to AAS semanticId.
+	// DPP dictionary reference.
 	DictionaryReference string `json:"dictionaryReference,omitempty"`
 
 	Value []LangString `json:"value"`

--- a/pkg/dppapiservice/go/model_multi_valued_data_element.go
+++ b/pkg/dppapiservice/go/model_multi_valued_data_element.go
@@ -38,12 +38,12 @@ package dppapi
 
 type MultiValuedDataElement struct {
 
-	// DPP element identifier mapped to AAS Referable/idShort.
+	// DPP element identifier.
 	ElementId string `json:"elementId"`
 
 	ObjectType string `json:"objectType"`
 
-	// DPP dictionary reference mapped to AAS semanticId.
+	// DPP dictionary reference.
 	DictionaryReference string `json:"dictionaryReference,omitempty"`
 
 	ValueDataType XsdValueDataType `json:"valueDataType,omitempty"`

--- a/pkg/dppapiservice/go/model_related_resource.go
+++ b/pkg/dppapiservice/go/model_related_resource.go
@@ -38,12 +38,12 @@ package dppapi
 
 type RelatedResource struct {
 
-	// DPP element identifier mapped to AAS Referable/idShort.
+	// DPP element identifier.
 	ElementId string `json:"elementId"`
 
 	ObjectType string `json:"objectType"`
 
-	// DPP dictionary reference mapped to AAS semanticId.
+	// DPP dictionary reference.
 	DictionaryReference string `json:"dictionaryReference,omitempty"`
 
 	ResourceTitle string `json:"resourceTitle,omitempty"`

--- a/pkg/dppapiservice/go/model_single_valued_data_element.go
+++ b/pkg/dppapiservice/go/model_single_valued_data_element.go
@@ -38,12 +38,12 @@ package dppapi
 
 type SingleValuedDataElement struct {
 
-	// DPP element identifier mapped to AAS Referable/idShort.
+	// DPP element identifier.
 	ElementId string `json:"elementId"`
 
 	ObjectType string `json:"objectType"`
 
-	// DPP dictionary reference mapped to AAS semanticId.
+	// DPP dictionary reference.
 	DictionaryReference string `json:"dictionaryReference,omitempty"`
 
 	ValueDataType XsdValueDataType `json:"valueDataType"`


### PR DESCRIPTION
## Description of Changes

This PR finalizes the DPP API service against the current CEN/CLC JTC 24 DPP API and metamodel drafts, using IDTA-02099-1 as additional guidance for the DppMetadata AAS mapping. It also improves dependency automation and example coverage.

### DPP API

- Align the OpenAPI definition and generated models with DPP terminology and representations.
- Support compressed and full DPP reads, lifecycle operations, merge-patch updates, historical reads, and fine-grained data-element access.
- Use RFC 9535 Normalized Paths for uniquely addressing DPP data elements.
- Correctly handle percent-encoded DPP identifiers and element paths without double-decoding.
- Support indexed scalar SubmodelElementList items in read and update operations.
- Map DPP content specifications to AAS Submodels using semantic IDs.
- Select the newest Submodel when multiple Submodels share the same semantic ID.
- Generate IDTA-02099-aligned DppMetadata elements, semantic IDs, value types, list metadata, and administrative timestamps.
- Preserve existing administrative metadata while assigning monotonic update timestamps.
- Expand request validation and error handling for invalid DPP documents and representations.

### Security

- Keep the decoded request path for ABAC policy evaluation while using the escaped path for Chi route discovery.
- Support percent-encoded identifiers and bracketed element paths without changing authorization semantics.
- Add regression coverage for DPP routes, encoded identifiers, fine-grained updates, and secured lifecycle operations.

### Examples and automation

- Refresh the DPP sample document, Postman collection, and documentation.
- Add the CatenaXample to the example smoke workflow and use published SNAPSHOT images by default.
- Correct Dependabot grouping for Docker base-image updates.
- Stabilize affected DPP and marker-access integration workflows.

## Related Issue

No linked issue.

## BaSyx Configuration for Testing

No additional manual configuration is required.

The DPP integration tests contain self-contained Docker Compose environments for:

- lifecycle and history testing;
- secured OIDC and ABAC testing.

## AAS Files Used for Testing

No external AAS files are required. Test DPPs and their corresponding AAS/Submodel structures are generated by the integration tests.

## Validation

The changes were validated with:

- DPP lifecycle and secured Docker integration tests;
- DPP API unit and validation tests;
- common security tests;
- example smoke tests;
- `go vet ./...`;
- `golangci-lint run ./...`;
- repository-wide `gofmt` and diff checks.

## Additional Information

The JTC 24 API and metamodel drafts were treated as the primary source of truth, followed by IDTA-02099-1 for the DppMetadata Submodel mapping.

Clients must provide `elementIdPath` as an RFC 9535 Normalized Path and percent-encode path parameters once when placing them in a URL.