### PR TITLE
Protect verification endpoints with API security

### DIFF
--- a/cmd/aasenvironmentservice/main.go
+++ b/cmd/aasenvironmentservice/main.go
@@ -107,9 +107,6 @@ func runServer(ctx context.Context, configPath string) error {
 	r := chi.NewRouter()
 	r.Use(common.ConfigMiddleware(cfg))
 	common.AddCors(r, cfg)
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
 
 	preconfigurationCompleted := atomic.Bool{}
 	common.AddHealthEndpointWithProbe(r, cfg, func() (bool, string) {
@@ -234,10 +231,14 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 	versioningGuard := history.NewMutationCoverageGuard(apiRouter)
+	versioningGuard.Exempt(http.MethodPost, "/verify")
 	apiRouter.Use(versioningGuard.Middleware)
 	apiRouter.Use(history.AuditContextMiddleware(cfg))
 	abacpolicy.ExemptManagementMutationRoutesIfEnabled(cfg, versioningGuard, "aasenvironmentservice")
 	abacpolicy.RegisterManagementRoutesIfEnabled(cfg, apiRouter, abacRepo, "aasenvironmentservice")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	for operation, rt := range aasRegistryCtrl.Routes() {
 		versioningGuard.ClassifyRoute(operation, rt.Method, rt.Pattern)

--- a/cmd/aasregistryservice/main.go
+++ b/cmd/aasregistryservice/main.go
@@ -79,9 +79,6 @@ func runServer(ctx context.Context, configPath string) error {
 
 	common.AddCors(r, cfg)
 	common.AddHealthEndpoint(r, cfg)
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
 
 	// Add Swagger UI
 	if err := common.AddSwaggerUIFromFS(r, openapiSpec, "openapi.yaml", "AAS Registry Service API", "/swagger", "/api-docs/openapi.yaml", cfg); err != nil {
@@ -143,10 +140,14 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 	versioningGuard := history.NewMutationCoverageGuard(apiRouter)
+	versioningGuard.Exempt(http.MethodPost, "/verify")
 	apiRouter.Use(versioningGuard.Middleware)
 	apiRouter.Use(history.AuditContextMiddleware(cfg))
 	abacpolicy.ExemptManagementMutationRoutesIfEnabled(cfg, versioningGuard, "aasregistryservice")
 	abacpolicy.RegisterManagementRoutesIfEnabled(cfg, apiRouter, abacRepo, "aasregistryservice")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	// Register all registry routes (protected)
 	for operation, rt := range smCtrl.Routes() {

--- a/cmd/aasrepositoryservice/main.go
+++ b/cmd/aasrepositoryservice/main.go
@@ -32,6 +32,7 @@ import (
 	"embed"
 	"flag"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -93,10 +94,6 @@ func runServer(ctx context.Context, configPath string) error {
 	common.AddCors(r, cfg)
 
 	common.AddHealthEndpoint(r, cfg)
-
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
 
 	if err := common.AddSwaggerUIFromFS(r, openapiSpec, "openapi.yaml", "Asset Administration Shell Repository API", "/swagger", "/api-docs/openapi.yaml", cfg); err != nil {
 		log.Printf("Warning: failed to load OpenAPI spec for Swagger UI: %v", err)
@@ -190,10 +187,14 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 	versioningGuard := history.NewMutationCoverageGuard(apiRouter)
+	versioningGuard.Exempt(http.MethodPost, "/verify")
 	apiRouter.Use(versioningGuard.Middleware)
 	apiRouter.Use(history.AuditContextMiddleware(cfg))
 	abacpolicy.ExemptManagementMutationRoutesIfEnabled(cfg, versioningGuard, "aasrepositoryservice")
 	abacpolicy.RegisterManagementRoutesIfEnabled(cfg, apiRouter, abacRepo, "aasrepositoryservice")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	for operation, rt := range aasCtrl.Routes() {
 		versioningGuard.ClassifyRoute(operation, rt.Method, rt.Pattern)

--- a/cmd/aasxfileserverservice/main.go
+++ b/cmd/aasxfileserverservice/main.go
@@ -65,10 +65,6 @@ func runServer(ctx context.Context, configPath string) error {
 
 	common.AddHealthEndpoint(r, cfg)
 
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
-
 	if err := common.AddSwaggerUIFromFS(r, openapiSpec, "openapi.yaml", "AASX File Server API", "/swagger", "/api-docs/openapi.yaml", cfg); err != nil {
 		log.Printf("Warning: failed to load OpenAPI spec for Swagger UI: %v", err)
 	}
@@ -118,6 +114,9 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 	abacpolicy.RegisterManagementRoutesIfEnabled(cfg, apiRouter, abacRepo, "aasxfileserverservice")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	for _, rt := range aasxCtrl.Routes() {
 		apiRouter.Method(rt.Method, rt.Pattern, rt.HandlerFunc)

--- a/cmd/companylookupservice/main.go
+++ b/cmd/companylookupservice/main.go
@@ -62,9 +62,6 @@ func runServer(ctx context.Context, configPath string) error {
 
 	// --- Health Endpoint (public) ---
 	common.AddHealthEndpoint(r, cfg)
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
 
 	// Add Swagger UI
 	if err := common.AddSwaggerUIFromFS(r, openapiSpec, "openapi.yaml", "Company Lookup Service API", "/swagger", "/api-docs/openapi.yaml", cfg); err != nil {
@@ -106,6 +103,9 @@ func runServer(ctx context.Context, configPath string) error {
 	// === Protected API Subrouter ===
 	apiRouter := chi.NewRouter()
 	common.ConfigureAPIRouter(apiRouter, "CompanyLookupService")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	// Register all company lookup routes
 	for _, rt := range companyLookupCtrl.Routes() {

--- a/cmd/conceptdescriptionrepositoryservice/main.go
+++ b/cmd/conceptdescriptionrepositoryservice/main.go
@@ -31,6 +31,7 @@ import (
 	"embed"
 	"flag"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -78,9 +79,6 @@ func runServer(ctx context.Context, configPath string) error {
 
 	common.AddCors(r, cfg)
 	common.AddHealthEndpoint(r, cfg)
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
 
 	// Add Swagger UI
 	if err := common.AddSwaggerUIFromFS(r, openapiSpec, "openapi.yaml", "Concept Description Repository API", "/swagger", "/api-docs/openapi.yaml", cfg); err != nil {
@@ -137,10 +135,14 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 	versioningGuard := history.NewMutationCoverageGuard(apiRouter)
+	versioningGuard.Exempt(http.MethodPost, "/verify")
 	apiRouter.Use(versioningGuard.Middleware)
 	apiRouter.Use(history.AuditContextMiddleware(cfg))
 	abacpolicy.ExemptManagementMutationRoutesIfEnabled(cfg, versioningGuard, "conceptdescriptionrepositoryservice")
 	abacpolicy.RegisterManagementRoutesIfEnabled(cfg, apiRouter, abacRepo, "conceptdescriptionrepositoryservice")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	for operation, rt := range cdCtrl.Routes() {
 		versioningGuard.ClassifyRoute(operation, rt.Method, rt.Pattern)

--- a/cmd/digitaltwinregistryservice/main.go
+++ b/cmd/digitaltwinregistryservice/main.go
@@ -85,9 +85,6 @@ func runServer(ctx context.Context, configPath string) error {
 	r.Use(common.ConfigMiddleware(cfg))
 	common.AddCors(r, cfg)
 	common.AddHealthEndpoint(r, cfg)
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
 
 	// Add Swagger UI
 	if err := common.AddSwaggerUIFromFS(r, openapiSpec, "openapi.yaml", "Digital Twin Registry API", "/swagger", "/api-docs/openapi.yaml", cfg); err != nil {
@@ -167,10 +164,14 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 	versioningGuard := history.NewMutationCoverageGuard(apiRouter)
+	versioningGuard.Exempt(http.MethodPost, "/verify")
 	apiRouter.Use(versioningGuard.Middleware)
 	apiRouter.Use(history.AuditContextMiddleware(cfg))
 	abacpolicy.ExemptManagementMutationRoutesIfEnabled(cfg, versioningGuard, "digitaltwinregistryservice")
 	abacpolicy.RegisterManagementRoutesIfEnabled(cfg, apiRouter, abacRepo, "digitaltwinregistryservice")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	for operation, rt := range registryCtrl.Routes() {
 		versioningGuard.ClassifyRoute(operation, rt.Method, rt.Pattern)

--- a/cmd/discoveryservice/main.go
+++ b/cmd/discoveryservice/main.go
@@ -65,9 +65,6 @@ func runServer(ctx context.Context, configPath string) error {
 	r.Use(common.ConfigMiddleware(cfg))
 
 	common.AddCors(r, cfg)
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
 
 	// --- Health Endpoint (public) ---
 	common.AddHealthEndpoint(r, cfg)
@@ -127,6 +124,9 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 	abacpolicy.RegisterManagementRoutesIfEnabled(cfg, apiRouter, abacRepo, "discoveryservice")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	// Register all discovery routes (protected)
 	for _, rt := range smCtrl.Routes() {

--- a/cmd/submodelregistryservice/main.go
+++ b/cmd/submodelregistryservice/main.go
@@ -79,9 +79,6 @@ func runServer(ctx context.Context, configPath string) error {
 
 	common.AddCors(r, cfg)
 	common.AddHealthEndpoint(r, cfg)
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
 
 	// Add Swagger UI
 	if err := common.AddSwaggerUIFromFS(r, openapiSpec, "openapi.yaml", "Submodel Registry Service API", "/swagger", "/api-docs/openapi.yaml", cfg); err != nil {
@@ -142,10 +139,14 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 	versioningGuard := history.NewMutationCoverageGuard(apiRouter)
+	versioningGuard.Exempt(http.MethodPost, "/verify")
 	apiRouter.Use(versioningGuard.Middleware)
 	apiRouter.Use(history.AuditContextMiddleware(cfg))
 	abacpolicy.ExemptManagementMutationRoutesIfEnabled(cfg, versioningGuard, "submodelregistryservice")
 	abacpolicy.RegisterManagementRoutesIfEnabled(cfg, apiRouter, abacRepo, "submodelregistryservice")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	// Register all registry routes (protected)
 	for _, rt := range smCtrl.OrderedRoutes() {

--- a/cmd/submodelrepositoryservice/main.go
+++ b/cmd/submodelrepositoryservice/main.go
@@ -98,9 +98,6 @@ func runServer(ctx context.Context, configPath string) error {
 
 	common.AddCors(r, cfg)
 	common.AddHealthEndpoint(r, cfg)
-	if cfg.Server.VerificationEndpointAvailable {
-		common.AddVerificationEndpoint(r, cfg)
-	}
 
 	// Add Swagger UI
 	if err := common.AddSwaggerUIFromFS(r, openapiSpec, "openapi.yaml", "Submodel Repository API", "/swagger", "/api-docs/openapi.yaml", cfg); err != nil {
@@ -205,10 +202,14 @@ func runServer(ctx context.Context, configPath string) error {
 		return err
 	}
 	versioningGuard := history.NewMutationCoverageGuard(apiRouter)
+	versioningGuard.Exempt(http.MethodPost, "/verify")
 	apiRouter.Use(versioningGuard.Middleware)
 	apiRouter.Use(history.AuditContextMiddleware(cfg))
 	abacpolicy.ExemptManagementMutationRoutesIfEnabled(cfg, versioningGuard, "submodelrepositoryservice")
 	abacpolicy.RegisterManagementRoutesIfEnabled(cfg, apiRouter, abacRepo, "submodelrepositoryservice")
+	if cfg.Server.VerificationEndpointAvailable {
+		common.AddVerificationEndpoint(apiRouter, cfg)
+	}
 
 	for operation, rt := range smCtrl.Routes() {
 		versioningGuard.ClassifyRoute(operation, rt.Method, rt.Pattern)

--- a/examples/BaSyxEntraIDExample/docker-compose.yml
+++ b/examples/BaSyxEntraIDExample/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - 8081:5004
     environment:
       - SERVER_PORT=5004
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - CORS_ALLOWEDORIGINS=*
       - CORS_ALLOWEDHEADERS=*
       - CORS_ALLOWEDCREDENTIALS=true

--- a/examples/BaSyxEntraIDExample/security_env/access-rules.json
+++ b/examples/BaSyxEntraIDExample/security_env/access-rules.json
@@ -24,6 +24,7 @@
         "name": "all_api",
         "objects": [
           { "ROUTE": "/health" },
+          { "ROUTE": "/verify" },
           { "ROUTE": "/shell-descriptors" },
           { "ROUTE": "/shell-descriptors/*" },
           { "ROUTE": "/submodel-descriptors" },

--- a/examples/BaSyxHistoryAuditGuardedExample/docker-compose.yml
+++ b/examples/BaSyxHistoryAuditGuardedExample/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "8082:8082"
     environment:
       - SERVER_PORT=8082
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - CORS_ALLOWEDORIGINS=*
       - CORS_ALLOWEDHEADERS=*
       - CORS_ALLOWEDCREDENTIALS=true

--- a/examples/BaSyxHistoryAuditGuardedExample/security_env/access-rules.json
+++ b/examples/BaSyxHistoryAuditGuardedExample/security_env/access-rules.json
@@ -17,6 +17,7 @@
         "objects": [
           { "ROUTE": "/description" },
           { "ROUTE": "/health" },
+          { "ROUTE": "/verify" },
           { "ROUTE": "/serialization" },
           { "ROUTE": "/upload" },
           { "ROUTE": "/lookup/shells" },

--- a/examples/BaSyxOryHydraExample/docker-compose.yml
+++ b/examples/BaSyxOryHydraExample/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "8081:5004"
     environment:
       - SERVER_PORT=5004
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - CORS_ALLOWEDORIGINS=*
       - CORS_ALLOWEDHEADERS=*
       - CORS_ALLOWEDCREDENTIALS=true

--- a/examples/BaSyxOryHydraExample/security_env/access-rules.json
+++ b/examples/BaSyxOryHydraExample/security_env/access-rules.json
@@ -24,6 +24,7 @@
         "name": "all_api",
         "objects": [
           { "ROUTE": "/health" },
+          { "ROUTE": "/verify" },
           { "ROUTE": "/shell-descriptors" },
           { "ROUTE": "/shell-descriptors/*" },
           { "ROUTE": "/submodel-descriptors" },

--- a/examples/BaSyxSecuredExample/README.md
+++ b/examples/BaSyxSecuredExample/README.md
@@ -120,7 +120,7 @@ This file defines three access levels:
 
    - ACL `admin_full` with `ALL` rights
    - Formula `is_admin` checks `role = admin`
-   - Object group `all_api` grants full CRUD access
+   - Object group `all_api` grants full CRUD access and access to the `/verify` endpoint
 
 To change who can see or edit what, update [`security_env/access-rules.json`](security_env/access-rules.json) (ACLs, formulas, and object groups).
 

--- a/examples/BaSyxSecuredExample/docker-compose.yml
+++ b/examples/BaSyxSecuredExample/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - 8082:5004
     environment:
       - SERVER_PORT=5004
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - CORS_ALLOWEDORIGINS=*
       - CORS_ALLOWEDHEADERS=*
       - CORS_ALLOWEDCREDENTIALS=true
@@ -41,6 +42,7 @@ services:
     command: ["/app/submodelregistryservice"]
     environment:
       - SERVER_PORT=5004
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - CORS_ALLOWEDORIGINS=*
       - CORS_ALLOWEDHEADERS=*
       - CORS_ALLOWEDCREDENTIALS=true
@@ -76,6 +78,7 @@ services:
     command: ["/app/discoveryservice"]
     environment:
       - SERVER_PORT=5004
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - CORS_ALLOWEDORIGINS=*
       - CORS_ALLOWEDHEADERS=*
       - CORS_ALLOWEDCREDENTIALS=true
@@ -125,6 +128,7 @@ services:
     command: ["/app/aasrepositoryservice"]
     environment:
       - SERVER_PORT=5004
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - CORS_ALLOWEDORIGINS=*
       - CORS_ALLOWEDHEADERS=*
       - CORS_ALLOWEDCREDENTIALS=true
@@ -160,6 +164,7 @@ services:
     command: ["/app/submodelrepositoryservice"]
     environment:
       - SERVER_PORT=5004
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - CORS_ALLOWEDORIGINS=*
       - CORS_ALLOWEDHEADERS=*
       - CORS_ALLOWEDCREDENTIALS=true
@@ -197,6 +202,7 @@ services:
     command: ["/app/conceptdescriptionrepositoryservice"]
     environment:
       - SERVER_PORT=5004
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - CORS_ALLOWEDORIGINS=*
       - CORS_ALLOWEDHEADERS=*
       - CORS_ALLOWEDCREDENTIALS=true

--- a/examples/BaSyxSecuredExample/security_env/access-rules.json
+++ b/examples/BaSyxSecuredExample/security_env/access-rules.json
@@ -24,6 +24,7 @@
         "name": "all_api",
         "objects": [
           { "ROUTE": "/health" },
+          { "ROUTE": "/verify" },
           { "ROUTE": "/shell-descriptors" },
           { "ROUTE": "/shell-descriptors/*" },
           { "ROUTE": "/submodel-descriptors" },

--- a/internal/common/endpoints.go
+++ b/internal/common/endpoints.go
@@ -120,9 +120,12 @@ func writeHealthResponse(w http.ResponseWriter, statusCode int, body map[string]
 	}
 }
 
-// AddVerificationEndpoint registers the POST /verify Endpoint that accepts a JSON, XML or AASX payload and verifies it against the AAS meta model regardless of the service and verification mode.
-func AddVerificationEndpoint(r *chi.Mux, config *Config) {
-	r.Post(config.Server.ContextPath+"/verify", func(w http.ResponseWriter, r *http.Request) {
+// AddVerificationEndpoint registers POST /verify relative to the provided API router.
+// The endpoint accepts JSON, XML, or AASX and verifies it against the AAS meta
+// model. Callers must provide the service API router so configured security
+// middleware applies before payload parsing.
+func AddVerificationEndpoint(r chi.Router, config *Config) {
+	r.Post("/verify", func(w http.ResponseWriter, r *http.Request) {
 		maxPayloadBytes := verificationMaxPayloadBytes(config)
 		r.Body = http.MaxBytesReader(w, r.Body, maxPayloadBytes)
 		r = r.WithContext(ContextWithConfig(r.Context(), config))

--- a/internal/common/endpoints_test.go
+++ b/internal/common/endpoints_test.go
@@ -363,10 +363,10 @@ func TestVerifyPayload_ReturnsAllVerificationMessages(t *testing.T) {
 
 func TestAddVerificationEndpoint_ReturnsAllVerificationMessages(t *testing.T) {
 	router := chi.NewRouter()
-	cfg := &Config{Server: ServerConfig{ContextPath: "/api"}}
+	cfg := &Config{}
 	AddVerificationEndpoint(router, cfg)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/verify", strings.NewReader(invalidPropertyWithMultipleVerificationIssuesPayload()))
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(invalidPropertyWithMultipleVerificationIssuesPayload()))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
@@ -391,10 +391,10 @@ func TestAddVerificationEndpoint_ReturnsAllVerificationMessages(t *testing.T) {
 
 func TestAddVerificationEndpoint_RawJSON(t *testing.T) {
 	router := chi.NewRouter()
-	cfg := &Config{Server: ServerConfig{ContextPath: "/api"}}
+	cfg := &Config{}
 	AddVerificationEndpoint(router, cfg)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/verify", strings.NewReader(`{"assetAdministrationShells":[],"submodels":[],"conceptDescriptions":[]}`))
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(`{"assetAdministrationShells":[],"submodels":[],"conceptDescriptions":[]}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
@@ -416,6 +416,24 @@ func TestAddVerificationEndpoint_RawJSON(t *testing.T) {
 	}
 }
 
+func TestAddVerificationEndpointUsesMountedContextPath(t *testing.T) {
+	router := chi.NewRouter()
+	apiRouter := chi.NewRouter()
+	cfg := &Config{Server: ServerConfig{ContextPath: "/api"}}
+	AddVerificationEndpoint(apiRouter, cfg)
+	router.Mount(cfg.Server.ContextPath, apiRouter)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/verify", strings.NewReader(`{"assetAdministrationShells":[],"submodels":[],"conceptDescriptions":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+}
+
 func TestAddVerificationEndpoint_RejectsRawPayloadOverConfiguredLimit(t *testing.T) {
 	router := chi.NewRouter()
 	cfg := &Config{
@@ -424,7 +442,7 @@ func TestAddVerificationEndpoint_RejectsRawPayloadOverConfiguredLimit(t *testing
 	}
 	AddVerificationEndpoint(router, cfg)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/verify", strings.NewReader(`{"assetAdministrationShells":[]}`))
+	req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(`{"assetAdministrationShells":[]}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
@@ -456,7 +474,7 @@ func TestAddVerificationEndpoint_RejectsMultipartPayloadOverConfiguredLimit(t *t
 		t.Fatalf("failed to close multipart writer: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/verify", &body)
+	req := httptest.NewRequest(http.MethodPost, "/verify", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	rec := httptest.NewRecorder()
 

--- a/internal/common/security/abac_engine_methods.go
+++ b/internal/common/security/abac_engine_methods.go
@@ -40,6 +40,9 @@ type mapMethodAndPatternToRights struct {
 }
 
 var mapMethodAndPatternToRightsData = []mapMethodAndPatternToRights{
+	// verification endpoint
+	{"POST", "/verify", []grammar.RightsEnum{grammar.RightsEnumEXECUTE}},
+
 	// description endpoints
 	{"GET", "/description", []grammar.RightsEnum{grammar.RightsEnumREAD}},
 

--- a/internal/common/security/abac_engine_methods_management_test.go
+++ b/internal/common/security/abac_engine_methods_management_test.go
@@ -44,6 +44,18 @@ func TestABACPolicyManagementValidateRequiresUpdateRight(t *testing.T) {
 	}
 }
 
+func TestVerificationEndpointRequiresExecuteRight(t *testing.T) {
+	t.Parallel()
+
+	rights, ok := rightsForMappedRoute(http.MethodPost, "/verify")
+	if !ok {
+		t.Fatal("expected verification endpoint to have an ABAC rights mapping")
+	}
+	if len(rights) != 1 || len(rights[0]) != 1 || rights[0][0] != grammar.RightsEnumEXECUTE {
+		t.Fatalf("expected verification endpoint to require EXECUTE, got %v", rights)
+	}
+}
+
 func rightsForMappedRoute(method string, pattern string) ([][]grammar.RightsEnum, bool) {
 	var matches [][]grammar.RightsEnum
 	for _, mapping := range mapMethodAndPatternToRightsData {

--- a/internal/common/security/authorize_test.go
+++ b/internal/common/security/authorize_test.go
@@ -154,6 +154,34 @@ func TestSecurityMiddleware_RejectsAnonymousGetWhenACLRequiresSubClaim(t *testin
 	}
 }
 
+func TestVerifyEndpointRequiresAuthWhenABACEnabled(t *testing.T) {
+	router := api.NewRouter()
+	model := &AccessModel{
+		apiRouter: router,
+		basePath:  "",
+	}
+
+	router.Use(ABACMiddleware(ABACSettings{
+		Enabled: true,
+		Model:   model,
+	}))
+	common.AddVerificationEndpoint(router, &common.Config{})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/verify",
+		strings.NewReader(`{"assetAdministrationShells":[],"submodels":[],"conceptDescriptions":[]}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d without authentication, got %d", http.StatusUnauthorized, rec.Code)
+	}
+}
+
 func TestABACMiddleware_UnknownRouteReturnsNotFound(t *testing.T) {
 	router := api.NewRouter()
 	model := &AccessModel{

--- a/internal/common/swagger.go
+++ b/internal/common/swagger.go
@@ -238,6 +238,10 @@ func injectVerifyEndpoint(specContent []byte) []byte {
 		"                      type: string\n" +
 		"        '400':\n" +
 		"          description: Invalid payload or unsupported format\n" +
+		"        '401':\n" +
+		"          description: Authentication is required when security is enabled\n" +
+		"        '403':\n" +
+		"          description: The caller is not authorized to execute verification\n" +
 		"        '413':\n" +
 		"          description: Payload exceeds configured size limit\n" +
 		"        '500':\n" +

--- a/internal/common/swagger_test.go
+++ b/internal/common/swagger_test.go
@@ -390,6 +390,12 @@ func TestInjectVerifyEndpoint_ReflectsSupportedVerifyRequestFormats(t *testing.T
 	if !strings.Contains(injected, "application/aasx+json:") {
 		t.Fatal("expected injected /verify requestBody to document application/aasx+json")
 	}
+	if !strings.Contains(injected, "Authentication is required when security is enabled") {
+		t.Fatal("expected injected /verify responses to document authentication failures")
+	}
+	if !strings.Contains(injected, "not authorized to execute verification") {
+		t.Fatal("expected injected /verify responses to document authorization failures")
+	}
 }
 
 func TestInjectServerURL_DoesNotInheritServerBasePathFromSpec(t *testing.T) {

--- a/internal/submodelrepository/security_tests/bodies/verifyEnvironment.json
+++ b/internal/submodelrepository/security_tests/bodies/verifyEnvironment.json
@@ -1,0 +1,39 @@
+{
+  "assetAdministrationShells": [
+    {
+      "id": "urn:example:aas:verification",
+      "idShort": "VerificationAAS",
+      "assetInformation": {
+        "assetKind": "Instance",
+        "globalAssetId": "urn:example:asset:verification"
+      },
+      "submodels": [
+        {
+          "type": "ModelReference",
+          "keys": [
+            {
+              "type": "Submodel",
+              "value": "urn:example:submodel:verification"
+            }
+          ]
+        }
+      ],
+      "modelType": "AssetAdministrationShell"
+    }
+  ],
+  "submodels": [
+    {
+      "id": "urn:example:submodel:verification",
+      "idShort": "VerificationSubmodel",
+      "kind": "Instance",
+      "modelType": "Submodel"
+    }
+  ],
+  "conceptDescriptions": [
+    {
+      "id": "urn:example:concept-description:verification",
+      "idShort": "VerificationConcept",
+      "modelType": "ConceptDescription"
+    }
+  ]
+}

--- a/internal/submodelrepository/security_tests/docker_compose/docker_compose.yml
+++ b/internal/submodelrepository/security_tests/docker_compose/docker_compose.yml
@@ -20,6 +20,7 @@ services:
       dockerfile: ./cmd/submodelrepositoryservice/Dockerfile
     environment:
       - SERVER_PORT=5004
+      - SERVER_VERIFICATIONENDPOINTAVAILABLE=true
       - POSTGRES_HOST=db
       - POSTGRES_PORT=5432
       - POSTGRES_USER=admin

--- a/internal/submodelrepository/security_tests/expected/expectedVerificationResult.json
+++ b/internal/submodelrepository/security_tests/expected/expectedVerificationResult.json
@@ -1,0 +1,8 @@
+{
+  "valid": true,
+  "format": "json",
+  "assetAdministrationShellCount": 1,
+  "submodelCount": 1,
+  "conceptDescriptionCount": 1,
+  "messages": []
+}

--- a/internal/submodelrepository/security_tests/it_config.json
+++ b/internal/submodelrepository/security_tests/it_config.json
@@ -7,6 +7,31 @@
     "expectedStatus": 200
   },
   {
+    "context": "Anonymous verification denied",
+    "token": null,
+    "method": "POST",
+    "endpoint": "{{BASYX_IT_API_URL}}/verify",
+    "data": "bodies/verifyEnvironment.json",
+    "expectedStatus": 403
+  },
+  {
+    "context": "Verification denied without EXECUTE rule",
+    "token": { "user": "usera", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "{{BASYX_IT_API_URL}}/verify",
+    "data": "bodies/verifyEnvironment.json",
+    "expectedStatus": 403
+  },
+  {
+    "context": "Verification allowed by editor EXECUTE rule",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "POST",
+    "endpoint": "{{BASYX_IT_API_URL}}/verify",
+    "data": "bodies/verifyEnvironment.json",
+    "shouldMatch": "expected/expectedVerificationResult.json",
+    "expectedStatus": 200
+  },
+  {
     "context": "Anonymous list denied",
     "token": null,
     "method": "GET",

--- a/internal/submodelrepository/security_tests/security_env/access-rules.json
+++ b/internal/submodelrepository/security_tests/security_env/access-rules.json
@@ -8,6 +8,7 @@
 
     "DEFOBJECTS": [
       { "name": "description", "objects": [ { "ROUTE": "/description" } ] },
+      { "name": "verification_endpoint", "objects": [ { "ROUTE": "/verify" } ] },
       { "name": "all_submodel_read_routes", "objects": [
         { "ROUTE": "/submodels" },
         { "ROUTE": "/submodels/*" },
@@ -72,6 +73,7 @@
       { "name": "update_role", "acl": { "USEATTRIBUTES": "role_attr", "RIGHTS": ["UPDATE"], "ACCESS": "ALLOW" } },
       { "name": "update_member", "acl": { "USEATTRIBUTES": "member_attr", "RIGHTS": ["UPDATE"], "ACCESS": "ALLOW" } },
       { "name": "delete_role", "acl": { "USEATTRIBUTES": "role_attr", "RIGHTS": ["DELETE"], "ACCESS": "ALLOW" } },
+      { "name": "execute_role", "acl": { "USEATTRIBUTES": "role_attr", "RIGHTS": ["EXECUTE"], "ACCESS": "ALLOW" } },
       { "name": "admin_all", "acl": { "USEATTRIBUTES": "member_attr", "RIGHTS": ["ALL"], "ACCESS": "ALLOW" } }
     ],
 
@@ -180,6 +182,7 @@
     "rules": [
       { "USEACL": "admin_all", "OBJECTS": [ { "ROUTE": "*" } ], "USEFORMULA": "is_admin" },
       { "USEACL": "read_only_public", "USEOBJECTS": [ "description" ], "USEFORMULA": "always_true" },
+      { "USEACL": "execute_role", "USEOBJECTS": [ "verification_endpoint" ], "USEFORMULA": "editor_only" },
 
       { "USEACL": "read_role", "USEOBJECTS": [ "all_submodel_read_routes" ], "USEFORMULA": "viewer_formula_annotated_only" },
 


### PR DESCRIPTION
## Description of Changes

Moves the `POST /verify` endpoint into each service's API router so configured OIDC and ABAC middleware is applied before payload parsing.

The root cause was that `/verify` was registered directly on the public root router, while security middleware was installed only on the mounted API router.

This change:

- registers `/verify` relative to the protected API router
- removes the legacy root-router registration pattern
- maps `/verify` to the ABAC `EXECUTE` right
- exempts verification from mutation-history coverage because it is read-only
- documents possible `401` and `403` responses in the injected OpenAPI operation
- updates secured examples to explicitly enable and authorize verification where appropriate
- explicitly disables verification in the Digital Twin Registry example
- adds full-stack security integration coverage for:
  - anonymous denial
  - authenticated users without `EXECUTE` permission
  - authenticated users granted `EXECUTE` permission
  - successful verification of a minimal environment containing one AAS, one referenced submodel, and one concept description

## Related Issue

Closes #450