### PR TITLE
Refactor schema upload process to improve error handling and add compatibility checks

### DIFF
--- a/internal/basyxconfigurationservice/sequences/schema_upload.go
+++ b/internal/basyxconfigurationservice/sequences/schema_upload.go
@@ -71,18 +71,32 @@ func (su *SchemaUpload) Execute(stepIndex int) (int, error) {
 		return 1, fmt.Errorf("BASYXCFG-SCHEMA-READFILE: %w", err)
 	}
 
-	if _, err = su.ctx.DB.Exec(string(schemaSQL)); err != nil {
-		if isRc01UpgradeError(err) {
-			if err = su.applyRc01Compatibility(schemaToLoad); err != nil {
-				return 1, err
-			}
-		}
-
-		return su.Execute(stepIndex)
+	if err = su.executeSchemaWithRc01Compatibility(schemaToLoad, string(schemaSQL)); err != nil {
+		return 1, err
 	}
 
 	_, _ = fmt.Printf("[Step %d] Schema upload completed\n", stepIndex)
 	return 0, nil
+}
+
+func (su *SchemaUpload) executeSchemaWithRc01Compatibility(schemaPath string, schemaSQL string) error {
+	err := su.executeSchema(schemaSQL)
+	if err == nil || !isRc01UpgradeError(err) {
+		return err
+	}
+
+	if err = su.applyRc01Compatibility(schemaPath); err != nil {
+		return err
+	}
+
+	return su.executeSchema(schemaSQL)
+}
+
+func (su *SchemaUpload) executeSchema(schemaSQL string) error {
+	if _, err := su.ctx.DB.Exec(schemaSQL); err != nil {
+		return fmt.Errorf("BASYXCFG-SCHEMA-EXECUTE: %w", err)
+	}
+	return nil
 }
 
 func (su *SchemaUpload) resolveSchemaPath() (string, error) {

--- a/internal/basyxconfigurationservice/sequences/schema_upload_error_utils.go
+++ b/internal/basyxconfigurationservice/sequences/schema_upload_error_utils.go
@@ -30,10 +30,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
 
 const (
 	errCaseRc01UpgradeFieldErr      = "pq: column \"db_created_at\" does not exist (42703)"
+	rc01MissingColumnMessage        = "column \"db_created_at\" does not exist"
+	rc01UndefinedColumnPostgresCode = "42703"
 	rc01CompatibilitySchemaFileName = "rc1_compatibility.sql"
 )
 
@@ -51,5 +55,14 @@ func (su *SchemaUpload) applyRc01Compatibility(schemaToLoad string) error {
 }
 
 func isRc01UpgradeError(err error) bool {
-	return strings.HasSuffix(err.Error(), errCaseRc01UpgradeFieldErr)
+	if err == nil {
+		return false
+	}
+
+	errorMessage := err.Error()
+	isLegacyError := strings.HasSuffix(errorMessage, errCaseRc01UpgradeFieldErr)
+	isUndefinedTimestampColumn := common.IsPostgresErrorCode(err, rc01UndefinedColumnPostgresCode) &&
+		strings.Contains(errorMessage, rc01MissingColumnMessage)
+
+	return isLegacyError || isUndefinedTimestampColumn
 }

--- a/internal/basyxconfigurationservice/sequences/schema_upload_error_utils_test.go
+++ b/internal/basyxconfigurationservice/sequences/schema_upload_error_utils_test.go
@@ -1,0 +1,107 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package sequences
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestIsRc01UpgradeError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "pgx error",
+			err:  newRc01PgError(),
+			want: true,
+		},
+		{
+			name: "wrapped pgx error",
+			err:  fmt.Errorf("schema upload failed: %w", newRc01PgError()),
+			want: true,
+		},
+		{
+			name: "wrong SQL state",
+			err: &pgconn.PgError{
+				Severity: "ERROR",
+				Code:     "23505",
+				Message:  `column "db_created_at" does not exist`,
+			},
+			want: false,
+		},
+		{
+			name: "wrong column",
+			err: &pgconn.PgError{
+				Severity: "ERROR",
+				Code:     "42703",
+				Message:  `column "other_column" does not exist`,
+			},
+			want: false,
+		},
+		{
+			name: "legacy pq error text",
+			err:  errors.New(errCaseRc01UpgradeFieldErr),
+			want: true,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertRc01UpgradeError(t, test.err, test.want)
+		})
+	}
+}
+
+func assertRc01UpgradeError(t *testing.T, err error, want bool) {
+	t.Helper()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("isRc01UpgradeError() panicked: %v", recovered)
+		}
+	}()
+	if got := isRc01UpgradeError(err); got != want {
+		t.Fatalf("isRc01UpgradeError() = %t, want %t", got, want)
+	}
+}
+
+func newRc01PgError() error {
+	return &pgconn.PgError{
+		Severity: "ERROR",
+		Code:     "42703",
+		Message:  `column "db_created_at" does not exist`,
+	}
+}

--- a/internal/basyxconfigurationservice/sequences/schema_upload_test.go
+++ b/internal/basyxconfigurationservice/sequences/schema_upload_test.go
@@ -26,7 +26,9 @@
 package sequences
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -204,6 +206,95 @@ func TestSchemaUploadExecuteReturnsLockError(t *testing.T) {
 	}
 }
 
+func TestSchemaUploadExecuteReturnsSchemaExecutionError(t *testing.T) {
+	schema := "THIS IS NOT VALID SQL;"
+	step, mock := newSchemaUploadTestStep(t, writeTempSchema(t, schema))
+	schemaErr := errors.New("invalid schema")
+
+	expectSchemaAdvisoryLock(mock)
+	mock.ExpectExec(regexp.QuoteMeta(schema)).
+		WillReturnError(schemaErr)
+	expectSchemaAdvisoryUnlock(mock)
+
+	statusCode, execErr := step.Execute(3)
+	if execErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if statusCode != 1 {
+		t.Fatalf("expected status code 1, got %d", statusCode)
+	}
+	if !strings.Contains(execErr.Error(), "BASYXCFG-SCHEMA-EXECUTE") {
+		t.Fatalf("unexpected error: %v", execErr)
+	}
+	if !errors.Is(execErr, schemaErr) {
+		t.Fatalf("expected schema execution cause, got: %v", execErr)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestSchemaUploadExecuteAppliesRc01CompatibilityAndRetriesOnce(t *testing.T) {
+	schema := "CREATE TABLE IF NOT EXISTS test_table (id INT PRIMARY KEY);"
+	compatibilitySQL := "ALTER TABLE test_table ADD COLUMN db_created_at TIMESTAMPTZ;"
+	schemaPath := writeTempSchemaWithCompatibility(t, schema, compatibilitySQL)
+	step, mock := newSchemaUploadTestStep(t, schemaPath)
+
+	expectSchemaAdvisoryLock(mock)
+	mock.ExpectExec(regexp.QuoteMeta(schema)).
+		WillReturnError(newRc01PgError())
+	mock.ExpectExec(regexp.QuoteMeta(compatibilitySQL)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(schema)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectSchemaAdvisoryUnlock(mock)
+
+	statusCode, execErr := step.Execute(3)
+	if execErr != nil {
+		t.Fatalf("unexpected error: %v", execErr)
+	}
+	if statusCode != 0 {
+		t.Fatalf("expected status code 0, got %d", statusCode)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestSchemaUploadExecuteReturnsErrorAfterFailedRc01Retry(t *testing.T) {
+	schema := "CREATE TABLE IF NOT EXISTS test_table (id INT PRIMARY KEY);"
+	compatibilitySQL := "ALTER TABLE test_table ADD COLUMN db_created_at TIMESTAMPTZ;"
+	schemaPath := writeTempSchemaWithCompatibility(t, schema, compatibilitySQL)
+	step, mock := newSchemaUploadTestStep(t, schemaPath)
+	retryErr := newRc01PgError()
+
+	expectSchemaAdvisoryLock(mock)
+	mock.ExpectExec(regexp.QuoteMeta(schema)).
+		WillReturnError(newRc01PgError())
+	mock.ExpectExec(regexp.QuoteMeta(compatibilitySQL)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(schema)).
+		WillReturnError(retryErr)
+	expectSchemaAdvisoryUnlock(mock)
+
+	statusCode, execErr := step.Execute(3)
+	if execErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if statusCode != 1 {
+		t.Fatalf("expected status code 1, got %d", statusCode)
+	}
+	if !strings.Contains(execErr.Error(), "BASYXCFG-SCHEMA-EXECUTE") {
+		t.Fatalf("unexpected error: %v", execErr)
+	}
+	if !errors.Is(execErr, retryErr) {
+		t.Fatalf("expected retry failure cause, got: %v", execErr)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
 func writeTempSchema(t *testing.T, sql string) string {
 	t.Helper()
 	path := t.TempDir() + "/schema.sql"
@@ -211,4 +302,38 @@ func writeTempSchema(t *testing.T, sql string) string {
 		t.Fatalf("write schema file: %v", err)
 	}
 	return path
+}
+
+func writeTempSchemaWithCompatibility(t *testing.T, schemaSQL string, compatibilitySQL string) string {
+	t.Helper()
+	schemaPath := writeTempSchema(t, schemaSQL)
+	compatibilityPath := filepath.Join(filepath.Dir(schemaPath), rc01CompatibilitySchemaFileName)
+	if err := os.WriteFile(compatibilityPath, []byte(compatibilitySQL), 0o600); err != nil {
+		t.Fatalf("write compatibility schema: %v", err)
+	}
+	return schemaPath
+}
+
+func newSchemaUploadTestStep(t *testing.T, schemaPath string) (*SchemaUpload, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return NewSchemaUpload(&ExecutionContext{DB: db}, schemaPath), mock
+}
+
+func expectSchemaAdvisoryLock(mock sqlmock.Sqlmock) {
+	mock.ExpectExec(regexp.QuoteMeta("SELECT pg_advisory_lock($1)")).
+		WithArgs(schemaAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func expectSchemaAdvisoryUnlock(mock sqlmock.Sqlmock) {
+	mock.ExpectExec(regexp.QuoteMeta("SELECT pg_advisory_unlock($1)")).
+		WithArgs(schemaAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
 }


### PR DESCRIPTION
## Description of Changes

This pull request refactors and improves the schema upload logic, especially around handling compatibility errors for RC01 upgrades. It introduces more robust error detection for missing columns, improves test coverage for these scenarios, and refactors the code for better maintainability.

**Schema Upload Logic Refactoring and Error Handling:**

* Refactored `SchemaUpload.Execute` to delegate schema execution and RC01 compatibility handling to a new helper method, improving code clarity and reducing duplication. Added a new method `executeSchemaWithRc01Compatibility` to encapsulate the retry logic and error handling. (`internal/basyxconfigurationservice/sequences/schema_upload.go` [internal/basyxconfigurationservice/sequences/schema_upload.goL74-R99](diffhunk://#diff-f7b0554adbb6c4df78769a372b109362a4aa55657f75a3a9523f0272f55adccdL74-R99))
* Improved RC01 upgrade error detection in `isRc01UpgradeError` to cover both legacy error messages and modern Postgres error codes/messages, using a new utility from the `common` package. (`internal/basyxconfigurationservice/sequences/schema_upload_error_utils.go` [internal/basyxconfigurationservice/sequences/schema_upload_error_utils.goL54-R67](diffhunk://#diff-16a4f93bf7c7216052695d6da0f8e0165d0038a845e8a1a2316573f099df0e93L54-R67))

**Testing Enhancements:**

* Added comprehensive unit tests for `isRc01UpgradeError`, covering various error scenarios including wrapped errors, legacy errors, and Postgres error codes. (`internal/basyxconfigurationservice/sequences/schema_upload_error_utils_test.go` [internal/basyxconfigurationservice/sequences/schema_upload_error_utils_test.goR1-R107](diffhunk://#diff-6ee75c3995ba800136a008ece79a40e87e3351366c08fe679f9e4fed3994c032R1-R107))
* Expanded integration tests for `SchemaUpload.Execute` to cover error propagation, RC01 compatibility application and retry, and failure cases after retry. Added test helpers for schema file creation and mock setup. (`internal/basyxconfigurationservice/sequences/schema_upload_test.go` [[1]](diffhunk://#diff-156cd49b1a1e1141e025242671a842c863909937222070cb585a29c66adf5801R209-R297) [[2]](diffhunk://#diff-156cd49b1a1e1141e025242671a842c863909937222070cb585a29c66adf5801R306-R339)

**Dependency and Constant Updates:**

* Updated imports and constants to support the new error handling logic and compatibility file detection. (`internal/basyxconfigurationservice/sequences/schema_upload_error_utils.go` [internal/basyxconfigurationservice/sequences/schema_upload_error_utils.goR33-R40](diffhunk://#diff-16a4f93bf7c7216052695d6da0f8e0165d0038a845e8a1a2316573f099df0e93R33-R40))

These changes make the schema upload process more robust, especially when handling database schema mismatches during upgrades, and ensure that the logic is well-tested and maintainable.

## Related Issue

closes #492 
