### PR TITLE
Stream AASX File Server uploads and downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,21 @@ POSTGRES_CONNMAXLIFETIMEMINUTES=5
 
 All HTTP timeout values are in seconds and must be greater than zero. The legacy Viper-derived names such as `SERVER_READTIMEOUTSECONDS` still work; readable aliases with underscores and `BASYX_` prefixes, such as `BASYX_SERVER_READ_TIMEOUT_SECONDS`, are also supported.
 
-For `aasenvironmentservice`, `aasrepositoryservice`, and `submodelrepositoryservice`, uploads are additionally bounded by:
+Binary uploads and AASX package expansion are bounded independently:
 
 ```yaml
 general:
     uploadMaxSizeBytes: 134217728
+    aasxMaxPartCount: 10000
+    aasxMaxOPCMetadataSizeBytes: 16777216
+    aasxMaxPartExpandedSizeBytes: 134217728
+    aasxMaxTotalExpandedSizeBytes: 134217728
+    aasxMaxThumbnailSizeBytes: 16777216
 ```
 
-This value limits the accepted request body and provides a second streamed-content limit before attachment or thumbnail bytes are written to PostgreSQL. Multipart overhead counts toward the HTTP request limit.
+`uploadMaxSizeBytes` limits the compressed HTTP request, including multipart overhead. The AASX limits constrain entry count, expanded OPC metadata, each expanded part, all expanded payload parts combined, and thumbnails respectively. All limits must be positive, and the total expanded limit must be greater than or equal to the per-part limit, which must be greater than or equal to the thumbnail limit.
+
+The AASX File Server uses transaction-scoped PostgreSQL large objects for seekable upload staging, so it does not require a writable local temporary directory. Package downloads are streamed from PostgreSQL instead of being materialized in process memory.
 
 - `POST /upload`
 - `PUT /shells/{aasIdentifier}/asset-information/thumbnail`

--- a/cmd/aasxfileserverservice/config.yaml
+++ b/cmd/aasxfileserverservice/config.yaml
@@ -34,6 +34,11 @@ postgres:
 
 general:
   uploadMaxSizeBytes: 134217728
+  aasxMaxPartCount: 10000
+  aasxMaxOPCMetadataSizeBytes: 16777216
+  aasxMaxPartExpandedSizeBytes: 134217728
+  aasxMaxTotalExpandedSizeBytes: 134217728
+  aasxMaxThumbnailSizeBytes: 16777216
 
 # swagger:
 #   enabled: true

--- a/cmd/aasxfileserverservice/main.go
+++ b/cmd/aasxfileserverservice/main.go
@@ -38,6 +38,7 @@ import (
 	aasxapi "github.com/eclipse-basyx/basyx-go-components/internal/aasxfileserver/api"
 	aasxpersistence "github.com/eclipse-basyx/basyx-go-components/internal/aasxfileserver/persistence"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/binarycontent"
 	commonmodel "github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/security/abacpolicy"
 	openapi "github.com/eclipse-basyx/basyx-go-components/pkg/aasxfileserverapi/go"
@@ -99,7 +100,11 @@ func runServer(ctx context.Context, configPath string) error {
 	log.Println("✅ Postgres connection established")
 
 	aasxSvc := aasxapi.NewAASXFileServerAPIAPIService(aasxDatabase)
-	aasxCtrl := openapi.NewAASXFileServerAPIAPIController(aasxSvc, "")
+	aasxCtrl := openapi.NewAASXFileServerAPIAPIController(
+		aasxSvc,
+		"",
+		openapi.WithAASXFileServerUploadStager(binarycontent.NewStager(sharedDB), cfg.General.UploadMaxSizeBytes),
+	)
 
 	descSvc := aasxapi.NewDescriptionAPIAPIService()
 	descCtrl := openapi.NewDescriptionAPIAPIController(descSvc, "")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require github.com/go-chi/chi/v5 v5.3.1
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/FriedJannik/aas-go-sdk v1.3.2
-	github.com/aas-core-works/aas-package3-golang v1.0.0
+	github.com/aas-core-works/aas-package3-golang/v2 v2.0.0
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.30
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.29

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/FriedJannik/aas-go-sdk v1.3.2 h1:kb6TZc0ORINUoGPzmbCPagMRJZ/aMR747PIEe7VH+pA=
 github.com/FriedJannik/aas-go-sdk v1.3.2/go.mod h1:2Ui4RhCuJcLXyG26FhM7ti5WOALw9Iv3t7SnDu+tYu0=
-github.com/aas-core-works/aas-package3-golang v1.0.0 h1:Q+iLgs28eOYjRbZ9YbkxNLb4vjC/9CA2TZFwFagjbN4=
-github.com/aas-core-works/aas-package3-golang v1.0.0/go.mod h1:uDObjS4hNhBujH9L59QIAacokk7uAl9X0BbmNCkPtDs=
+github.com/aas-core-works/aas-package3-golang/v2 v2.0.0 h1:zboYmOKbHKEi3hirPcKKGiOsMy5WA/NHcO5yLU/S+Xk=
+github.com/aas-core-works/aas-package3-golang/v2 v2.0.0/go.mod h1:NnyXDNwyPX2ORNR669+ck1XpbffcExNR146sycZtKBc=
 github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
 github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=

--- a/internal/aasenvironment/integration_tests/aasenvironment_serialization_integration_test.go
+++ b/internal/aasenvironment/integration_tests/aasenvironment_serialization_integration_test.go
@@ -49,7 +49,7 @@ import (
 	aasjsonization "github.com/FriedJannik/aas-go-sdk/jsonization"
 	aastypes "github.com/FriedJannik/aas-go-sdk/types"
 	aasxmlization "github.com/FriedJannik/aas-go-sdk/xmlization"
-	aasx "github.com/aas-core-works/aas-package3-golang"
+	aasx "github.com/aas-core-works/aas-package3-golang/v2"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
 	"github.com/stretchr/testify/require"
 )
@@ -237,14 +237,16 @@ func TestSerializationDownloadAASXXMLAfterThreeAASUploadRequestedAcceptFormat(t 
 
 			switch testCase.expectedFormat {
 			case "aasx-xml":
-				downloadedSpecParts := readAASXSpecPartsFromPayload(t, downloadPayload)
+				downloadedSpecParts, closePackage := readAASXSpecPartsFromPayload(t, downloadPayload)
+				defer closePackage()
 				require.NotEmptyf(t, downloadedSpecParts, "AASX payload for Accept %q has no spec parts", testCase.accept)
 				for _, specPart := range downloadedSpecParts {
 					require.Truef(t, isXMLSpecPart(specPart), "AASX spec part for Accept %q must be XML", testCase.accept)
 				}
 
 			case "aasx-json":
-				downloadedSpecParts := readAASXSpecPartsFromPayload(t, downloadPayload)
+				downloadedSpecParts, closePackage := readAASXSpecPartsFromPayload(t, downloadPayload)
+				defer closePackage()
 				require.NotEmptyf(t, downloadedSpecParts, "AASX payload for Accept %q has no spec parts", testCase.accept)
 				for _, specPart := range downloadedSpecParts {
 					require.Truef(t, isJSONSpecPart(specPart), "AASX spec part for Accept %q must be JSON", testCase.accept)
@@ -289,7 +291,8 @@ func TestSerializationDownloadAASXWithoutUploadContainsSameIds(t *testing.T) {
 			payload := downloadAASXSerializationFullEnvironment(t, testCase.accept, true)
 			require.NotEmpty(t, payload)
 
-			specParts := readAASXSpecPartsFromPayload(t, payload)
+			specParts, closePackage := readAASXSpecPartsFromPayload(t, payload)
+			defer closePackage()
 			require.NotEmptyf(t, specParts, "serialization payload without upload must contain at least one AASX spec part for Accept %q", testCase.accept)
 
 			environment, transformToEnvErr := environmentFromAASXSpecParts(specParts)
@@ -338,7 +341,8 @@ func TestSerializationDownloadAASXWithoutUploadContainsSubsetIds(t *testing.T) {
 			)
 			require.NotEmpty(t, payload)
 
-			specParts := readAASXSpecPartsFromPayload(t, payload)
+			specParts, closePackage := readAASXSpecPartsFromPayload(t, payload)
+			defer closePackage()
 			require.NotEmptyf(t, specParts, "filtered serialization payload must contain at least one AASX spec part for Accept %q", testCase.accept)
 
 			environment, transformToEnvErr := environmentFromAASXSpecParts(specParts)
@@ -835,21 +839,19 @@ func humanReadableSupplementaryName(uri string) string {
 	return baseName
 }
 
-func readAASXSpecPartsFromPayload(t *testing.T, payload []byte) []*aasx.Part {
+func readAASXSpecPartsFromPayload(t *testing.T, payload []byte) ([]*aasx.Part, func()) {
 	t.Helper()
 
-	tempPath := filepath.Join(t.TempDir(), "serialization_result.aasx")
-	require.NoError(t, os.WriteFile(tempPath, payload, 0o600))
-
 	packaging := aasx.NewPackaging()
-	packageReader, err := packaging.OpenRead(tempPath)
-	require.NoErrorf(t, err, "failed to open serialization payload as AASX package from %q", tempPath)
-	defer func() { _ = packageReader.Close() }()
+	packageReader, err := packaging.OpenReadFromStream(bytes.NewReader(payload))
+	require.NoError(t, err, "failed to open serialization payload as AASX package")
 
 	specParts, err := packageReader.Specs()
 	require.NoError(t, err)
 
-	return specParts
+	return specParts, func() {
+		require.NoError(t, packageReader.Close())
+	}
 }
 
 // environmentFromAASXSpecParts converts AASX XML/JSON spec parts into an AAS

--- a/internal/aasenvironment/serialization_api_service.go
+++ b/internal/aasenvironment/serialization_api_service.go
@@ -48,7 +48,7 @@ import (
 	"github.com/FriedJannik/aas-go-sdk/jsonization"
 	aastypes "github.com/FriedJannik/aas-go-sdk/types"
 	aasxmlization "github.com/FriedJannik/aas-go-sdk/xmlization"
-	aasx "github.com/aas-core-works/aas-package3-golang"
+	aasx "github.com/aas-core-works/aas-package3-golang/v2"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 )

--- a/internal/aasenvironment/serialization_api_service_accept_test.go
+++ b/internal/aasenvironment/serialization_api_service_accept_test.go
@@ -32,7 +32,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	aasx "github.com/aas-core-works/aas-package3-golang"
+	aasx "github.com/aas-core-works/aas-package3-golang/v2"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/aasenvironment/upload_api_service.go
+++ b/internal/aasenvironment/upload_api_service.go
@@ -45,7 +45,7 @@ import (
 	aasjsonization "github.com/FriedJannik/aas-go-sdk/jsonization"
 	aastypes "github.com/FriedJannik/aas-go-sdk/types"
 	aasxmlization "github.com/FriedJannik/aas-go-sdk/xmlization"
-	aasx "github.com/aas-core-works/aas-package3-golang"
+	aasx "github.com/aas-core-works/aas-package3-golang/v2"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	commonmodel "github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 )

--- a/internal/aasenvironment/upload_api_service_test.go
+++ b/internal/aasenvironment/upload_api_service_test.go
@@ -32,7 +32,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	aasx "github.com/aas-core-works/aas-package3-golang"
+	aasx "github.com/aas-core-works/aas-package3-golang/v2"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
 

--- a/internal/aasxfileserver/api/api_aasx_file_server_api_service.go
+++ b/internal/aasxfileserver/api/api_aasx_file_server_api_service.go
@@ -120,7 +120,7 @@ func (s *AASXFileServerAPIAPIService) GetAllAASXPackageIds(ctx context.Context, 
 // Returns:
 //   - openapi.ImplResponse: Created package description or mapped API error.
 //   - error: Reserved for failures not represented by an API response.
-func (s *AASXFileServerAPIAPIService) PostAASXPackage(ctx context.Context, file common.StagedUpload, aasIDs []string, fileName string) (openapi.ImplResponse, error) {
+func (s *AASXFileServerAPIAPIService) PostAASXPackage(ctx context.Context, file openapi.StagedUpload, aasIDs []string, fileName string) (openapi.ImplResponse, error) {
 	const operation = "PostAASXPackage"
 
 	if file == nil {
@@ -195,7 +195,7 @@ func (s *AASXFileServerAPIAPIService) GetAASXByPackageId(ctx context.Context, pa
 // Returns:
 //   - openapi.ImplResponse: HTTP 204 for replacement, HTTP 201 for creation, or a mapped API error.
 //   - error: Reserved for failures not represented by an API response.
-func (s *AASXFileServerAPIAPIService) PutAASXByPackageId(ctx context.Context, packageID string, file common.StagedUpload, aasIDs []string, fileName string) (openapi.ImplResponse, error) {
+func (s *AASXFileServerAPIAPIService) PutAASXByPackageId(ctx context.Context, packageID string, file openapi.StagedUpload, aasIDs []string, fileName string) (openapi.ImplResponse, error) {
 	const operation = "PutAASXByPackageId"
 
 	if file == nil {

--- a/internal/aasxfileserver/api/api_aasx_file_server_api_service.go
+++ b/internal/aasxfileserver/api/api_aasx_file_server_api_service.go
@@ -31,7 +31,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -48,7 +47,13 @@ type AASXFileServerAPIAPIService struct {
 	backend *persistence.AASXFileServerDatabase
 }
 
-// NewAASXFileServerAPIAPIService constructs an API service backed by a Postgres persistence layer.
+// NewAASXFileServerAPIAPIService constructs an AASX file server service.
+//
+// Parameters:
+//   - backend: PostgreSQL persistence backend used by all service operations.
+//
+// Returns:
+//   - *AASXFileServerAPIAPIService: Configured service instance.
 func NewAASXFileServerAPIAPIService(backend *persistence.AASXFileServerDatabase) *AASXFileServerAPIAPIService {
 	return &AASXFileServerAPIAPIService{backend: backend}
 }
@@ -104,8 +109,18 @@ func (s *AASXFileServerAPIAPIService) GetAllAASXPackageIds(ctx context.Context, 
 	}), nil
 }
 
-// PostAASXPackage stores a new package with a server-generated package identifier.
-func (s *AASXFileServerAPIAPIService) PostAASXPackage(ctx context.Context, file *os.File, aasIDs []string, fileName string) (openapi.ImplResponse, error) {
+// PostAASXPackage stores a staged package under a server-generated identifier.
+//
+// Parameters:
+//   - ctx: Request context containing cancellation and configured AASX limits.
+//   - file: Seekable staged package owned by the HTTP request.
+//   - aasIDs: AAS identifiers associated with the package.
+//   - fileName: Preferred download filename.
+//
+// Returns:
+//   - openapi.ImplResponse: Created package description or mapped API error.
+//   - error: Reserved for failures not represented by an API response.
+func (s *AASXFileServerAPIAPIService) PostAASXPackage(ctx context.Context, file common.StagedUpload, aasIDs []string, fileName string) (openapi.ImplResponse, error) {
 	const operation = "PostAASXPackage"
 
 	if file == nil {
@@ -115,6 +130,9 @@ func (s *AASXFileServerAPIAPIService) PostAASXPackage(ctx context.Context, file 
 	rawPackageID := generatePackageID()
 	record, err := s.backend.CreatePackage(ctx, rawPackageID, file, aasIDs, fileName)
 	if err != nil {
+		if common.IsErrPayloadTooLarge(err) {
+			return newAPIErrorResponse(err, http.StatusRequestEntityTooLarge, operation, "PayloadTooLarge"), nil
+		}
 		if common.IsErrConflict(err) {
 			return newAPIErrorResponse(err, http.StatusConflict, operation, "PackageIdConflict"), nil
 		}
@@ -127,7 +145,15 @@ func (s *AASXFileServerAPIAPIService) PostAASXPackage(ctx context.Context, file 
 	return openapi.Response(http.StatusCreated, toPackageDescription(*record)), nil
 }
 
-// GetAASXByPackageId returns the binary payload and metadata headers for one package.
+// GetAASXByPackageId returns a streamed package and its download metadata.
+//
+// Parameters:
+//   - ctx: Request context used for lookup, streaming, and cancellation.
+//   - packageID: Base64URL-encoded package identifier from the request path.
+//
+// Returns:
+//   - openapi.ImplResponse: FileDownload owning the response stream, or a mapped API error.
+//   - error: Reserved for failures not represented by an API response.
 func (s *AASXFileServerAPIAPIService) GetAASXByPackageId(ctx context.Context, packageID string) (openapi.ImplResponse, error) {
 	const operation = "GetAASXByPackageId"
 
@@ -157,8 +183,19 @@ func (s *AASXFileServerAPIAPIService) GetAASXByPackageId(ctx context.Context, pa
 	}), nil
 }
 
-// PutAASXByPackageId creates or updates a package addressed by the path package identifier.
-func (s *AASXFileServerAPIAPIService) PutAASXByPackageId(ctx context.Context, packageID string, file *os.File, aasIDs []string, fileName string) (openapi.ImplResponse, error) {
+// PutAASXByPackageId creates or replaces a staged package.
+//
+// Parameters:
+//   - ctx: Request context containing cancellation and configured AASX limits.
+//   - packageID: Base64URL-encoded package identifier from the request path.
+//   - file: Seekable staged replacement package owned by the HTTP request.
+//   - aasIDs: Replacement AAS identifiers associated with the package.
+//   - fileName: Preferred replacement download filename.
+//
+// Returns:
+//   - openapi.ImplResponse: HTTP 204 for replacement, HTTP 201 for creation, or a mapped API error.
+//   - error: Reserved for failures not represented by an API response.
+func (s *AASXFileServerAPIAPIService) PutAASXByPackageId(ctx context.Context, packageID string, file common.StagedUpload, aasIDs []string, fileName string) (openapi.ImplResponse, error) {
 	const operation = "PutAASXByPackageId"
 
 	if file == nil {
@@ -172,6 +209,9 @@ func (s *AASXFileServerAPIAPIService) PutAASXByPackageId(ctx context.Context, pa
 
 	updated, record, err := s.backend.PutPackage(ctx, decodedPackageID, file, aasIDs, fileName)
 	if err != nil {
+		if common.IsErrPayloadTooLarge(err) {
+			return newAPIErrorResponse(err, http.StatusRequestEntityTooLarge, operation, "PayloadTooLarge"), nil
+		}
 		if common.IsErrConflict(err) {
 			return newAPIErrorResponse(err, http.StatusConflict, operation, "PackageIdConflict"), nil
 		}

--- a/internal/aasxfileserver/persistence/aasx_database.go
+++ b/internal/aasxfileserver/persistence/aasx_database.go
@@ -315,6 +315,7 @@ func (p *AASXFileServerDatabase) GetPackageByID(ctx context.Context, packageID s
 	query, args, err := dialect.From("aasx_package").
 		Select("id", "file_oid", "file_name", "content_type").
 		Where(goqu.C("package_id").Eq(packageID)).
+		ForShare(exp.Wait).
 		ToSQL()
 	if err != nil {
 		return nil, common.NewInternalServerError("AASXFS-GETPACKAGE-BUILDSQL " + err.Error())
@@ -371,6 +372,7 @@ func (p *AASXFileServerDatabase) DeletePackageByID(ctx context.Context, packageI
 	selectSQL, selectArgs, err := dialect.From("aasx_package").
 		Select("id", "file_oid").
 		Where(goqu.C("package_id").Eq(packageID)).
+		ForUpdate(exp.Wait).
 		ToSQL()
 	if err != nil {
 		return common.NewInternalServerError("AASXFS-DELETEPACKAGE-BUILDSELECT " + err.Error())
@@ -508,7 +510,10 @@ func resolvePackageContentTypeForUpload(file io.ReadSeeker, fileName string, lim
 	if errors.Is(aasxErr, aasx.ErrReaderLimitExceeded) {
 		return "", common.NewErrPayloadTooLarge("AASXFS-RESOLVEMIME-AASXLIMIT " + aasxErr.Error())
 	}
-	if aasxErr == nil && aasxContentType != "" {
+	if aasxErr != nil {
+		return "", common.NewErrBadRequest("AASXFS-RESOLVEMIME-INVALIDAASX " + aasxErr.Error())
+	}
+	if aasxContentType != "" {
 		resolvedContentType = aasxContentType
 	}
 

--- a/internal/aasxfileserver/persistence/aasx_database.go
+++ b/internal/aasxfileserver/persistence/aasx_database.go
@@ -33,21 +33,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
-	aasx "github.com/aas-core-works/aas-package3-golang"
+	aasx "github.com/aas-core-works/aas-package3-golang/v2"
 	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/exp"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/binarycontent"
 )
 
-const (
-	largeObjectWriteMode      = 0x00020000
-	largeObjectReadMode       = 0x00040000
-	defaultPackageContentType = "application/asset-administration-shell-package"
-)
+const defaultPackageContentType = "application/asset-administration-shell-package"
 
 // PackageRecord contains package metadata returned by list and write operations.
 type PackageRecord struct {
@@ -58,10 +55,11 @@ type PackageRecord struct {
 	AASIDs      []string
 }
 
-// PackageBinary combines package metadata with package bytes.
+// PackageBinary combines package metadata with a streamed package body.
+// Content owns the read transaction and must be closed by the caller.
 type PackageBinary struct {
 	PackageRecord
-	Content []byte
+	Content io.ReadCloser
 }
 
 // AASXFileServerDatabase exposes package persistence operations.
@@ -69,7 +67,14 @@ type AASXFileServerDatabase struct {
 	db *sql.DB
 }
 
-// NewAASXFileServerDatabaseFromDB creates an AASX database backend from an existing SQL handle.
+// NewAASXFileServerDatabaseFromDB creates an AASX database backend from a shared pool.
+//
+// Parameters:
+//   - db: Caller-owned PostgreSQL connection pool.
+//
+// Returns:
+//   - *AASXFileServerDatabase: Backend sharing db.
+//   - error: Validation error when db is nil.
 func NewAASXFileServerDatabaseFromDB(db *sql.DB) (*AASXFileServerDatabase, error) {
 	if db == nil {
 		return nil, common.NewErrBadRequest("AASXFS-NEWFROMDB-NILDB database handle must not be nil")
@@ -147,8 +152,19 @@ func (p *AASXFileServerDatabase) ListPackages(ctx context.Context, limit int32, 
 	return records, nextCursor, nil
 }
 
-// CreatePackage creates a new package and fails if the package ID already exists.
-func (p *AASXFileServerDatabase) CreatePackage(ctx context.Context, packageID string, file *os.File, aasIDs []string, fileName string) (*PackageRecord, error) {
+// CreatePackage atomically persists a staged package and its metadata.
+//
+// Parameters:
+//   - ctx: Request context containing cancellation and configured AASX limits.
+//   - packageID: Unencoded package identifier to create.
+//   - file: Caller-owned staged package; promotion transfers its large object into persistence.
+//   - aasIDs: AAS identifiers associated with the package.
+//   - fileName: Preferred download filename.
+//
+// Returns:
+//   - *PackageRecord: Persisted package metadata.
+//   - error: Validation, conflict, inspection, promotion, or database error.
+func (p *AASXFileServerDatabase) CreatePackage(ctx context.Context, packageID string, file common.StagedUpload, aasIDs []string, fileName string) (*PackageRecord, error) {
 	record, _, err := p.putPackage(ctx, strings.TrimSpace(packageID), file, aasIDs, fileName, false)
 	if err != nil {
 		return nil, err
@@ -156,8 +172,23 @@ func (p *AASXFileServerDatabase) CreatePackage(ctx context.Context, packageID st
 	return record, nil
 }
 
-// PutPackage upserts a package and reports whether an existing package was updated.
-func (p *AASXFileServerDatabase) PutPackage(ctx context.Context, packageID string, file *os.File, aasIDs []string, fileName string) (bool, *PackageRecord, error) {
+// PutPackage atomically creates or replaces a staged package.
+//
+// When replacing a package, metadata, AAS identifiers, and the large-object OID
+// are swapped in one transaction and the previous large object is unlinked.
+//
+// Parameters:
+//   - ctx: Request context containing cancellation and configured AASX limits.
+//   - packageID: Unencoded package identifier to create or replace.
+//   - file: Caller-owned staged package; promotion transfers its large object into persistence.
+//   - aasIDs: Replacement AAS identifiers associated with the package.
+//   - fileName: Preferred replacement download filename.
+//
+// Returns:
+//   - bool: True when an existing package was replaced; false when one was created.
+//   - *PackageRecord: Persisted package metadata.
+//   - error: Validation, inspection, promotion, or database error.
+func (p *AASXFileServerDatabase) PutPackage(ctx context.Context, packageID string, file common.StagedUpload, aasIDs []string, fileName string) (bool, *PackageRecord, error) {
 	record, updated, err := p.putPackage(ctx, strings.TrimSpace(packageID), file, aasIDs, fileName, true)
 	if err != nil {
 		return false, nil, err
@@ -165,7 +196,7 @@ func (p *AASXFileServerDatabase) PutPackage(ctx context.Context, packageID strin
 	return updated, record, nil
 }
 
-func (p *AASXFileServerDatabase) putPackage(ctx context.Context, packageID string, file *os.File, aasIDs []string, fileName string, allowUpdate bool) (*PackageRecord, bool, error) {
+func (p *AASXFileServerDatabase) putPackage(ctx context.Context, packageID string, file common.StagedUpload, aasIDs []string, fileName string, allowUpdate bool) (*PackageRecord, bool, error) {
 	if strings.TrimSpace(packageID) == "" {
 		return nil, false, common.NewErrBadRequest("AASXFS-PUTPACKAGE-EMPTYPACKAGEID packageId must not be empty")
 	}
@@ -174,31 +205,37 @@ func (p *AASXFileServerDatabase) putPackage(ctx context.Context, packageID strin
 	}
 
 	normalizedAASIDs := normalizeAASIDs(aasIDs)
-
-	tx, err := p.db.BeginTx(ctx, nil)
+	resolvedFileName := normalizeFileName(fileName, "")
+	detectedContentType, err := resolvePackageContentTypeForUpload(file, resolvedFileName, common.AASXLimitsFromContext(ctx))
 	if err != nil {
-		return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-STARTTX " + err.Error())
+		return nil, false, err
 	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
+	if _, err = file.Seek(0, io.SeekStart); err != nil {
+		return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-SEEK " + err.Error())
+	}
 
+	var record *PackageRecord
+	updated := false
+	err = file.Promote(ctx, func(ctx context.Context, tx *sql.Tx, newOID int64, _ int64) error {
+		var persistErr error
+		record, updated, persistErr = persistStagedPackage(ctx, tx, packageID, newOID, normalizedAASIDs, resolvedFileName, detectedContentType, allowUpdate)
+		return persistErr
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return record, updated, nil
+}
+
+func persistStagedPackage(ctx context.Context, tx *sql.Tx, packageID string, newOID int64, aasIDs []string, fileName string, contentType string, allowUpdate bool) (*PackageRecord, bool, error) {
 	dialect := goqu.Dialect("postgres")
-	selectSQL, selectArgs, err := dialect.From("aasx_package").
-		Select("id", "file_oid", "file_name").
-		Where(goqu.C("package_id").Eq(packageID)).
-		ToSQL()
+	selectSQL, selectArgs, err := dialect.From("aasx_package").Select("id", "file_oid", "file_name").
+		Where(goqu.C("package_id").Eq(packageID)).ForUpdate(exp.Wait).ToSQL()
 	if err != nil {
 		return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-BUILDSELECT " + err.Error())
 	}
-
-	var existingID int64
-	var existingOID int64
+	var existingID, existingOID int64
 	var existingFileName string
-	// #nosec G701 -- SQL is generated by goqu with fixed table/column names and bound arguments.
 	scanErr := tx.QueryRowContext(ctx, selectSQL, selectArgs...).Scan(&existingID, &existingOID, &existingFileName)
 	exists := scanErr == nil
 	if scanErr != nil && !errors.Is(scanErr, sql.ErrNoRows) {
@@ -207,99 +244,61 @@ func (p *AASXFileServerDatabase) putPackage(ctx context.Context, packageID strin
 	if exists && !allowUpdate {
 		return nil, false, common.NewErrConflict("AASXFS-PUTPACKAGE-CONFLICT packageId already exists")
 	}
-
-	resolvedFileName := normalizeFileName(fileName, file)
-	if resolvedFileName == "" {
-		resolvedFileName = strings.TrimSpace(existingFileName)
+	if fileName == "" {
+		fileName = strings.TrimSpace(existingFileName)
 	}
-	if resolvedFileName == "" {
-		resolvedFileName = packageID + ".aasx"
+	if fileName == "" {
+		fileName = packageID + ".aasx"
 	}
-
-	newOID, detectedContentType, err := writeLargeObjectFromFile(tx, file, resolvedFileName)
-	if err != nil {
-		return nil, false, err
-	}
-
 	if exists {
-		updateSQL, updateArgs, buildErr := dialect.Update("aasx_package").
-			Set(goqu.Record{
-				"file_oid":     newOID,
-				"file_name":    resolvedFileName,
-				"content_type": detectedContentType,
-			}).
-			Where(goqu.C("id").Eq(existingID)).
-			ToSQL()
+		query, args, buildErr := dialect.Update("aasx_package").Set(goqu.Record{
+			"file_oid": newOID, "file_name": fileName, "content_type": contentType,
+		}).Where(goqu.C("id").Eq(existingID)).ToSQL()
 		if buildErr != nil {
 			return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-BUILDUPDATE " + buildErr.Error())
 		}
-		// #nosec G701 -- SQL is generated by goqu with fixed table/column names and bound arguments.
-		if _, execErr := tx.ExecContext(ctx, updateSQL, updateArgs...); execErr != nil {
+		if _, execErr := tx.ExecContext(ctx, query, args...); execErr != nil {
 			return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-UPDATE " + execErr.Error())
 		}
-
-		if err = replaceAASIDs(ctx, tx, existingID, normalizedAASIDs); err != nil {
+		if err = replaceAASIDs(ctx, tx, existingID, aasIDs); err != nil {
 			return nil, false, err
 		}
-
-		// #nosec G701 -- Query text is static and the OID is passed as a bound argument.
-		if _, unlinkErr := tx.ExecContext(ctx, `SELECT lo_unlink($1)`, existingOID); unlinkErr != nil {
-			return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-UNLINKOLDLO " + unlinkErr.Error())
+		if err = binarycontent.UnlinkOIDTx(ctx, tx, existingOID); err != nil {
+			return nil, false, err
 		}
-
-		if commitErr := tx.Commit(); commitErr != nil {
-			return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-COMMIT " + commitErr.Error())
-		}
-		committed = true
-
-		return &PackageRecord{
-			PackageID:   packageID,
-			FileName:    resolvedFileName,
-			ContentType: detectedContentType,
-			AASIDs:      normalizedAASIDs,
-		}, true, nil
+		return &PackageRecord{DBID: existingID, PackageID: packageID, FileName: fileName, ContentType: contentType, AASIDs: aasIDs}, true, nil
 	}
-
-	insertSQL, insertArgs, err := dialect.Insert("aasx_package").
-		Rows(goqu.Record{
-			"package_id":   packageID,
-			"file_oid":     newOID,
-			"file_name":    resolvedFileName,
-			"content_type": detectedContentType,
-		}).
-		Returning("id").
-		ToSQL()
+	query, args, err := dialect.Insert("aasx_package").Rows(goqu.Record{
+		"package_id": packageID, "file_oid": newOID, "file_name": fileName, "content_type": contentType,
+	}).Returning("id").ToSQL()
 	if err != nil {
 		return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-BUILDINSERT " + err.Error())
 	}
-
 	var newID int64
-	// #nosec G701 -- SQL is generated by goqu with fixed table/column names and bound arguments.
-	if err = tx.QueryRowContext(ctx, insertSQL, insertArgs...).Scan(&newID); err != nil {
+	if err = tx.QueryRowContext(ctx, query, args...).Scan(&newID); err != nil {
 		if isUniqueViolation(err) {
 			return nil, false, common.NewErrConflict("AASXFS-PUTPACKAGE-CONFLICT packageId already exists")
 		}
 		return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-INSERT " + err.Error())
 	}
-
-	if err = replaceAASIDs(ctx, tx, newID, normalizedAASIDs); err != nil {
+	if err = replaceAASIDs(ctx, tx, newID, aasIDs); err != nil {
 		return nil, false, err
 	}
-
-	if commitErr := tx.Commit(); commitErr != nil {
-		return nil, false, common.NewInternalServerError("AASXFS-PUTPACKAGE-COMMIT " + commitErr.Error())
-	}
-	committed = true
-
-	return &PackageRecord{
-		PackageID:   packageID,
-		FileName:    resolvedFileName,
-		ContentType: detectedContentType,
-		AASIDs:      normalizedAASIDs,
-	}, false, nil
+	return &PackageRecord{DBID: newID, PackageID: packageID, FileName: fileName, ContentType: contentType, AASIDs: aasIDs}, false, nil
 }
 
-// GetPackageByID returns metadata and binary content for one package ID.
+// GetPackageByID returns metadata and a streaming body for one package.
+//
+// The returned Content reader owns the read transaction. The caller must close
+// it on successful completion, copy failure, or request cancellation.
+//
+// Parameters:
+//   - ctx: Request context used for lookup, streaming, and cancellation.
+//   - packageID: Unencoded package identifier.
+//
+// Returns:
+//   - *PackageBinary: Metadata and caller-owned content stream.
+//   - error: Not-found, query, transaction, or large-object open error.
 func (p *AASXFileServerDatabase) GetPackageByID(ctx context.Context, packageID string) (*PackageBinary, error) {
 	tx, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -332,18 +331,14 @@ func (p *AASXFileServerDatabase) GetPackageByID(ctx context.Context, packageID s
 		return nil, common.NewInternalServerError("AASXFS-GETPACKAGE-QUERY " + err.Error())
 	}
 
-	content, err := readLargeObject(tx, fileOID)
-	if err != nil {
-		return nil, err
-	}
-
 	aasIDs, err := p.getAASIDsTx(ctx, tx, packageDBID)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = tx.Commit(); err != nil {
-		return nil, common.NewInternalServerError("AASXFS-GETPACKAGE-COMMIT " + err.Error())
+	content, err := binarycontent.OpenOIDTx(ctx, tx, fileOID)
+	if err != nil {
+		return nil, err
 	}
 	committed = true
 
@@ -401,8 +396,8 @@ func (p *AASXFileServerDatabase) DeletePackageByID(ctx context.Context, packageI
 		return common.NewInternalServerError("AASXFS-DELETEPACKAGE-DELETE " + err.Error())
 	}
 
-	if _, err = tx.ExecContext(ctx, `SELECT lo_unlink($1)`, fileOID); err != nil {
-		return common.NewInternalServerError("AASXFS-DELETEPACKAGE-UNLINK " + err.Error())
+	if err = binarycontent.UnlinkOIDTx(ctx, tx, fileOID); err != nil {
+		return err
 	}
 
 	if err = tx.Commit(); err != nil {
@@ -491,60 +486,7 @@ func replaceAASIDs(ctx context.Context, tx *sql.Tx, packageDBID int64, aasIDs []
 	return nil
 }
 
-func writeLargeObjectFromFile(tx *sql.Tx, file *os.File, fileName string) (int64, string, error) {
-	filePath := filepath.Clean(file.Name())
-	// #nosec G703 -- file.Name() points to server-created temp files from multipart parsing.
-	reopenedFile, err := os.Open(filePath)
-	if err != nil {
-		return 0, "", common.NewErrBadRequest("AASXFS-WRITELO-OPENFILE " + err.Error())
-	}
-	defer func() { _ = reopenedFile.Close() }()
-
-	contentType, err := resolvePackageContentTypeForUpload(reopenedFile, fileName)
-	if err != nil {
-		return 0, "", err
-	}
-
-	if _, err = reopenedFile.Seek(0, 0); err != nil {
-		return 0, "", common.NewInternalServerError("AASXFS-WRITELO-SEEK " + err.Error())
-	}
-
-	var fileOID int64
-	if err = tx.QueryRow(`SELECT lo_create(0)`).Scan(&fileOID); err != nil {
-		return 0, "", common.NewInternalServerError("AASXFS-WRITELO-CREATE " + err.Error())
-	}
-
-	var loFD int
-	if err = tx.QueryRow(`SELECT lo_open($1, $2)`, fileOID, largeObjectWriteMode).Scan(&loFD); err != nil {
-		return 0, "", common.NewInternalServerError("AASXFS-WRITELO-OPEN " + err.Error())
-	}
-
-	buffer := make([]byte, 8192)
-	for {
-		chunkSize, readErr := reopenedFile.Read(buffer)
-		if chunkSize > 0 {
-			if _, writeErr := tx.Exec(`SELECT lowrite($1, $2)`, loFD, buffer[:chunkSize]); writeErr != nil {
-				_, _ = tx.Exec(`SELECT lo_close($1)`, loFD)
-				return 0, "", common.NewInternalServerError("AASXFS-WRITELO-WRITE " + writeErr.Error())
-			}
-		}
-		if readErr != nil {
-			if readErr == io.EOF {
-				break
-			}
-			_, _ = tx.Exec(`SELECT lo_close($1)`, loFD)
-			return 0, "", common.NewInternalServerError("AASXFS-WRITELO-READ " + readErr.Error())
-		}
-	}
-
-	if _, err = tx.Exec(`SELECT lo_close($1)`, loFD); err != nil {
-		return 0, "", common.NewInternalServerError("AASXFS-WRITELO-CLOSE " + err.Error())
-	}
-
-	return fileOID, contentType, nil
-}
-
-func resolvePackageContentTypeForUpload(file *os.File, fileName string) (string, error) {
+func resolvePackageContentTypeForUpload(file io.ReadSeeker, fileName string, limits common.AASXLimits) (string, error) {
 	if file == nil {
 		return "", common.NewErrBadRequest("AASXFS-RESOLVEMIME-NILFILE package file must not be nil")
 	}
@@ -562,7 +504,10 @@ func resolvePackageContentTypeForUpload(file *os.File, fileName string) (string,
 
 	resolvedContentType, _ := common.ResolveUploadedContentType(detectedContentType, "", fileName)
 
-	aasxContentType, aasxErr := detectAASXEnvironmentContentType(file)
+	aasxContentType, aasxErr := detectAASXEnvironmentContentType(file, limits)
+	if errors.Is(aasxErr, aasx.ErrReaderLimitExceeded) {
+		return "", common.NewErrPayloadTooLarge("AASXFS-RESOLVEMIME-AASXLIMIT " + aasxErr.Error())
+	}
 	if aasxErr == nil && aasxContentType != "" {
 		resolvedContentType = aasxContentType
 	}
@@ -574,7 +519,7 @@ func resolvePackageContentTypeForUpload(file *os.File, fileName string) (string,
 	return resolvedContentType, nil
 }
 
-func detectAASXEnvironmentContentType(file *os.File) (string, error) {
+func detectAASXEnvironmentContentType(file io.ReadSeeker, limits common.AASXLimits) (string, error) {
 	if file == nil {
 		return "", common.NewErrBadRequest("AASXFS-DETECTAASX-NILFILE package file must not be nil")
 	}
@@ -584,7 +529,7 @@ func detectAASXEnvironmentContentType(file *os.File) (string, error) {
 	}
 
 	packaging := aasx.NewPackaging()
-	packageReader, err := packaging.OpenReadFromStream(file)
+	packageReader, err := packaging.OpenReadFromStream(file, limits.ReaderOptions()...)
 	if err != nil {
 		return "", err
 	}
@@ -646,33 +591,6 @@ func normalizeAASXPartPath(specPart *aasx.Part) string {
 	return strings.ToLower(uriPath)
 }
 
-func readLargeObject(tx *sql.Tx, fileOID int64) ([]byte, error) {
-	var loFD int
-	if err := tx.QueryRow(`SELECT lo_open($1, $2)`, fileOID, largeObjectReadMode).Scan(&loFD); err != nil {
-		return nil, common.NewInternalServerError("AASXFS-READLO-OPEN " + err.Error())
-	}
-
-	content := make([]byte, 0, 8192)
-	for {
-		var bytesRead []byte
-		err := tx.QueryRow(`SELECT loread($1, $2)`, loFD, 8192).Scan(&bytesRead)
-		if err != nil {
-			_, _ = tx.Exec(`SELECT lo_close($1)`, loFD)
-			return nil, common.NewInternalServerError("AASXFS-READLO-READ " + err.Error())
-		}
-		if len(bytesRead) == 0 {
-			break
-		}
-		content = append(content, bytesRead...)
-	}
-
-	if _, err := tx.Exec(`SELECT lo_close($1)`, loFD); err != nil {
-		return nil, common.NewInternalServerError("AASXFS-READLO-CLOSE " + err.Error())
-	}
-
-	return content, nil
-}
-
 func normalizeAASIDs(aasIDs []string) []string {
 	seen := make(map[string]struct{}, len(aasIDs))
 	result := make([]string, 0, len(aasIDs))
@@ -695,20 +613,12 @@ func normalizeAASIDs(aasIDs []string) []string {
 	return result
 }
 
-func normalizeFileName(providedFileName string, tempFile *os.File) string {
+func normalizeFileName(providedFileName string, fallbackFileName string) string {
 	trimmed := strings.TrimSpace(providedFileName)
 	if trimmed != "" {
 		return filepath.Base(trimmed)
 	}
-	if tempFile == nil {
-		return ""
-	}
-
-	base := filepath.Base(tempFile.Name())
-	if idx := strings.LastIndex(base, "."); idx > 0 {
-		base = base[:idx]
-	}
-	return strings.TrimSpace(base)
+	return strings.TrimSpace(filepath.Base(fallbackFileName))
 }
 
 func isUniqueViolation(err error) bool {

--- a/internal/aasxfileserver/persistence/aasx_database_test.go
+++ b/internal/aasxfileserver/persistence/aasx_database_test.go
@@ -26,6 +26,7 @@
 package persistence
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,6 +51,18 @@ func TestParseCursorID(t *testing.T) {
 
 	_, err = ParseCursorID("abc")
 	require.Error(t, err)
+}
+
+func TestResolvePackageContentTypeRejectsMalformedAASX(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolvePackageContentTypeForUpload(
+		bytes.NewReader([]byte("not an AASX package")),
+		"invalid.aasx",
+		common.AASXLimitsFromConfig(nil),
+	)
+	require.Error(t, err)
+	require.True(t, common.IsErrBadRequest(err), "expected bad request, got %v", err)
 }
 
 func TestNormalizeAASIDs(t *testing.T) {

--- a/internal/aasxfileserver/persistence/aasx_database_test.go
+++ b/internal/aasxfileserver/persistence/aasx_database_test.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,14 +62,8 @@ func TestNormalizeAASIDs(t *testing.T) {
 func TestNormalizeFileName(t *testing.T) {
 	t.Parallel()
 
-	tempFile, err := os.CreateTemp("", "upload-file.aasx.*")
-	require.NoError(t, err)
-	// #nosec G703 -- tempFile.Name() is provided by os.CreateTemp in this test.
-	defer func() { _ = os.Remove(tempFile.Name()) }()
-	defer func() { _ = tempFile.Close() }()
-
-	require.Equal(t, "provided.aasx", normalizeFileName("  provided.aasx ", tempFile))
-	require.Equal(t, "upload-file.aasx", normalizeFileName("", tempFile))
+	require.Equal(t, "provided.aasx", normalizeFileName("  provided.aasx ", "upload-file.aasx"))
+	require.Equal(t, "upload-file.aasx", normalizeFileName("", "upload-file.aasx"))
 }
 
 func TestDetectAASXEnvironmentContentType(t *testing.T) {
@@ -101,7 +96,7 @@ func TestDetectAASXEnvironmentContentType(t *testing.T) {
 			require.NoError(t, err)
 			defer func() { _ = tempFile.Close() }()
 
-			resolved, err := detectAASXEnvironmentContentType(tempFile)
+			resolved, err := detectAASXEnvironmentContentType(tempFile, common.AASXLimitsFromConfig(nil))
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, resolved)
 		})

--- a/internal/common/aasx_limits.go
+++ b/internal/common/aasx_limits.go
@@ -1,0 +1,147 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	aasx "github.com/aas-core-works/aas-package3-golang/v2"
+)
+
+const (
+	defaultAASXMaxPartCount              = 10000
+	defaultAASXMaxOPCMetadataSizeBytes   = 16 << 20
+	defaultAASXMaxPartExpandedSizeBytes  = 128 << 20
+	defaultAASXMaxTotalExpandedSizeBytes = 128 << 20
+	defaultAASXMaxThumbnailSizeBytes     = 16 << 20
+)
+
+// AASXLimits contains the bounded-memory limits applied to AASX readers and writers.
+// All values are required to be positive after configuration defaults are applied.
+type AASXLimits struct {
+	// MaxPartCount is the maximum number of non-directory ZIP entries.
+	MaxPartCount uint64
+	// MaxOPCMetadataSizeBytes is the maximum combined expanded OPC metadata size.
+	MaxOPCMetadataSizeBytes uint64
+	// MaxPartExpandedSizeBytes is the maximum expanded size of one payload part.
+	MaxPartExpandedSizeBytes uint64
+	// MaxTotalExpandedSizeBytes is the maximum combined expanded payload size.
+	MaxTotalExpandedSizeBytes uint64
+	// MaxThumbnailSizeBytes is the maximum expanded thumbnail size.
+	MaxThumbnailSizeBytes uint64
+}
+
+// AASXLimitsFromConfig resolves bounded-memory AASX limits from configuration.
+//
+// Parameters:
+//   - cfg: Process configuration. Nil or non-positive fields use secure defaults.
+//
+// Returns:
+//   - AASXLimits: Fully populated limits suitable for package processing.
+func AASXLimitsFromConfig(cfg *Config) AASXLimits {
+	if cfg == nil {
+		return defaultAASXLimits()
+	}
+	limits := AASXLimits{
+		MaxPartCount:              positiveUint64FromInt(cfg.General.AASXMaxPartCount, defaultAASXMaxPartCount),
+		MaxOPCMetadataSizeBytes:   positiveUint64(cfg.General.AASXMaxOPCMetadataSizeBytes, defaultAASXMaxOPCMetadataSizeBytes),
+		MaxPartExpandedSizeBytes:  positiveUint64(cfg.General.AASXMaxPartExpandedSizeBytes, defaultAASXMaxPartExpandedSizeBytes),
+		MaxTotalExpandedSizeBytes: positiveUint64(cfg.General.AASXMaxTotalExpandedSizeBytes, defaultAASXMaxTotalExpandedSizeBytes),
+		MaxThumbnailSizeBytes:     positiveUint64(cfg.General.AASXMaxThumbnailSizeBytes, defaultAASXMaxThumbnailSizeBytes),
+	}
+	return limits
+}
+
+// AASXLimitsFromContext resolves AASX limits from request-scoped configuration.
+//
+// Parameters:
+//   - ctx: Request context populated by ConfigMiddleware.
+//
+// Returns:
+//   - AASXLimits: Request limits, or secure defaults when no configuration exists.
+func AASXLimitsFromContext(ctx context.Context) AASXLimits {
+	cfg, _ := ConfigFromContext(ctx)
+	return AASXLimitsFromConfig(cfg)
+}
+
+// ReaderOptions converts limits to aas-package3 lazy-reader options.
+//
+// Returns:
+//   - []aasx.ReaderOption: Options covering entry count, metadata, per-part, and total expansion.
+func (limits AASXLimits) ReaderOptions() []aasx.ReaderOption {
+	return []aasx.ReaderOption{
+		aasx.WithMaxPartCount(limits.MaxPartCount),
+		aasx.WithMaxOPCMetadataBytes(limits.MaxOPCMetadataSizeBytes),
+		aasx.WithMaxPartExpandedBytes(limits.MaxPartExpandedSizeBytes),
+		aasx.WithMaxTotalExpandedBytes(limits.MaxTotalExpandedSizeBytes),
+	}
+}
+
+// CheckPartSize validates one expanded package part before it is consumed.
+//
+// Parameters:
+//   - size: Expanded part size in bytes.
+//   - thumbnail: Whether to apply the stricter thumbnail limit.
+//
+// Returns:
+//   - error: A 413-classified error when the applicable limit is exceeded.
+func (limits AASXLimits) CheckPartSize(size uint64, thumbnail bool) error {
+	maximum := limits.MaxPartExpandedSizeBytes
+	label := "part"
+	if thumbnail {
+		maximum = limits.MaxThumbnailSizeBytes
+		label = "thumbnail"
+	}
+	if size > maximum {
+		return NewErrPayloadTooLarge(fmt.Sprintf("AASX-LIMIT-%s expanded %s size %d exceeds configured maximum %d", label, label, size, maximum))
+	}
+	return nil
+}
+
+func defaultAASXLimits() AASXLimits {
+	return AASXLimits{
+		MaxPartCount:              defaultAASXMaxPartCount,
+		MaxOPCMetadataSizeBytes:   defaultAASXMaxOPCMetadataSizeBytes,
+		MaxPartExpandedSizeBytes:  defaultAASXMaxPartExpandedSizeBytes,
+		MaxTotalExpandedSizeBytes: defaultAASXMaxTotalExpandedSizeBytes,
+		MaxThumbnailSizeBytes:     defaultAASXMaxThumbnailSizeBytes,
+	}
+}
+
+func positiveUint64FromInt(value int, fallback uint64) uint64 {
+	if value <= 0 {
+		return fallback
+	}
+	return uint64(value)
+}
+
+func positiveUint64(value int64, fallback uint64) uint64 {
+	if value <= 0 {
+		return fallback
+	}
+	return uint64(value)
+}

--- a/internal/common/aasx_limits_test.go
+++ b/internal/common/aasx_limits_test.go
@@ -1,0 +1,127 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"bytes"
+	"errors"
+	"net/url"
+	"testing"
+
+	aasx "github.com/aas-core-works/aas-package3-golang/v2"
+)
+
+func TestAASXLimitsFromConfigMapsConfiguredValues(t *testing.T) {
+	cfg := &Config{General: GeneralConfig{
+		AASXMaxPartCount:              17,
+		AASXMaxOPCMetadataSizeBytes:   23,
+		AASXMaxPartExpandedSizeBytes:  31,
+		AASXMaxTotalExpandedSizeBytes: 47,
+		AASXMaxThumbnailSizeBytes:     13,
+	}}
+
+	limits := AASXLimitsFromConfig(cfg)
+	if limits.MaxPartCount != 17 || limits.MaxOPCMetadataSizeBytes != 23 ||
+		limits.MaxPartExpandedSizeBytes != 31 || limits.MaxTotalExpandedSizeBytes != 47 ||
+		limits.MaxThumbnailSizeBytes != 13 {
+		t.Fatalf("unexpected mapped limits: %+v", limits)
+	}
+}
+
+func TestAASXReaderOptionsEnforceEveryConfiguredReaderLimit(t *testing.T) {
+	packageBytes := buildAASXLimitFixture(t, bytes.Repeat([]byte("x"), 64))
+	tests := []struct {
+		name   string
+		limits AASXLimits
+	}{
+		{
+			name: "part count",
+			limits: AASXLimits{MaxPartCount: 1, MaxOPCMetadataSizeBytes: 1 << 20,
+				MaxPartExpandedSizeBytes: 1 << 20, MaxTotalExpandedSizeBytes: 1 << 20},
+		},
+		{
+			name: "OPC metadata",
+			limits: AASXLimits{MaxPartCount: 100, MaxOPCMetadataSizeBytes: 1,
+				MaxPartExpandedSizeBytes: 1 << 20, MaxTotalExpandedSizeBytes: 1 << 20},
+		},
+		{
+			name: "part expansion",
+			limits: AASXLimits{MaxPartCount: 100, MaxOPCMetadataSizeBytes: 1 << 20,
+				MaxPartExpandedSizeBytes: 32, MaxTotalExpandedSizeBytes: 1 << 20},
+		},
+		{
+			name: "total expansion",
+			limits: AASXLimits{MaxPartCount: 100, MaxOPCMetadataSizeBytes: 1 << 20,
+				MaxPartExpandedSizeBytes: 1 << 20, MaxTotalExpandedSizeBytes: 32},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader, err := aasx.NewPackaging().OpenReadFromStream(bytes.NewReader(packageBytes), test.limits.ReaderOptions()...)
+			if reader != nil {
+				_ = reader.Close()
+			}
+			if !errors.Is(err, aasx.ErrReaderLimitExceeded) {
+				t.Fatalf("expected reader-limit error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAASXLimitsCheckThumbnailUsesStricterLimit(t *testing.T) {
+	limits := AASXLimits{MaxPartExpandedSizeBytes: 128, MaxThumbnailSizeBytes: 16}
+	if err := limits.CheckPartSize(17, false); err != nil {
+		t.Fatalf("ordinary part should be accepted: %v", err)
+	}
+	if err := limits.CheckPartSize(17, true); !IsErrPayloadTooLarge(err) {
+		t.Fatalf("expected typed thumbnail limit error, got %v", err)
+	}
+}
+
+func buildAASXLimitFixture(t *testing.T, specification []byte) []byte {
+	t.Helper()
+	var destination bytes.Buffer
+	writer, err := aasx.NewPackaging().CreateWriter(&destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	specificationURI, err := url.Parse("/aasx/content.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	specificationPart, err := writer.PutPartFromStream(specificationURI, "application/json", bytes.NewReader(specification))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.MakeSpec(specificationPart); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return destination.Bytes()
+}

--- a/internal/common/binarycontent/staged_large_object.go
+++ b/internal/common/binarycontent/staged_large_object.go
@@ -1,0 +1,334 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package binarycontent
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+)
+
+// StagedLargeObject owns a transaction-scoped PostgreSQL large object.
+// Its transaction remains open until Promote commits it or Close rolls it back.
+type StagedLargeObject struct {
+	ctx        context.Context
+	tx         *sql.Tx
+	oid        int64
+	size       int64
+	descriptor int
+	reader     *largeObjectReader
+	closed     bool
+	mu         sync.Mutex
+}
+
+// NewStager binds a database pool for request upload staging.
+//
+// Parameters:
+//   - db: PostgreSQL connection pool used to create transaction-scoped large objects.
+//
+// Returns:
+//   - common.UploadStager: Reusable staging function bound to db.
+//
+// Example:
+//
+//	stager := binarycontent.NewStager(db)
+//	upload, err := stager(ctx, requestBody, 128<<20)
+func NewStager(db *sql.DB) common.UploadStager {
+	return func(ctx context.Context, input io.Reader, maxSizeBytes int64) (common.StagedUpload, error) {
+		return Stage(ctx, db, input, maxSizeBytes)
+	}
+}
+
+// Stage streams input into a transaction-scoped large object.
+//
+// Parameters:
+//   - ctx: Request context used for database calls and cancellation.
+//   - db: PostgreSQL connection pool.
+//   - input: Source payload.
+//   - maxSizeBytes: Maximum accepted payload size.
+//
+// Returns:
+//   - common.StagedUpload: Caller-owned seekable object; Close it unless promoted.
+//   - error: Coded validation, payload-limit, or database error.
+func Stage(ctx context.Context, db *sql.DB, input io.Reader, maxSizeBytes int64) (common.StagedUpload, error) {
+	if db == nil {
+		return nil, common.NewInternalServerError("BINARYCONTENT-STAGE-NILDB database handle is required")
+	}
+	if input == nil {
+		return nil, common.NewErrBadRequest("BINARYCONTENT-STAGE-NILREADER upload payload is required")
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, common.NewInternalServerError("BINARYCONTENT-STAGE-STARTTX " + err.Error())
+	}
+	oid, _, size, err := writeTransientLargeObjectTx(ctx, tx, input, maxSizeBytes)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	return &StagedLargeObject{ctx: ctx, tx: tx, oid: oid, size: size, descriptor: -1}, nil
+}
+
+// Size returns the number of staged bytes.
+//
+// Returns:
+//   - int64: Staged payload size, or zero for a nil receiver.
+func (stage *StagedLargeObject) Size() int64 {
+	if stage == nil {
+		return 0
+	}
+	return stage.size
+}
+
+// Read implements io.Reader for the staged large object.
+//
+// Parameters:
+//   - destination: Buffer receiving staged bytes.
+//
+// Returns:
+//   - int: Number of bytes read.
+//   - error: Read, context, transaction, or EOF result.
+func (stage *StagedLargeObject) Read(destination []byte) (int, error) {
+	stage.mu.Lock()
+	defer stage.mu.Unlock()
+	if err := stage.ensureReaderLocked(); err != nil {
+		return 0, err
+	}
+	return stage.reader.Read(destination)
+}
+
+// Seek implements io.Seeker for the staged large object.
+//
+// Parameters:
+//   - offset: Offset interpreted relative to whence.
+//   - whence: One of io.SeekStart, io.SeekCurrent, or io.SeekEnd.
+//
+// Returns:
+//   - int64: New absolute read position.
+//   - error: Seek, context, or transaction error.
+func (stage *StagedLargeObject) Seek(offset int64, whence int) (int64, error) {
+	stage.mu.Lock()
+	defer stage.mu.Unlock()
+	if err := stage.ensureReaderLocked(); err != nil {
+		return 0, err
+	}
+	return stage.reader.Seek(offset, whence)
+}
+
+// Promote atomically commits the staged object after persist associates its OID.
+//
+// Parameters:
+//   - ctx: Request context used for final persistence and commit.
+//   - persist: Callback receiving the staging transaction, large-object OID, and byte size.
+//
+// Returns:
+//   - error: Callback or commit error. On error, the caller must still call Close.
+func (stage *StagedLargeObject) Promote(ctx context.Context, persist func(context.Context, *sql.Tx, int64, int64) error) error {
+	if stage == nil || persist == nil {
+		return common.NewInternalServerError("BINARYCONTENT-PROMOTE-INVALID stage and persistence callback are required")
+	}
+	stage.mu.Lock()
+	defer stage.mu.Unlock()
+	if stage.closed {
+		return common.NewInternalServerError("BINARYCONTENT-PROMOTE-CLOSED staged upload is closed")
+	}
+	if err := stage.closeReaderLocked(ctx); err != nil {
+		return err
+	}
+	if err := persist(ctx, stage.tx, stage.oid, stage.size); err != nil {
+		return err
+	}
+	if err := stage.tx.Commit(); err != nil {
+		return common.NewInternalServerError("BINARYCONTENT-PROMOTE-COMMIT " + err.Error())
+	}
+	stage.closed = true
+	return nil
+}
+
+// Close discards an unpromoted staged object by rolling back its transaction.
+// It is idempotent and leaves successfully promoted objects intact.
+//
+// Returns:
+//   - error: Large-object descriptor or transaction cleanup error.
+func (stage *StagedLargeObject) Close() error {
+	if stage == nil {
+		return nil
+	}
+	stage.mu.Lock()
+	defer stage.mu.Unlock()
+	if stage.closed {
+		return nil
+	}
+	closeErr := stage.closeReaderLocked(stage.ctx)
+	rollbackErr := stage.tx.Rollback()
+	stage.closed = true
+	if closeErr != nil {
+		return closeErr
+	}
+	if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+		return common.NewInternalServerError("BINARYCONTENT-STAGE-ROLLBACK " + rollbackErr.Error())
+	}
+	return nil
+}
+
+func (stage *StagedLargeObject) ensureReaderLocked() error {
+	if stage == nil || stage.closed {
+		return common.NewInternalServerError("BINARYCONTENT-STAGE-CLOSED staged upload is closed")
+	}
+	if stage.reader != nil {
+		return nil
+	}
+	query, args, err := goqu.Select(goqu.Func("lo_open", stage.oid, largeObjectReadMode)).ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("BINARYCONTENT-STAGE-BUILDOPEN " + err.Error())
+	}
+	if err = stage.tx.QueryRowContext(stage.ctx, query, args...).Scan(&stage.descriptor); err != nil {
+		return common.NewInternalServerError("BINARYCONTENT-STAGE-OPEN " + err.Error())
+	}
+	stage.reader = &largeObjectReader{ctx: stage.ctx, tx: stage.tx, descriptor: stage.descriptor}
+	return nil
+}
+
+func (stage *StagedLargeObject) closeReaderLocked(ctx context.Context) error {
+	if stage.reader == nil {
+		return nil
+	}
+	err := closeLargeObjectTx(ctx, stage.tx, stage.descriptor)
+	stage.reader = nil
+	stage.descriptor = -1
+	return err
+}
+
+type transactionLargeObjectReader struct {
+	ctx        context.Context
+	tx         *sql.Tx
+	descriptor int
+	reader     *largeObjectReader
+	closed     bool
+	mu         sync.Mutex
+}
+
+// OpenOID opens a PostgreSQL large object for bounded-memory response streaming.
+//
+// Parameters:
+//   - ctx: Request context used for reads and cancellation.
+//   - db: PostgreSQL connection pool.
+//   - oid: PostgreSQL large-object identifier.
+//
+// Returns:
+//   - io.ReadCloser: Reader owning its database transaction; callers must close it.
+//   - error: Coded transaction or large-object open error.
+func OpenOID(ctx context.Context, db *sql.DB, oid int64) (io.ReadCloser, error) {
+	if db == nil {
+		return nil, common.NewInternalServerError("BINARYCONTENT-OPENOID-NILDB database handle is required")
+	}
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, common.NewInternalServerError("BINARYCONTENT-OPENOID-STARTTX " + err.Error())
+	}
+	reader, err := OpenOIDTx(ctx, tx, oid)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, err
+	}
+	return reader, nil
+}
+
+// OpenOIDTx opens a large object and transfers transaction ownership to the reader.
+//
+// Parameters:
+//   - ctx: Request context used for reads and cancellation.
+//   - tx: Existing transaction whose ownership transfers to the returned reader.
+//   - oid: PostgreSQL large-object identifier.
+//
+// Returns:
+//   - io.ReadCloser: Reader that closes the descriptor and rolls back tx on Close.
+//   - error: Coded validation or large-object open error; tx remains caller-owned on failure.
+func OpenOIDTx(ctx context.Context, tx *sql.Tx, oid int64) (io.ReadCloser, error) {
+	if tx == nil {
+		return nil, common.NewInternalServerError("BINARYCONTENT-OPENOID-NILTX transaction is required")
+	}
+	query, args, err := goqu.Select(goqu.Func("lo_open", oid, largeObjectReadMode)).ToSQL()
+	if err != nil {
+		return nil, common.NewInternalServerError("BINARYCONTENT-OPENOID-BUILDOPEN " + err.Error())
+	}
+	var descriptor int
+	if err = tx.QueryRowContext(ctx, query, args...).Scan(&descriptor); err != nil {
+		return nil, common.NewInternalServerError("BINARYCONTENT-OPENOID-OPEN " + err.Error())
+	}
+	return &transactionLargeObjectReader{
+		ctx: ctx, tx: tx, descriptor: descriptor,
+		reader: &largeObjectReader{ctx: ctx, tx: tx, descriptor: descriptor},
+	}, nil
+}
+
+func (reader *transactionLargeObjectReader) Read(destination []byte) (int, error) {
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	if reader.closed {
+		return 0, io.ErrClosedPipe
+	}
+	return reader.reader.Read(destination)
+}
+
+func (reader *transactionLargeObjectReader) Close() error {
+	if reader == nil {
+		return nil
+	}
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	if reader.closed {
+		return nil
+	}
+	closeErr := closeLargeObjectTx(reader.ctx, reader.tx, reader.descriptor)
+	rollbackErr := reader.tx.Rollback()
+	reader.closed = true
+	if closeErr != nil {
+		return closeErr
+	}
+	if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+		return common.NewInternalServerError("BINARYCONTENT-OPENOID-ROLLBACK " + rollbackErr.Error())
+	}
+	return nil
+}
+
+// UnlinkOIDTx deletes a PostgreSQL large object in the caller's transaction.
+//
+// Parameters:
+//   - ctx: Request context used for the delete operation.
+//   - tx: Transaction that owns the delete operation.
+//   - oid: PostgreSQL large-object identifier to unlink.
+//
+// Returns:
+//   - error: Coded query-build or execution error.
+func UnlinkOIDTx(ctx context.Context, tx *sql.Tx, oid int64) error {
+	return unlinkLargeObjectTx(ctx, tx, oid)
+}

--- a/internal/common/binarycontent/staged_large_object_test.go
+++ b/internal/common/binarycontent/staged_large_object_test.go
@@ -1,0 +1,103 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package binarycontent
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func expectStagedLargeObjectWrite(mock sqlmock.Sqlmock, content string) {
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT lo_create`).WillReturnRows(sqlmock.NewRows([]string{"lo_create"}).AddRow(17))
+	mock.ExpectQuery(`SELECT lo_open`).WillReturnRows(sqlmock.NewRows([]string{"lo_open"}).AddRow(23))
+	mock.ExpectQuery(`SELECT lowrite`).WillReturnRows(sqlmock.NewRows([]string{"lowrite"}).AddRow(len(content)))
+	mock.ExpectExec(`SELECT lo_close`).WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func TestStagedLargeObjectCloseRollsBack(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectStagedLargeObjectWrite(mock, "package")
+	mock.ExpectRollback()
+
+	staged, err := Stage(t.Context(), db, strings.NewReader("package"), 1024)
+	require.NoError(t, err)
+	require.Equal(t, int64(len("package")), staged.Size())
+	require.NoError(t, staged.Close())
+	require.NoError(t, staged.Close())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStagedLargeObjectPromoteCommits(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectStagedLargeObjectWrite(mock, "package")
+	mock.ExpectCommit()
+
+	staged, err := Stage(t.Context(), db, strings.NewReader("package"), 1024)
+	require.NoError(t, err)
+	err = staged.Promote(t.Context(), func(_ context.Context, tx *sql.Tx, oid int64, size int64) error {
+		require.NotNil(t, tx)
+		require.Equal(t, int64(17), oid)
+		require.Equal(t, int64(len("package")), size)
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, staged.Close())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOpenOIDClosesDescriptorAndTransaction(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT lo_open`).WillReturnRows(sqlmock.NewRows([]string{"lo_open"}).AddRow(23))
+	mock.ExpectQuery(`SELECT loread`).WillReturnRows(sqlmock.NewRows([]string{"loread"}).AddRow([]byte("package")))
+	mock.ExpectQuery(`SELECT loread`).WillReturnRows(sqlmock.NewRows([]string{"loread"}).AddRow([]byte{}))
+	mock.ExpectExec(`SELECT lo_close`).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectRollback()
+
+	reader, err := OpenOID(t.Context(), db, 17)
+	require.NoError(t, err)
+	content, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, "package", string(content))
+	require.NoError(t, reader.Close())
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/common/binarycontent/store.go
+++ b/internal/common/binarycontent/store.go
@@ -37,6 +37,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"net/url"
 	"path"
 	"sort"
@@ -272,7 +273,7 @@ func writeTransientLargeObjectTx(ctx context.Context, tx *sql.Tx, reader io.Read
 		count, readErr := reader.Read(buffer)
 		if count > 0 {
 			if maxSizeBytes > 0 && int64(count) > maxSizeBytes-size {
-				return 0, "", 0, common.NewErrBadRequest(fmt.Sprintf("BINARYCONTENT-STORE-TOOLARGE upload exceeds configured maximum of %d bytes", maxSizeBytes))
+				return 0, "", 0, common.NewErrPayloadTooLarge(fmt.Sprintf("BINARYCONTENT-STORE-TOOLARGE upload exceeds configured maximum of %d bytes", maxSizeBytes))
 			}
 			chunk := buffer[:count]
 			if _, err = hash.Write(chunk); err != nil {
@@ -297,6 +298,13 @@ func writeTransientLargeObjectTx(ctx context.Context, tx *sql.Tx, reader io.Read
 		if readErr != nil {
 			if errors.Is(readErr, io.EOF) {
 				break
+			}
+			if common.IsErrPayloadTooLarge(readErr) {
+				return 0, "", 0, readErr
+			}
+			var maxBytesError *http.MaxBytesError
+			if errors.As(readErr, &maxBytesError) {
+				return 0, "", 0, common.NewErrPayloadTooLarge(fmt.Sprintf("BINARYCONTENT-STORE-TOOLARGE upload exceeds configured maximum of %d bytes", maxSizeBytes))
 			}
 			return 0, "", 0, common.NewInternalServerError("BINARYCONTENT-STORE-READ " + readErr.Error())
 		}
@@ -423,6 +431,20 @@ func ReadOIDTx(ctx context.Context, tx *sql.Tx, oid int64) ([]byte, error) {
 // callback while the caller's transaction remains open.
 func StreamTx(ctx context.Context, tx *sql.Tx, content Content, consume func(io.Reader) error) error {
 	return streamOIDTx(ctx, tx, content.OID, consume)
+}
+
+// StreamOIDTx streams a PostgreSQL large object in the caller's transaction.
+//
+// Parameters:
+//   - ctx: Request context used for reads and cancellation.
+//   - tx: Existing transaction containing the large object.
+//   - oid: PostgreSQL large-object identifier.
+//   - consume: Callback that must consume the reader before returning.
+//
+// Returns:
+//   - error: Consumer, descriptor-close, query, or context error.
+func StreamOIDTx(ctx context.Context, tx *sql.Tx, oid int64, consume func(io.Reader) error) error {
+	return streamOIDTx(ctx, tx, oid, consume)
 }
 
 func streamOIDTx(ctx context.Context, tx *sql.Tx, oid int64, consume func(io.Reader) error) error {

--- a/internal/common/binarycontent/store_test.go
+++ b/internal/common/binarycontent/store_test.go
@@ -133,7 +133,7 @@ func TestStoreTxRejectsContentAboveConfiguredLimitBeforeWriting(t *testing.T) {
 
 	_, _, _, err = writeTransientLargeObjectTx(ctx, tx, strings.NewReader("four"), common.UploadMaxSizeBytesFromContext(ctx))
 	require.ErrorContains(t, err, "BINARYCONTENT-STORE-TOOLARGE")
-	require.True(t, common.IsErrBadRequest(err))
+	require.True(t, common.IsErrPayloadTooLarge(err))
 	require.NoError(t, tx.Rollback())
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/common/configuration.go
+++ b/internal/common/configuration.go
@@ -49,137 +49,147 @@ const defaultServerStrictVerification = string(commonmodel.VerificationModePermi
 // DefaultConfig holds all default values for configuration options.
 // These values are also used to mark default values in the printed configuration.
 var DefaultConfig = struct {
-	ServerHost                          string
-	ServerPort                          int
-	ServerContextPath                   string
-	ServerCacheEnabled                  bool
-	ServerStrictVerification            string
-	ServerVerificationEndpointAvailable bool
-	ServerReadHeaderTimeoutSeconds      int
-	ServerReadTimeoutSeconds            int
-	ServerWriteTimeoutSeconds           int
-	ServerIdleTimeoutSeconds            int
-	ServerShutdownTimeoutSeconds        int
-	PgPort                              int
-	PgDBName                            string
-	PgSSLMode                           string
-	PgMaxOpen                           int
-	PgMaxIdle                           int
-	PgConnLifetime                      int
-	AllowedOrigins                      []string
-	AllowedMethods                      []string
-	AllowedHeaders                      []string
-	AllowCredentials                    bool
-	OIDCTrustlistPath                   string
-	OIDCJWKSURL                         string
-	ABACEnabled                         bool
-	ABACModelPath                       string
-	ABACPolicyFileImport                string
-	ABACPolicyScope                     string
-	ABACManagementAPIEnabled            bool
-	GeneralImplicitCasts                bool
-	GeneralDescriptorDebug              bool
-	GeneralDiscoveryIntegration         bool
-	GeneralSupportsSingularSSID         bool
-	GeneralEnableCustomHeaderMW         bool
-	GeneralTrustProxyHeaders            bool
-	GeneralTrustedProxyCIDRs            []string
-	GeneralAASPreconfigPaths            []string
-	GeneralBulkBatchLimit               int
-	GeneralUploadMaxSizeBytes           int64
-	HistoryConfigMode                   string
-	HistoryConfigRetentionDays          int
-	HistoryConfigFullSnapshotInterval   int
-	HistoryConfigImmutability           string
-	HistoryConfigAuditIdentityMode      string
-	HistoryEvidenceEnabled              bool
-	HistoryEvidenceProvider             string
-	HistoryEvidenceBucket               string
-	HistoryEvidencePrefix               string
-	HistoryEvidenceRegion               string
-	HistoryEvidenceEndpoint             string
-	HistoryEvidenceAccessKeyID          string
-	HistoryEvidenceSecretAccessKey      string
-	HistoryEvidenceUsePathStyle         bool
-	HistoryEvidenceRetentionMode        string
-	HistoryEvidenceRetentionDays        int
-	HistoryEvidenceWriteTimeoutSeconds  int
-	HistoryEvidenceSigningPrivateKey    string
-	HistoryEvidenceSigningPublicKey     string
-	HistoryEvidenceSigningRequired      bool
-	HistoryIntegrityAnchorProvider      string
-	EventingEnabled                     bool
-	EventingFormat                      string
-	EventingSinks                       []string
-	EventingOutboxEnabled               bool
-	EventingTopicPrefix                 string
-	SwaggerEnabled                      bool
+	ServerHost                           string
+	ServerPort                           int
+	ServerContextPath                    string
+	ServerCacheEnabled                   bool
+	ServerStrictVerification             string
+	ServerVerificationEndpointAvailable  bool
+	ServerReadHeaderTimeoutSeconds       int
+	ServerReadTimeoutSeconds             int
+	ServerWriteTimeoutSeconds            int
+	ServerIdleTimeoutSeconds             int
+	ServerShutdownTimeoutSeconds         int
+	PgPort                               int
+	PgDBName                             string
+	PgSSLMode                            string
+	PgMaxOpen                            int
+	PgMaxIdle                            int
+	PgConnLifetime                       int
+	AllowedOrigins                       []string
+	AllowedMethods                       []string
+	AllowedHeaders                       []string
+	AllowCredentials                     bool
+	OIDCTrustlistPath                    string
+	OIDCJWKSURL                          string
+	ABACEnabled                          bool
+	ABACModelPath                        string
+	ABACPolicyFileImport                 string
+	ABACPolicyScope                      string
+	ABACManagementAPIEnabled             bool
+	GeneralImplicitCasts                 bool
+	GeneralDescriptorDebug               bool
+	GeneralDiscoveryIntegration          bool
+	GeneralSupportsSingularSSID          bool
+	GeneralEnableCustomHeaderMW          bool
+	GeneralTrustProxyHeaders             bool
+	GeneralTrustedProxyCIDRs             []string
+	GeneralAASPreconfigPaths             []string
+	GeneralBulkBatchLimit                int
+	GeneralUploadMaxSizeBytes            int64
+	GeneralAASXMaxPartCount              int
+	GeneralAASXMaxOPCMetadataSizeBytes   int64
+	GeneralAASXMaxPartExpandedSizeBytes  int64
+	GeneralAASXMaxTotalExpandedSizeBytes int64
+	GeneralAASXMaxThumbnailSizeBytes     int64
+	HistoryConfigMode                    string
+	HistoryConfigRetentionDays           int
+	HistoryConfigFullSnapshotInterval    int
+	HistoryConfigImmutability            string
+	HistoryConfigAuditIdentityMode       string
+	HistoryEvidenceEnabled               bool
+	HistoryEvidenceProvider              string
+	HistoryEvidenceBucket                string
+	HistoryEvidencePrefix                string
+	HistoryEvidenceRegion                string
+	HistoryEvidenceEndpoint              string
+	HistoryEvidenceAccessKeyID           string
+	HistoryEvidenceSecretAccessKey       string
+	HistoryEvidenceUsePathStyle          bool
+	HistoryEvidenceRetentionMode         string
+	HistoryEvidenceRetentionDays         int
+	HistoryEvidenceWriteTimeoutSeconds   int
+	HistoryEvidenceSigningPrivateKey     string
+	HistoryEvidenceSigningPublicKey      string
+	HistoryEvidenceSigningRequired       bool
+	HistoryIntegrityAnchorProvider       string
+	EventingEnabled                      bool
+	EventingFormat                       string
+	EventingSinks                        []string
+	EventingOutboxEnabled                bool
+	EventingTopicPrefix                  string
+	SwaggerEnabled                       bool
 }{
-	ServerHost:                          "0.0.0.0",
-	ServerPort:                          5004,
-	ServerContextPath:                   "",
-	ServerCacheEnabled:                  false,
-	ServerStrictVerification:            defaultServerStrictVerification,
-	ServerVerificationEndpointAvailable: true,
-	ServerReadHeaderTimeoutSeconds:      15,
-	ServerReadTimeoutSeconds:            300,
-	ServerWriteTimeoutSeconds:           300,
-	ServerIdleTimeoutSeconds:            60,
-	ServerShutdownTimeoutSeconds:        10,
-	PgPort:                              5432,
-	PgDBName:                            "basyxTestDB",
-	PgSSLMode:                           "disable",
-	PgMaxOpen:                           50,
-	PgMaxIdle:                           50,
-	PgConnLifetime:                      5,
-	AllowedOrigins:                      []string{},
-	AllowedMethods:                      []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-	AllowedHeaders:                      []string{},
-	AllowCredentials:                    false,
-	OIDCTrustlistPath:                   "config/trustlist.json",
-	OIDCJWKSURL:                         "",
-	ABACEnabled:                         false,
-	ABACModelPath:                       "config/access_rules/access-rules.json",
-	ABACPolicyFileImport:                "",
-	ABACPolicyScope:                     "",
-	ABACManagementAPIEnabled:            false,
-	GeneralImplicitCasts:                true,
-	GeneralDescriptorDebug:              false,
-	GeneralDiscoveryIntegration:         false,
-	GeneralSupportsSingularSSID:         false,
-	GeneralEnableCustomHeaderMW:         false,
-	GeneralTrustProxyHeaders:            false,
-	GeneralTrustedProxyCIDRs:            []string{},
-	GeneralAASPreconfigPaths:            []string{},
-	GeneralBulkBatchLimit:               1000,
-	GeneralUploadMaxSizeBytes:           128 << 20,
-	HistoryConfigMode:                   "off",
-	HistoryConfigRetentionDays:          0,
-	HistoryConfigFullSnapshotInterval:   1,
-	HistoryConfigImmutability:           "none",
-	HistoryConfigAuditIdentityMode:      "none",
-	HistoryEvidenceEnabled:              false,
-	HistoryEvidenceProvider:             "none",
-	HistoryEvidenceBucket:               "",
-	HistoryEvidencePrefix:               "basyx-history-evidence",
-	HistoryEvidenceRegion:               "us-east-1",
-	HistoryEvidenceEndpoint:             "",
-	HistoryEvidenceAccessKeyID:          "",
-	HistoryEvidenceSecretAccessKey:      "",
-	HistoryEvidenceUsePathStyle:         false,
-	HistoryEvidenceRetentionMode:        "",
-	HistoryEvidenceRetentionDays:        0,
-	HistoryEvidenceWriteTimeoutSeconds:  10,
-	HistoryEvidenceSigningPrivateKey:    "",
-	HistoryEvidenceSigningPublicKey:     "",
-	HistoryEvidenceSigningRequired:      false,
-	HistoryIntegrityAnchorProvider:      "none",
-	EventingEnabled:                     false,
-	EventingFormat:                      "cloudevents",
-	EventingSinks:                       []string{},
-	EventingOutboxEnabled:               false,
-	EventingTopicPrefix:                 "basyx",
-	SwaggerEnabled:                      true,
+	ServerHost:                           "0.0.0.0",
+	ServerPort:                           5004,
+	ServerContextPath:                    "",
+	ServerCacheEnabled:                   false,
+	ServerStrictVerification:             defaultServerStrictVerification,
+	ServerVerificationEndpointAvailable:  true,
+	ServerReadHeaderTimeoutSeconds:       15,
+	ServerReadTimeoutSeconds:             300,
+	ServerWriteTimeoutSeconds:            300,
+	ServerIdleTimeoutSeconds:             60,
+	ServerShutdownTimeoutSeconds:         10,
+	PgPort:                               5432,
+	PgDBName:                             "basyxTestDB",
+	PgSSLMode:                            "disable",
+	PgMaxOpen:                            50,
+	PgMaxIdle:                            50,
+	PgConnLifetime:                       5,
+	AllowedOrigins:                       []string{},
+	AllowedMethods:                       []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+	AllowedHeaders:                       []string{},
+	AllowCredentials:                     false,
+	OIDCTrustlistPath:                    "config/trustlist.json",
+	OIDCJWKSURL:                          "",
+	ABACEnabled:                          false,
+	ABACModelPath:                        "config/access_rules/access-rules.json",
+	ABACPolicyFileImport:                 "",
+	ABACPolicyScope:                      "",
+	ABACManagementAPIEnabled:             false,
+	GeneralImplicitCasts:                 true,
+	GeneralDescriptorDebug:               false,
+	GeneralDiscoveryIntegration:          false,
+	GeneralSupportsSingularSSID:          false,
+	GeneralEnableCustomHeaderMW:          false,
+	GeneralTrustProxyHeaders:             false,
+	GeneralTrustedProxyCIDRs:             []string{},
+	GeneralAASPreconfigPaths:             []string{},
+	GeneralBulkBatchLimit:                1000,
+	GeneralUploadMaxSizeBytes:            128 << 20,
+	GeneralAASXMaxPartCount:              defaultAASXMaxPartCount,
+	GeneralAASXMaxOPCMetadataSizeBytes:   defaultAASXMaxOPCMetadataSizeBytes,
+	GeneralAASXMaxPartExpandedSizeBytes:  defaultAASXMaxPartExpandedSizeBytes,
+	GeneralAASXMaxTotalExpandedSizeBytes: defaultAASXMaxTotalExpandedSizeBytes,
+	GeneralAASXMaxThumbnailSizeBytes:     defaultAASXMaxThumbnailSizeBytes,
+	HistoryConfigMode:                    "off",
+	HistoryConfigRetentionDays:           0,
+	HistoryConfigFullSnapshotInterval:    1,
+	HistoryConfigImmutability:            "none",
+	HistoryConfigAuditIdentityMode:       "none",
+	HistoryEvidenceEnabled:               false,
+	HistoryEvidenceProvider:              "none",
+	HistoryEvidenceBucket:                "",
+	HistoryEvidencePrefix:                "basyx-history-evidence",
+	HistoryEvidenceRegion:                "us-east-1",
+	HistoryEvidenceEndpoint:              "",
+	HistoryEvidenceAccessKeyID:           "",
+	HistoryEvidenceSecretAccessKey:       "",
+	HistoryEvidenceUsePathStyle:          false,
+	HistoryEvidenceRetentionMode:         "",
+	HistoryEvidenceRetentionDays:         0,
+	HistoryEvidenceWriteTimeoutSeconds:   10,
+	HistoryEvidenceSigningPrivateKey:     "",
+	HistoryEvidenceSigningPublicKey:      "",
+	HistoryEvidenceSigningRequired:       false,
+	HistoryIntegrityAnchorProvider:       "none",
+	EventingEnabled:                      false,
+	EventingFormat:                       "cloudevents",
+	EventingSinks:                        []string{},
+	EventingOutboxEnabled:                false,
+	EventingTopicPrefix:                  "basyx",
+	SwaggerEnabled:                       true,
 }
 
 const (
@@ -379,6 +389,11 @@ type GeneralConfig struct {
 	TrustProxyHeaders                      bool     `mapstructure:"trustProxyHeaders" yaml:"trustProxyHeaders" json:"trustProxyHeaders"`                                                                // Trust Forwarded/X-Forwarded-* headers when request source matches trustedProxyCIDRs
 	TrustedProxyCIDRs                      []string `mapstructure:"trustedProxyCIDRs" yaml:"trustedProxyCIDRs" json:"trustedProxyCIDRs"`                                                                // CIDR allowlist for proxy source addresses eligible to provide forwarded headers
 	UploadMaxSizeBytes                     int64    `mapstructure:"uploadMaxSizeBytes" yaml:"uploadMaxSizeBytes" json:"uploadMaxSizeBytes"`                                                             // Maximum allowed upload payload size in bytes
+	AASXMaxPartCount                       int      `mapstructure:"aasxMaxPartCount" yaml:"aasxMaxPartCount" json:"aasxMaxPartCount"`                                                                   // Maximum non-directory entries in an AASX package
+	AASXMaxOPCMetadataSizeBytes            int64    `mapstructure:"aasxMaxOPCMetadataSizeBytes" yaml:"aasxMaxOPCMetadataSizeBytes" json:"aasxMaxOPCMetadataSizeBytes"`                                  // Maximum combined expanded OPC metadata size
+	AASXMaxPartExpandedSizeBytes           int64    `mapstructure:"aasxMaxPartExpandedSizeBytes" yaml:"aasxMaxPartExpandedSizeBytes" json:"aasxMaxPartExpandedSizeBytes"`                               // Maximum expanded size of one AASX payload part
+	AASXMaxTotalExpandedSizeBytes          int64    `mapstructure:"aasxMaxTotalExpandedSizeBytes" yaml:"aasxMaxTotalExpandedSizeBytes" json:"aasxMaxTotalExpandedSizeBytes"`                            // Maximum combined expanded AASX payload size
+	AASXMaxThumbnailSizeBytes              int64    `mapstructure:"aasxMaxThumbnailSizeBytes" yaml:"aasxMaxThumbnailSizeBytes" json:"aasxMaxThumbnailSizeBytes"`                                        // Maximum expanded size of an AASX thumbnail
 	AASPreconfigPaths                      []string `mapstructure:"aasPreconfigPaths" yaml:"aasPreconfigPaths" json:"aasPreconfigPaths"`                                                                // Files/directories loaded at startup for AAS preconfiguration
 	BulkBatchLimit                         int      `mapstructure:"bulkBatchLimit" yaml:"bulkBatchLimit" json:"bulkBatchLimit"`                                                                         // Maximum row count per generated bulk SQL statement
 }
@@ -559,6 +574,24 @@ func validateGeneralConfig(cfg *Config) error {
 	}
 	if cfg.General.BulkBatchLimit <= 0 {
 		return fmt.Errorf("CONFIG-GENERAL-BULKBATCHLIMIT general.bulkBatchLimit must be greater than 0")
+	}
+	if cfg.General.UploadMaxSizeBytes <= 0 {
+		return fmt.Errorf("CONFIG-GENERAL-UPLOADMAXSIZE general.uploadMaxSizeBytes must be greater than 0")
+	}
+	if cfg.General.AASXMaxPartCount <= 0 {
+		return fmt.Errorf("CONFIG-GENERAL-AASXPARTCOUNT general.aasxMaxPartCount must be greater than 0")
+	}
+	if cfg.General.AASXMaxOPCMetadataSizeBytes <= 0 {
+		return fmt.Errorf("CONFIG-GENERAL-AASXOPCMETADATA general.aasxMaxOPCMetadataSizeBytes must be greater than 0")
+	}
+	if cfg.General.AASXMaxPartExpandedSizeBytes <= 0 {
+		return fmt.Errorf("CONFIG-GENERAL-AASXPARTSIZE general.aasxMaxPartExpandedSizeBytes must be greater than 0")
+	}
+	if cfg.General.AASXMaxTotalExpandedSizeBytes < cfg.General.AASXMaxPartExpandedSizeBytes {
+		return fmt.Errorf("CONFIG-GENERAL-AASXTOTALSIZE general.aasxMaxTotalExpandedSizeBytes must be greater than or equal to general.aasxMaxPartExpandedSizeBytes")
+	}
+	if cfg.General.AASXMaxThumbnailSizeBytes <= 0 || cfg.General.AASXMaxThumbnailSizeBytes > cfg.General.AASXMaxPartExpandedSizeBytes {
+		return fmt.Errorf("CONFIG-GENERAL-AASXTHUMBNAILSIZE general.aasxMaxThumbnailSizeBytes must be greater than 0 and no greater than general.aasxMaxPartExpandedSizeBytes")
 	}
 	return nil
 }
@@ -1149,6 +1182,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("general.trustProxyHeaders", DefaultConfig.GeneralTrustProxyHeaders)
 	v.SetDefault("general.trustedProxyCIDRs", DefaultConfig.GeneralTrustedProxyCIDRs)
 	v.SetDefault("general.uploadMaxSizeBytes", DefaultConfig.GeneralUploadMaxSizeBytes)
+	v.SetDefault("general.aasxMaxPartCount", DefaultConfig.GeneralAASXMaxPartCount)
+	v.SetDefault("general.aasxMaxOPCMetadataSizeBytes", DefaultConfig.GeneralAASXMaxOPCMetadataSizeBytes)
+	v.SetDefault("general.aasxMaxPartExpandedSizeBytes", DefaultConfig.GeneralAASXMaxPartExpandedSizeBytes)
+	v.SetDefault("general.aasxMaxTotalExpandedSizeBytes", DefaultConfig.GeneralAASXMaxTotalExpandedSizeBytes)
+	v.SetDefault("general.aasxMaxThumbnailSizeBytes", DefaultConfig.GeneralAASXMaxThumbnailSizeBytes)
 	v.SetDefault("general.aasPreconfigPaths", []string{})
 	v.SetDefault("general.bulkBatchLimit", DefaultConfig.GeneralBulkBatchLimit)
 
@@ -1250,6 +1288,11 @@ func PrintConfiguration(cfg *Config) {
 	lines = append(lines, "General:")
 	add("Bulk Batch Limit", cfg.General.BulkBatchLimit, DefaultConfig.GeneralBulkBatchLimit)
 	add("Upload Max Size (bytes)", cfg.General.UploadMaxSizeBytes, DefaultConfig.GeneralUploadMaxSizeBytes)
+	add("AASX Max Part Count", cfg.General.AASXMaxPartCount, DefaultConfig.GeneralAASXMaxPartCount)
+	add("AASX Max OPC Metadata Size (bytes)", cfg.General.AASXMaxOPCMetadataSizeBytes, DefaultConfig.GeneralAASXMaxOPCMetadataSizeBytes)
+	add("AASX Max Part Expanded Size (bytes)", cfg.General.AASXMaxPartExpandedSizeBytes, DefaultConfig.GeneralAASXMaxPartExpandedSizeBytes)
+	add("AASX Max Total Expanded Size (bytes)", cfg.General.AASXMaxTotalExpandedSizeBytes, DefaultConfig.GeneralAASXMaxTotalExpandedSizeBytes)
+	add("AASX Max Thumbnail Size (bytes)", cfg.General.AASXMaxThumbnailSizeBytes, DefaultConfig.GeneralAASXMaxThumbnailSizeBytes)
 
 	lines = append(lines, divider)
 

--- a/internal/common/configuration_test.go
+++ b/internal/common/configuration_test.go
@@ -675,6 +675,41 @@ func TestValidateHistoryAndEventingConfigAcceptsDiffBackedSnapshotInterval(t *te
 	}
 }
 
+func TestValidateGeneralConfigAASXLimits(t *testing.T) {
+	valid := GeneralConfig{
+		BulkBatchLimit:                1000,
+		UploadMaxSizeBytes:            128 << 20,
+		AASXMaxPartCount:              10000,
+		AASXMaxOPCMetadataSizeBytes:   16 << 20,
+		AASXMaxPartExpandedSizeBytes:  128 << 20,
+		AASXMaxTotalExpandedSizeBytes: 128 << 20,
+		AASXMaxThumbnailSizeBytes:     16 << 20,
+	}
+	if err := validateGeneralConfig(&Config{General: valid}); err != nil {
+		t.Fatalf("expected valid AASX limits, got %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*GeneralConfig)
+	}{
+		{name: "part count", mutate: func(cfg *GeneralConfig) { cfg.AASXMaxPartCount = 0 }},
+		{name: "OPC metadata", mutate: func(cfg *GeneralConfig) { cfg.AASXMaxOPCMetadataSizeBytes = 0 }},
+		{name: "part size", mutate: func(cfg *GeneralConfig) { cfg.AASXMaxPartExpandedSizeBytes = 0 }},
+		{name: "total below part", mutate: func(cfg *GeneralConfig) { cfg.AASXMaxTotalExpandedSizeBytes = cfg.AASXMaxPartExpandedSizeBytes - 1 }},
+		{name: "thumbnail above part", mutate: func(cfg *GeneralConfig) { cfg.AASXMaxThumbnailSizeBytes = cfg.AASXMaxPartExpandedSizeBytes + 1 }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := valid
+			test.mutate(&candidate)
+			if err := validateGeneralConfig(&Config{General: candidate}); err == nil {
+				t.Fatal("expected invalid AASX limits to be rejected")
+			}
+		})
+	}
+}
+
 func TestValidateHistoryAndEventingConfigAcceptsCompleteS3EvidenceConfig(t *testing.T) {
 	cfg := Config{
 		JWS: JWSConfig{PrivateKeyPath: "fallback-key.pem"},

--- a/internal/common/endpoints.go
+++ b/internal/common/endpoints.go
@@ -43,7 +43,7 @@ import (
 	aastypes "github.com/FriedJannik/aas-go-sdk/types"
 	"github.com/FriedJannik/aas-go-sdk/verification"
 	aasxmlization "github.com/FriedJannik/aas-go-sdk/xmlization"
-	aasx "github.com/aas-core-works/aas-package3-golang"
+	aasx "github.com/aas-core-works/aas-package3-golang/v2"
 	"github.com/go-chi/chi/v5"
 )
 

--- a/internal/common/error_handler.go
+++ b/internal/common/error_handler.go
@@ -43,6 +43,14 @@ type sqlStateError interface {
 	SQLState() string
 }
 
+type payloadTooLargeError struct {
+	message string
+}
+
+func (err *payloadTooLargeError) Error() string {
+	return "413 Payload Too Large: " + err.message
+}
+
 // IsPostgresErrorCode reports whether an error has a PostgreSQL SQLSTATE.
 //
 // The function unwraps err and checks any error that exposes SQLState().
@@ -136,6 +144,22 @@ func NewErrNotFound(elementID string) error {
 //	// Returns error: "400 Bad Request: invalid JSON format"
 func NewErrBadRequest(message string) error {
 	return errors.New("400 Bad Request: " + message)
+}
+
+// NewErrPayloadTooLarge creates a standardized "413 Payload Too Large" error.
+//
+// Parameters:
+//   - message: Description of which configured payload limit was exceeded
+//
+// Returns:
+//   - error: An error with message format "413 Payload Too Large: <message>"
+//
+// Example:
+//
+//	err := NewErrPayloadTooLarge("upload exceeds configured maximum")
+//	// Returns error: "413 Payload Too Large: upload exceeds configured maximum"
+func NewErrPayloadTooLarge(message string) error {
+	return &payloadTooLargeError{message: message}
 }
 
 // NewInternalServerError creates a standardized "500 Internal Server Error" error.
@@ -249,6 +273,25 @@ func IsErrBadRequest(err error) bool {
 	return hasErrorPrefix(err, "400 Bad Request: ")
 }
 
+// IsErrPayloadTooLarge checks if the given error is a "413 Payload Too Large" error.
+//
+// Parameters:
+//   - err: Error to inspect
+//
+// Returns:
+//   - bool: true if the error is a 413 Payload Too Large error, false otherwise
+//
+// Example:
+//
+//	err := NewErrPayloadTooLarge("request too large")
+//	if IsErrPayloadTooLarge(err) {
+//	    // Handle the exceeded payload limit.
+//	}
+func IsErrPayloadTooLarge(err error) bool {
+	var typedError *payloadTooLargeError
+	return errors.As(err, &typedError) || hasErrorPrefix(err, "413 Payload Too Large: ")
+}
+
 // IsInternalServerError checks if the given error is a "500 Internal Server Error" error.
 //
 // Parameters:
@@ -356,10 +399,27 @@ func NewErrorResponse(err error, errorCode int, component string, function strin
 	if IsErrServiceUnavailable(err) {
 		errorCode = http.StatusServiceUnavailable
 	}
+	if IsErrPayloadTooLarge(err) {
+		errorCode = http.StatusRequestEntityTooLarge
+	}
 	return model.NewErrorResponse(err, errorCode, component, function, info)
 }
 
-// WriteErrorResponse writes a standardized error response.
+// WriteErrorResponse writes a standardized JSON error response.
+//
+// Typed common errors may override status; for example, a payload-limit error
+// is always emitted as HTTP 413.
+//
+// Parameters:
+//   - w: Destination response writer.
+//   - err: Error exposed in the structured response.
+//   - status: Fallback HTTP status code.
+//   - component: Component name used in the correlation code.
+//   - function: Operation name used in the correlation code.
+//   - info: Step name used in the correlation code.
+//
+// Returns:
+//   - error: JSON encoding or response-write error.
 func WriteErrorResponse(w http.ResponseWriter, err error, status int, component, function, info string) error {
 	response := NewErrorResponse(err, status, component, function, info)
 	return model.EncodeJSONResponse(response.Body, &response.Code, w)

--- a/internal/common/error_handler_test.go
+++ b/internal/common/error_handler_test.go
@@ -51,6 +51,11 @@ func TestErrorClassifiers_RecognizeWrappedErrors(t *testing.T) {
 			assert: IsErrBadRequest,
 		},
 		{
+			name:   "payload too large",
+			err:    fmt.Errorf("outer: %w", NewErrPayloadTooLarge("x")),
+			assert: IsErrPayloadTooLarge,
+		},
+		{
 			name:   "internal server",
 			err:    fmt.Errorf("outer: %w", NewInternalServerError("x")),
 			assert: IsInternalServerError,

--- a/internal/common/multipart_upload.go
+++ b/internal/common/multipart_upload.go
@@ -35,7 +35,11 @@ import (
 	"strings"
 )
 
-const maxMultipartMetadataBytes int64 = 1 << 20
+const (
+	maxMultipartMetadataBytes      int64 = 1 << 20
+	maxMultipartTotalMetadataBytes int64 = 2 << 20
+	maxMultipartPartCount                = 256
+)
 
 type multipartFileStager func(context.Context, string, string, io.Reader, int64) (StagedUpload, error)
 
@@ -157,6 +161,8 @@ func readMultipartUploadFields(
 		acceptedFileFields[field] = struct{}{}
 	}
 	result := &MultipartUpload{Fields: make(map[string][]string)}
+	partCount := 0
+	var metadataBytes int64
 	cleanup := true
 	defer func() {
 		if cleanup {
@@ -171,6 +177,11 @@ func readMultipartUploadFields(
 		}
 		if nextErr != nil {
 			return nil, normalizeMultipartReadError(nextErr, maxRequestBytes)
+		}
+		partCount++
+		if partCount > maxMultipartPartCount {
+			_ = part.Close()
+			return nil, NewErrPayloadTooLarge(fmt.Sprintf("COMMON-MULTIPART-PARTCOUNT request contains more than %d parts", maxMultipartPartCount))
 		}
 
 		name := part.FormName()
@@ -191,6 +202,10 @@ func readMultipartUploadFields(
 			}
 			continue
 		}
+		if strings.TrimSpace(part.FileName()) != "" {
+			_ = part.Close()
+			return nil, NewErrBadRequest(fmt.Sprintf("COMMON-MULTIPART-UNEXPECTEDFILE file part %q is not supported", name))
+		}
 
 		value, readErr := io.ReadAll(io.LimitReader(part, maxMultipartMetadataBytes+1))
 		closeErr := part.Close()
@@ -203,6 +218,10 @@ func readMultipartUploadFields(
 		if int64(len(value)) > maxMultipartMetadataBytes {
 			return nil, NewErrPayloadTooLarge(fmt.Sprintf("COMMON-MULTIPART-METADATA field %q exceeds %d bytes", name, maxMultipartMetadataBytes))
 		}
+		metadataBytes += int64(len(value))
+		if metadataBytes > maxMultipartTotalMetadataBytes {
+			return nil, NewErrPayloadTooLarge(fmt.Sprintf("COMMON-MULTIPART-METADATATOTAL metadata exceeds %d bytes", maxMultipartTotalMetadataBytes))
+		}
 		result.Fields[name] = append(result.Fields[name], string(value))
 	}
 
@@ -214,7 +233,7 @@ func readMultipartUploadFields(
 }
 
 func normalizeMultipartReadError(err error, maximum int64) error {
-	if IsErrPayloadTooLarge(err) {
+	if IsErrPayloadTooLarge(err) || IsInternalServerError(err) || IsErrServiceUnavailable(err) {
 		return err
 	}
 	var maxBytesError *http.MaxBytesError

--- a/internal/common/multipart_upload.go
+++ b/internal/common/multipart_upload.go
@@ -1,0 +1,225 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+const maxMultipartMetadataBytes int64 = 1 << 20
+
+type multipartFileStager func(context.Context, string, string, io.Reader, int64) (StagedUpload, error)
+
+// MultipartUpload contains one staged file and its text form fields.
+type MultipartUpload struct {
+	// File is the staged, seekable file payload and must be closed by the caller.
+	File StagedUpload
+	// MultipartFileName is the filename declared by the multipart file part.
+	MultipartFileName string
+	// FileContentType is the media type declared by the multipart file part.
+	FileContentType string
+	// Fields contains all non-file form values in encounter order.
+	Fields map[string][]string
+}
+
+// Close discards the staged file unless it has already been promoted.
+//
+// Returns:
+//   - error: Cleanup error, or nil when already closed/promoted.
+func (upload *MultipartUpload) Close() error {
+	if upload == nil || upload.File == nil {
+		return nil
+	}
+	return upload.File.Close()
+}
+
+// FirstField returns the first form value for a field.
+//
+// Parameters:
+//   - name: Multipart form field name.
+//
+// Returns:
+//   - string: First value, or an empty string when absent.
+func (upload *MultipartUpload) FirstField(name string) string {
+	if upload == nil {
+		return ""
+	}
+	values := upload.Fields[name]
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+// ReadMultipartUpload parses a request sequentially and stages exactly one file part.
+//
+// Parameters:
+//   - w: Response writer used by http.MaxBytesReader.
+//   - r: Multipart HTTP request.
+//   - maxRequestBytes: Maximum complete request size, including multipart framing.
+//   - fileField: Accepted file-part field name.
+//   - stager: External seekable-storage provider.
+//
+// Returns:
+//   - *MultipartUpload: Parsed metadata and caller-owned staged file.
+//   - error: Coded 400, 413, or internal staging error.
+func ReadMultipartUpload(
+	w http.ResponseWriter,
+	r *http.Request,
+	maxRequestBytes int64,
+	fileField string,
+	stager UploadStager,
+) (*MultipartUpload, error) {
+	return ReadMultipartUploadFields(w, r, maxRequestBytes, stager, fileField)
+}
+
+// ReadMultipartUploadFields stages exactly one part matching any supplied field name.
+//
+// Parameters:
+//   - w: Response writer used by http.MaxBytesReader.
+//   - r: Multipart HTTP request.
+//   - maxRequestBytes: Maximum complete request size, including multipart framing.
+//   - stager: External seekable-storage provider.
+//   - fileFields: Accepted file-part field names.
+//
+// Returns:
+//   - *MultipartUpload: Parsed metadata and caller-owned staged file.
+//   - error: Coded 400, 413, or internal staging error.
+func ReadMultipartUploadFields(
+	w http.ResponseWriter,
+	r *http.Request,
+	maxRequestBytes int64,
+	stager UploadStager,
+	fileFields ...string,
+) (*MultipartUpload, error) {
+	if stager == nil {
+		return nil, NewInternalServerError("COMMON-MULTIPART-NILSTAGER upload stager is required")
+	}
+	return readMultipartUploadFields(w, r, maxRequestBytes, func(ctx context.Context, _ string, _ string, input io.Reader, maximum int64) (StagedUpload, error) {
+		return stager(ctx, input, maximum)
+	}, fileFields...)
+}
+
+func readMultipartUploadFields(
+	w http.ResponseWriter,
+	r *http.Request,
+	maxRequestBytes int64,
+	stager multipartFileStager,
+	fileFields ...string,
+) (*MultipartUpload, error) {
+	if r == nil || stager == nil {
+		return nil, NewInternalServerError("COMMON-MULTIPART-INVALID request and upload stager are required")
+	}
+	if maxRequestBytes <= 0 {
+		maxRequestBytes = DefaultConfig.GeneralUploadMaxSizeBytes
+	}
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || !strings.EqualFold(mediaType, "multipart/form-data") {
+		return nil, NewErrBadRequest("COMMON-MULTIPART-CONTENTTYPE multipart/form-data is required")
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBytes)
+	reader, err := r.MultipartReader()
+	if err != nil {
+		return nil, NewErrBadRequest("COMMON-MULTIPART-CREATEREADER " + err.Error())
+	}
+
+	acceptedFileFields := make(map[string]struct{}, len(fileFields))
+	for _, field := range fileFields {
+		acceptedFileFields[field] = struct{}{}
+	}
+	result := &MultipartUpload{Fields: make(map[string][]string)}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = result.Close()
+		}
+	}()
+
+	for {
+		part, nextErr := reader.NextPart()
+		if errors.Is(nextErr, io.EOF) {
+			break
+		}
+		if nextErr != nil {
+			return nil, normalizeMultipartReadError(nextErr, maxRequestBytes)
+		}
+
+		name := part.FormName()
+		if _, isFile := acceptedFileFields[name]; isFile {
+			if result.File != nil {
+				_ = part.Close()
+				return nil, NewErrBadRequest("COMMON-MULTIPART-DUPLICATEFILE exactly one file part is allowed")
+			}
+			result.MultipartFileName = strings.TrimSpace(part.FileName())
+			result.FileContentType = strings.TrimSpace(part.Header.Get("Content-Type"))
+			result.File, err = stager(r.Context(), result.MultipartFileName, result.FileContentType, part, maxRequestBytes)
+			closeErr := part.Close()
+			if err != nil {
+				return nil, normalizeMultipartReadError(err, maxRequestBytes)
+			}
+			if closeErr != nil {
+				return nil, normalizeMultipartReadError(closeErr, maxRequestBytes)
+			}
+			continue
+		}
+
+		value, readErr := io.ReadAll(io.LimitReader(part, maxMultipartMetadataBytes+1))
+		closeErr := part.Close()
+		if readErr != nil {
+			return nil, normalizeMultipartReadError(readErr, maxRequestBytes)
+		}
+		if closeErr != nil {
+			return nil, normalizeMultipartReadError(closeErr, maxRequestBytes)
+		}
+		if int64(len(value)) > maxMultipartMetadataBytes {
+			return nil, NewErrPayloadTooLarge(fmt.Sprintf("COMMON-MULTIPART-METADATA field %q exceeds %d bytes", name, maxMultipartMetadataBytes))
+		}
+		result.Fields[name] = append(result.Fields[name], string(value))
+	}
+
+	if result.File == nil {
+		return nil, NewErrBadRequest(fmt.Sprintf("COMMON-MULTIPART-MISSINGFILE one of multipart file fields %q is required", fileFields))
+	}
+	cleanup = false
+	return result, nil
+}
+
+func normalizeMultipartReadError(err error, maximum int64) error {
+	if IsErrPayloadTooLarge(err) {
+		return err
+	}
+	var maxBytesError *http.MaxBytesError
+	if errors.As(err, &maxBytesError) {
+		return NewErrPayloadTooLarge(fmt.Sprintf("COMMON-MULTIPART-TOOLARGE request exceeds configured maximum of %d bytes", maximum))
+	}
+	return NewErrBadRequest("COMMON-MULTIPART-READ " + err.Error())
+}

--- a/internal/common/multipart_upload_test.go
+++ b/internal/common/multipart_upload_test.go
@@ -1,0 +1,185 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type multipartMemoryStage struct {
+	*bytes.Reader
+}
+
+func (stage *multipartMemoryStage) Size() int64  { return stage.Reader.Size() }
+func (stage *multipartMemoryStage) Close() error { return nil }
+func (stage *multipartMemoryStage) Promote(context.Context, func(context.Context, *sql.Tx, int64, int64) error) error {
+	return nil
+}
+
+func multipartMemoryStager(_ context.Context, input io.Reader, maximum int64) (StagedUpload, error) {
+	content, err := io.ReadAll(io.LimitReader(input, maximum+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(content)) > maximum {
+		return nil, NewErrPayloadTooLarge("COMMON-MULTIPARTTEST-TOOLARGE payload exceeds limit")
+	}
+	return &multipartMemoryStage{Reader: bytes.NewReader(content)}, nil
+}
+
+func TestReadMultipartUploadAcceptsMetadataAfterFile(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	file, err := writer.CreateFormFile("file", "fallback.aasx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = file.Write([]byte("package")); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.WriteField("fileName", "selected.aasx"); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.WriteField("aasIds", "one,two"); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	upload, err := ReadMultipartUpload(httptest.NewRecorder(), request, 4096, "file", multipartMemoryStager)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	defer func() { _ = upload.Close() }()
+	if upload.FirstField("fileName") != "selected.aasx" || upload.MultipartFileName != "fallback.aasx" {
+		t.Fatalf("unexpected upload metadata: %+v", upload)
+	}
+	content, err := io.ReadAll(upload.File)
+	if err != nil || string(content) != "package" {
+		t.Fatalf("unexpected staged content %q: %v", string(content), err)
+	}
+}
+
+func TestReadMultipartUploadAcceptsMetadataBeforeFile(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("fileName", "selected.aasx"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.WriteField("aasIds", "one,two"); err != nil {
+		t.Fatal(err)
+	}
+	file, err := writer.CreateFormFile("file", "fallback.aasx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = file.Write([]byte("package")); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	upload, err := ReadMultipartUpload(httptest.NewRecorder(), request, 4096, "file", multipartMemoryStager)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	defer func() { _ = upload.Close() }()
+	if upload.FirstField("fileName") != "selected.aasx" || upload.FirstField("aasIds") != "one,two" {
+		t.Fatalf("unexpected upload metadata: %+v", upload)
+	}
+}
+
+func TestReadMultipartUploadRejectsMissingFile(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("fileName", "selected.aasx"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	if _, err := ReadMultipartUpload(httptest.NewRecorder(), request, 4096, "file", multipartMemoryStager); !IsErrBadRequest(err) {
+		t.Fatalf("expected bad request for missing file, got %v", err)
+	}
+}
+
+func TestReadMultipartUploadRejectsDuplicateFiles(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for _, name := range []string{"first.aasx", "second.aasx"} {
+		part, err := writer.CreateFormFile("file", name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = part.Write([]byte(name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	if _, err := ReadMultipartUpload(httptest.NewRecorder(), request, 4096, "file", multipartMemoryStager); !IsErrBadRequest(err) {
+		t.Fatalf("expected bad request for duplicate files, got %v", err)
+	}
+}
+
+func TestReadMultipartUploadRejectsOversizedRequest(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "large.aasx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = part.Write(bytes.Repeat([]byte("x"), 1024)); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	if _, err = ReadMultipartUpload(httptest.NewRecorder(), request, 128, "file", multipartMemoryStager); !IsErrPayloadTooLarge(err) {
+		t.Fatalf("expected payload-too-large error, got %v", err)
+	}
+}

--- a/internal/common/multipart_upload_test.go
+++ b/internal/common/multipart_upload_test.go
@@ -183,3 +183,101 @@ func TestReadMultipartUploadRejectsOversizedRequest(t *testing.T) {
 		t.Fatalf("expected payload-too-large error, got %v", err)
 	}
 }
+
+func TestReadMultipartUploadPreservesStagingErrors(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "package.aasx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = part.Write([]byte("package")); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	stagingErr := NewInternalServerError("COMMON-MULTIPARTTEST-STAGE database unavailable")
+	_, err = ReadMultipartUpload(httptest.NewRecorder(), request, 4096, "file", func(context.Context, io.Reader, int64) (StagedUpload, error) {
+		return nil, stagingErr
+	})
+	if !IsInternalServerError(err) {
+		t.Fatalf("expected internal staging error, got %v", err)
+	}
+}
+
+func TestReadMultipartUploadRejectsExcessivePartCount(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for index := 0; index < maxMultipartPartCount; index++ {
+		if err := writer.WriteField("metadata", ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	part, err := writer.CreateFormFile("file", "package.aasx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = part.Write([]byte("package")); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	if _, err = ReadMultipartUpload(httptest.NewRecorder(), request, 1<<20, "file", multipartMemoryStager); !IsErrPayloadTooLarge(err) {
+		t.Fatalf("expected part-count limit error, got %v", err)
+	}
+}
+
+func TestReadMultipartUploadRejectsExcessiveMetadata(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for index := 0; index < 3; index++ {
+		if err := writer.WriteField("metadata", string(bytes.Repeat([]byte("x"), 700<<10))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	part, err := writer.CreateFormFile("file", "package.aasx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = part.Write([]byte("package")); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	if _, err = ReadMultipartUpload(httptest.NewRecorder(), request, 4<<20, "file", multipartMemoryStager); !IsErrPayloadTooLarge(err) {
+		t.Fatalf("expected cumulative metadata limit error, got %v", err)
+	}
+}
+
+func TestReadMultipartUploadRejectsUnexpectedFilePart(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("other", "unexpected.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = part.Write([]byte("content")); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	if _, err = ReadMultipartUpload(httptest.NewRecorder(), request, 4096, "file", multipartMemoryStager); !IsErrBadRequest(err) {
+		t.Fatalf("expected bad request for unexpected file part, got %v", err)
+	}
+}

--- a/internal/common/staged_upload.go
+++ b/internal/common/staged_upload.go
@@ -1,0 +1,101 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+)
+
+// StagedUpload is seekable request content held outside process memory.
+// Callers must call Close unless Promote succeeds. Promote transfers the staged
+// object into persistent ownership by executing its callback in the staging transaction.
+type StagedUpload interface {
+	io.ReadSeeker
+	// Size returns the number of staged bytes.
+	Size() int64
+	// Promote runs persist in the staging transaction and commits on success.
+	Promote(context.Context, func(context.Context, *sql.Tx, int64, int64) error) error
+	// Close discards an unpromoted upload and is safe to call after promotion.
+	Close() error
+}
+
+// UploadStager copies one request stream into bounded seekable storage.
+//
+// Parameters:
+//   - context.Context: Request context used for cancellation and authorization propagation.
+//   - io.Reader: Source payload to stage.
+//   - int64: Maximum accepted source size in bytes.
+//
+// Returns:
+//   - StagedUpload: Seekable staged content owned by the caller.
+//   - error: A coded staging or payload-limit error.
+type UploadStager func(context.Context, io.Reader, int64) (StagedUpload, error)
+
+type payloadLimitReader struct {
+	reader    io.Reader
+	remaining uint64
+	maximum   uint64
+	label     string
+}
+
+// NewPayloadLimitReader wraps a stream with a typed payload-size limit.
+//
+// Parameters:
+//   - reader: Source stream.
+//   - maximum: Maximum bytes that may be returned.
+//   - label: Human-readable payload label included in limit errors.
+//
+// Returns:
+//   - io.Reader: Reader that returns a 413-classified error when source data exceeds maximum.
+func NewPayloadLimitReader(reader io.Reader, maximum uint64, label string) io.Reader {
+	return &payloadLimitReader{reader: reader, remaining: maximum, maximum: maximum, label: label}
+}
+
+func (reader *payloadLimitReader) Read(destination []byte) (int, error) {
+	if len(destination) == 0 {
+		return 0, nil
+	}
+	if reader.remaining > 0 {
+		if uint64(len(destination)) > reader.remaining {
+			destination = destination[:reader.remaining]
+		}
+		read, err := reader.reader.Read(destination)
+		if read < 0 {
+			return 0, NewInternalServerError("COMMON-LIMITREADER-NEGATIVEREAD source returned a negative byte count")
+		}
+		reader.remaining -= uint64(read)
+		return read, err
+	}
+	var probe [1]byte
+	read, err := reader.reader.Read(probe[:])
+	if read > 0 {
+		return 0, NewErrPayloadTooLarge(fmt.Sprintf("COMMON-LIMITREADER-TOOLARGE %s exceeds configured maximum of %d bytes", reader.label, reader.maximum))
+	}
+	return 0, err
+}

--- a/pkg/aasxfileserverapi/go/api.go
+++ b/pkg/aasxfileserverapi/go/api.go
@@ -13,8 +13,6 @@ package openapi
 import (
 	"context"
 	"net/http"
-
-	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
 
 // AASXFileServerAPIAPIRouter defines the required methods for binding the api requests to a responses for the AASXFileServerAPIAPI
@@ -41,9 +39,9 @@ type DescriptionAPIAPIRouter interface {
 // and updated with the logic required for the API.
 type AASXFileServerAPIAPIServicer interface {
 	GetAllAASXPackageIds(context.Context, string, int32, string) (ImplResponse, error)
-	PostAASXPackage(context.Context, common.StagedUpload, []string, string) (ImplResponse, error)
+	PostAASXPackage(context.Context, StagedUpload, []string, string) (ImplResponse, error)
 	GetAASXByPackageId(context.Context, string) (ImplResponse, error)
-	PutAASXByPackageId(context.Context, string, common.StagedUpload, []string, string) (ImplResponse, error)
+	PutAASXByPackageId(context.Context, string, StagedUpload, []string, string) (ImplResponse, error)
 	DeleteAASXByPackageId(context.Context, string) (ImplResponse, error)
 }
 

--- a/pkg/aasxfileserverapi/go/api.go
+++ b/pkg/aasxfileserverapi/go/api.go
@@ -13,7 +13,8 @@ package openapi
 import (
 	"context"
 	"net/http"
-	"os"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
 
 // AASXFileServerAPIAPIRouter defines the required methods for binding the api requests to a responses for the AASXFileServerAPIAPI
@@ -40,9 +41,9 @@ type DescriptionAPIAPIRouter interface {
 // and updated with the logic required for the API.
 type AASXFileServerAPIAPIServicer interface {
 	GetAllAASXPackageIds(context.Context, string, int32, string) (ImplResponse, error)
-	PostAASXPackage(context.Context, *os.File, []string, string) (ImplResponse, error)
+	PostAASXPackage(context.Context, common.StagedUpload, []string, string) (ImplResponse, error)
 	GetAASXByPackageId(context.Context, string) (ImplResponse, error)
-	PutAASXByPackageId(context.Context, string, *os.File, []string, string) (ImplResponse, error)
+	PutAASXByPackageId(context.Context, string, common.StagedUpload, []string, string) (ImplResponse, error)
 	DeleteAASXByPackageId(context.Context, string) (ImplResponse, error)
 }
 

--- a/pkg/aasxfileserverapi/go/api_aasx_file_server_api.go
+++ b/pkg/aasxfileserverapi/go/api_aasx_file_server_api.go
@@ -13,17 +13,19 @@ package openapi
 import (
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/go-chi/chi/v5"
 )
 
 // AASXFileServerAPIAPIController binds http requests to an api service and writes the service results to the http response
 type AASXFileServerAPIAPIController struct {
-	service      AASXFileServerAPIAPIServicer
-	errorHandler ErrorHandler
-	contextPath  string
+	service            AASXFileServerAPIAPIServicer
+	errorHandler       ErrorHandler
+	contextPath        string
+	uploadStager       common.UploadStager
+	maxUploadSizeBytes int64
 }
 
 // AASXFileServerAPIAPIOption for how the controller is set up.
@@ -33,6 +35,21 @@ type AASXFileServerAPIAPIOption func(*AASXFileServerAPIAPIController)
 func WithAASXFileServerAPIAPIErrorHandler(h ErrorHandler) AASXFileServerAPIAPIOption {
 	return func(c *AASXFileServerAPIAPIController) {
 		c.errorHandler = h
+	}
+}
+
+// WithAASXFileServerUploadStager configures bounded seekable upload storage.
+//
+// Parameters:
+//   - stager: External storage provider used for multipart file parts.
+//   - maxUploadSizeBytes: Maximum complete multipart request size.
+//
+// Returns:
+//   - AASXFileServerAPIAPIOption: Controller option applying the upload settings.
+func WithAASXFileServerUploadStager(stager common.UploadStager, maxUploadSizeBytes int64) AASXFileServerAPIAPIOption {
+	return func(c *AASXFileServerAPIAPIController) {
+		c.uploadStager = stager
+		c.maxUploadSizeBytes = maxUploadSizeBytes
 	}
 }
 
@@ -148,25 +165,13 @@ func (c *AASXFileServerAPIAPIController) GetAllAASXPackageIds(w http.ResponseWri
 
 // PostAASXPackage - Stores the AASX package at the server
 func (c *AASXFileServerAPIAPIController) PostAASXPackage(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+	upload, err := c.readPackageUpload(w, r)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "file", Err: err}, nil)
 		return
 	}
-	var fileParam *os.File
-	{
-		param, err := ReadFormFileToTempFile(r, "file")
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "file", Err: err}, nil)
-			return
-		}
-
-		fileParam = param
-	}
-
-	aasIdsParam := strings.Split(r.FormValue("aasIds"), ",")
-
-	fileNameParam := r.FormValue("fileName")
-	result, err := c.service.PostAASXPackage(r.Context(), fileParam, aasIdsParam, fileNameParam)
+	defer func() { _ = upload.Close() }()
+	result, err := c.service.PostAASXPackage(r.Context(), upload.File, uploadAASIDs(upload), uploadFileName(upload))
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -200,30 +205,18 @@ func (c *AASXFileServerAPIAPIController) GetAASXByPackageId(w http.ResponseWrite
 
 // PutAASXByPackageId - Creates or updates the AASX package at the server
 func (c *AASXFileServerAPIAPIController) PutAASXByPackageId(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
-		return
-	}
 	packageIdParam := chi.URLParam(r, "packageId")
 	if packageIdParam == "" {
 		c.errorHandler(w, r, &RequiredError{"packageId"}, nil)
 		return
 	}
-	var fileParam *os.File
-	{
-		param, err := ReadFormFileToTempFile(r, "file")
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "file", Err: err}, nil)
-			return
-		}
-
-		fileParam = param
+	upload, err := c.readPackageUpload(w, r)
+	if err != nil {
+		c.errorHandler(w, r, &ParsingError{Param: "file", Err: err}, nil)
+		return
 	}
-
-	aasIdsParam := strings.Split(r.FormValue("aasIds"), ",")
-
-	fileNameParam := r.FormValue("fileName")
-	result, err := c.service.PutAASXByPackageId(r.Context(), packageIdParam, fileParam, aasIdsParam, fileNameParam)
+	defer func() { _ = upload.Close() }()
+	result, err := c.service.PutAASXByPackageId(r.Context(), packageIdParam, upload.File, uploadAASIDs(upload), uploadFileName(upload))
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -236,6 +229,30 @@ func (c *AASXFileServerAPIAPIController) PutAASXByPackageId(w http.ResponseWrite
 	}
 	// If no error, encode the body and the result code
 	_ = EncodeJSONResponse(result.Body, &result.Code, w)
+}
+
+func (c *AASXFileServerAPIAPIController) readPackageUpload(w http.ResponseWriter, r *http.Request) (*common.MultipartUpload, error) {
+	if c.uploadStager == nil {
+		return nil, common.NewInternalServerError("AASXFILES-UPLOAD-NOSTAGER upload stager is not configured")
+	}
+	return common.ReadMultipartUpload(w, r, c.maxUploadSizeBytes, "file", c.uploadStager)
+}
+
+func uploadFileName(upload *common.MultipartUpload) string {
+	fileName := strings.TrimSpace(upload.FirstField("fileName"))
+	if fileName == "" {
+		fileName = upload.MultipartFileName
+	}
+	return fileName
+}
+
+func uploadAASIDs(upload *common.MultipartUpload) []string {
+	values := upload.Fields["aasIds"]
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, strings.Split(value, ",")...)
+	}
+	return result
 }
 
 // DeleteAASXByPackageId - Deletes a specific AASX package from the server

--- a/pkg/aasxfileserverapi/go/api_aasx_file_server_api.go
+++ b/pkg/aasxfileserverapi/go/api_aasx_file_server_api.go
@@ -11,6 +11,7 @@
 package openapi
 
 import (
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -200,7 +201,9 @@ func (c *AASXFileServerAPIAPIController) GetAASXByPackageId(w http.ResponseWrite
 		return
 	}
 	// If no error, encode the body and the result code
-	_ = EncodeJSONResponse(result.Body, &result.Code, w)
+	if encodeErr := EncodeJSONResponse(result.Body, &result.Code, w); encodeErr != nil {
+		log.Printf("AASXFILES-GETPACKAGE-STREAM response stream failed: %v", encodeErr)
+	}
 }
 
 // PutAASXByPackageId - Creates or updates the AASX package at the server

--- a/pkg/aasxfileserverapi/go/api_aasx_file_server_stream_test.go
+++ b/pkg/aasxfileserverapi/go/api_aasx_file_server_stream_test.go
@@ -1,0 +1,175 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package openapi
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+)
+
+type controllerMemoryStage struct{ *bytes.Reader }
+
+func (stage *controllerMemoryStage) Size() int64  { return stage.Reader.Size() }
+func (stage *controllerMemoryStage) Close() error { return nil }
+func (stage *controllerMemoryStage) Promote(context.Context, func(context.Context, *sql.Tx, int64, int64) error) error {
+	return nil
+}
+
+func controllerMemoryStager(_ context.Context, input io.Reader, maximum int64) (common.StagedUpload, error) {
+	content, err := io.ReadAll(io.LimitReader(input, maximum+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(content)) > maximum {
+		return nil, common.NewErrPayloadTooLarge("AASXFILES-TESTSTAGE-TOOLARGE")
+	}
+	return &controllerMemoryStage{Reader: bytes.NewReader(content)}, nil
+}
+
+type captureAASXFileServerService struct {
+	fileName string
+	aasIDs   []string
+	content  []byte
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (reader *trackingReadCloser) Close() error {
+	reader.closed = true
+	return nil
+}
+
+func (service *captureAASXFileServerService) GetAllAASXPackageIds(context.Context, string, int32, string) (ImplResponse, error) {
+	return Response(http.StatusOK, nil), nil
+}
+
+func (service *captureAASXFileServerService) PostAASXPackage(_ context.Context, file common.StagedUpload, aasIDs []string, fileName string) (ImplResponse, error) {
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return ImplResponse{}, err
+	}
+	service.fileName, service.aasIDs, service.content = fileName, aasIDs, content
+	return Response(http.StatusCreated, PackageDescription{PackageId: "created"}), nil
+}
+
+func (service *captureAASXFileServerService) GetAASXByPackageId(context.Context, string) (ImplResponse, error) {
+	return Response(http.StatusNotFound, nil), nil
+}
+
+func (service *captureAASXFileServerService) PutAASXByPackageId(context.Context, string, common.StagedUpload, []string, string) (ImplResponse, error) {
+	return Response(http.StatusNoContent, nil), nil
+}
+
+func (service *captureAASXFileServerService) DeleteAASXByPackageId(context.Context, string) (ImplResponse, error) {
+	return Response(http.StatusNoContent, nil), nil
+}
+
+func TestPostAASXPackageStreamsFileAndReadsTrailingMetadata(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir()+"/missing")
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "fallback.aasx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = part.Write([]byte("package-content")); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.WriteField("aasIds", "one,two"); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.WriteField("fileName", "selected.aasx"); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	service := &captureAASXFileServerService{}
+	controller := NewAASXFileServerAPIAPIController(service, "", WithAASXFileServerUploadStager(controllerMemoryStager, 4096))
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	response := httptest.NewRecorder()
+	controller.PostAASXPackage(response, request)
+
+	if response.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", response.Code, response.Body.String())
+	}
+	if service.fileName != "selected.aasx" || len(service.aasIDs) != 2 || string(service.content) != "package-content" {
+		t.Fatalf("unexpected captured upload: filename=%q aasIDs=%v content=%q", service.fileName, service.aasIDs, service.content)
+	}
+}
+
+func TestPostAASXPackageRejectsOversizedRequest(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "large.aasx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = part.Write(bytes.Repeat([]byte("x"), 1024)); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	controller := NewAASXFileServerAPIAPIController(&captureAASXFileServerService{}, "", WithAASXFileServerUploadStager(controllerMemoryStager, 128))
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	response := httptest.NewRecorder()
+	controller.PostAASXPackage(response, request)
+	if response.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status 413, got %d: %s", response.Code, response.Body.String())
+	}
+}
+
+func TestEncodeJSONResponseStreamsAndClosesDownload(t *testing.T) {
+	stream := &trackingReadCloser{Reader: bytes.NewReader(bytes.Repeat([]byte("chunk"), 20000))}
+	response := httptest.NewRecorder()
+	status := http.StatusOK
+	if err := EncodeJSONResponse(FileDownload{
+		Content: stream, ContentType: "application/aasx+json", Filename: "package.aasx",
+	}, &status, response); err != nil {
+		t.Fatalf("unexpected download error: %v", err)
+	}
+	if !stream.closed {
+		t.Fatal("expected download stream to be closed")
+	}
+	if response.Body.Len() != len("chunk")*20000 {
+		t.Fatalf("unexpected streamed byte count: %d", response.Body.Len())
+	}
+}

--- a/pkg/aasxfileserverapi/go/api_aasx_file_server_stream_test.go
+++ b/pkg/aasxfileserverapi/go/api_aasx_file_server_stream_test.go
@@ -23,12 +23,14 @@
 * SPDX-License-Identifier: MIT
 ******************************************************************************/
 
+// Package openapi tests the generated AASX File Server transport adapters.
 package openapi
 
 import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -68,6 +70,20 @@ type trackingReadCloser struct {
 	closed bool
 }
 
+type failingResponseWriter struct {
+	header http.Header
+}
+
+func (writer *failingResponseWriter) Header() http.Header {
+	return writer.header
+}
+
+func (*failingResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("client disconnected")
+}
+
+func (*failingResponseWriter) WriteHeader(int) {}
+
 func (reader *trackingReadCloser) Close() error {
 	reader.closed = true
 	return nil
@@ -77,7 +93,7 @@ func (service *captureAASXFileServerService) GetAllAASXPackageIds(context.Contex
 	return Response(http.StatusOK, nil), nil
 }
 
-func (service *captureAASXFileServerService) PostAASXPackage(_ context.Context, file common.StagedUpload, aasIDs []string, fileName string) (ImplResponse, error) {
+func (service *captureAASXFileServerService) PostAASXPackage(_ context.Context, file StagedUpload, aasIDs []string, fileName string) (ImplResponse, error) {
 	content, err := io.ReadAll(file)
 	if err != nil {
 		return ImplResponse{}, err
@@ -90,7 +106,7 @@ func (service *captureAASXFileServerService) GetAASXByPackageId(context.Context,
 	return Response(http.StatusNotFound, nil), nil
 }
 
-func (service *captureAASXFileServerService) PutAASXByPackageId(context.Context, string, common.StagedUpload, []string, string) (ImplResponse, error) {
+func (service *captureAASXFileServerService) PutAASXByPackageId(context.Context, string, StagedUpload, []string, string) (ImplResponse, error) {
 	return Response(http.StatusNoContent, nil), nil
 }
 
@@ -157,6 +173,32 @@ func TestPostAASXPackageRejectsOversizedRequest(t *testing.T) {
 	}
 }
 
+func TestPostAASXPackageReportsStagingFailureAsInternalError(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "package.aasx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = part.Write([]byte("package")); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	failedStager := func(context.Context, io.Reader, int64) (common.StagedUpload, error) {
+		return nil, common.NewInternalServerError("AASXFILES-TESTSTAGE-DATABASE unavailable")
+	}
+	controller := NewAASXFileServerAPIAPIController(&captureAASXFileServerService{}, "", WithAASXFileServerUploadStager(failedStager, 4096))
+	request := httptest.NewRequest(http.MethodPost, "/packages", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	response := httptest.NewRecorder()
+	controller.PostAASXPackage(response, request)
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d: %s", response.Code, response.Body.String())
+	}
+}
+
 func TestEncodeJSONResponseStreamsAndClosesDownload(t *testing.T) {
 	stream := &trackingReadCloser{Reader: bytes.NewReader(bytes.Repeat([]byte("chunk"), 20000))}
 	response := httptest.NewRecorder()
@@ -171,5 +213,19 @@ func TestEncodeJSONResponseStreamsAndClosesDownload(t *testing.T) {
 	}
 	if response.Body.Len() != len("chunk")*20000 {
 		t.Fatalf("unexpected streamed byte count: %d", response.Body.Len())
+	}
+}
+
+func TestEncodeJSONResponseClosesDownloadAfterCopyFailure(t *testing.T) {
+	stream := &trackingReadCloser{Reader: bytes.NewReader([]byte("package"))}
+	status := http.StatusOK
+	err := EncodeJSONResponse(FileDownload{
+		Content: stream, ContentType: "application/aasx+json", Filename: "package.aasx",
+	}, &status, &failingResponseWriter{header: make(http.Header)})
+	if err == nil {
+		t.Fatal("expected response copy error")
+	}
+	if !stream.closed {
+		t.Fatal("expected download stream to be closed after copy failure")
 	}
 }

--- a/pkg/aasxfileserverapi/go/error.go
+++ b/pkg/aasxfileserverapi/go/error.go
@@ -64,6 +64,12 @@ func DefaultErrorHandler(w http.ResponseWriter, _ *http.Request, err error, resu
 	if common.IsErrPayloadTooLarge(err) {
 		status = http.StatusRequestEntityTooLarge
 		info = "PayloadTooLarge"
+	} else if common.IsErrServiceUnavailable(err) {
+		status = http.StatusServiceUnavailable
+		info = "ServiceUnavailable"
+	} else if common.IsInternalServerError(err) {
+		status = http.StatusInternalServerError
+		info = "InternalServerError"
 	} else {
 		var parsingErr *ParsingError
 		if ok := errors.As(err, &parsingErr); ok {

--- a/pkg/aasxfileserverapi/go/error.go
+++ b/pkg/aasxfileserverapi/go/error.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 )
 
@@ -60,17 +61,22 @@ func DefaultErrorHandler(w http.ResponseWriter, _ *http.Request, err error, resu
 	status := http.StatusInternalServerError
 	info := "Service"
 
-	var parsingErr *ParsingError
-	if ok := errors.As(err, &parsingErr); ok {
-		status = http.StatusBadRequest
-		info = "ParseRequest"
+	if common.IsErrPayloadTooLarge(err) {
+		status = http.StatusRequestEntityTooLarge
+		info = "PayloadTooLarge"
 	} else {
-		var requiredErr *RequiredError
-		if errors.As(err, &requiredErr) {
-			status = http.StatusUnprocessableEntity
-			info = "RequiredParameter"
-		} else if result != nil && result.Code != 0 {
-			status = result.Code
+		var parsingErr *ParsingError
+		if ok := errors.As(err, &parsingErr); ok {
+			status = http.StatusBadRequest
+			info = "ParseRequest"
+		} else {
+			var requiredErr *RequiredError
+			if errors.As(err, &requiredErr) {
+				status = http.StatusUnprocessableEntity
+				info = "RequiredParameter"
+			} else if result != nil && result.Code != 0 {
+				status = result.Code
+			}
 		}
 	}
 

--- a/pkg/aasxfileserverapi/go/routers.go
+++ b/pkg/aasxfileserverapi/go/routers.go
@@ -14,10 +14,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -48,9 +46,11 @@ const errMsgRequiredMissing = "required parameter is missing"
 const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
 const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
 
-// FileDownload is a helper payload type for file downloads with custom headers.
+// FileDownload describes a streamed binary response with custom headers.
+// Content owns its backing resources and is closed by EncodeJSONResponse after
+// the copy completes or fails.
 type FileDownload struct {
-	Content     []byte
+	Content     io.ReadCloser
 	ContentType string
 	Filename    string
 	Headers     map[string]string
@@ -70,62 +70,32 @@ func NewRouter(routers ...Router) chi.Router {
 	return router
 }
 
-// EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
+// EncodeJSONResponse writes a streamed download or JSON API response.
+//
+// FileDownload bodies are copied without materializing them and are always
+// closed before this function returns.
+//
+// Parameters:
+//   - i: FileDownload or JSON-serializable response body.
+//   - status: Optional HTTP status; nil defaults to HTTP 200.
+//   - w: Destination response writer.
+//
+// Returns:
+//   - error: Stream-copy or JSON-encoding error.
 func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error {
 	wHeader := w.Header()
 
 	if i != nil {
 		switch d := i.(type) {
 		case FileDownload:
-			model.SetSafeDownloadHeaders(wHeader, d.Filename, d.ContentType)
-			for key, value := range d.Headers {
-				if strings.TrimSpace(key) == "" {
-					continue
-				}
-				wHeader.Set(key, value)
-			}
-			if status != nil {
-				w.WriteHeader(*status)
-			} else {
-				w.WriteHeader(http.StatusOK)
-			}
-			_, err := w.Write(d.Content)
-			return err
+			return writeFileDownload(w, status, d)
 		case *FileDownload:
 			if d != nil {
-				model.SetSafeDownloadHeaders(wHeader, d.Filename, d.ContentType)
-				for key, value := range d.Headers {
-					if strings.TrimSpace(key) == "" {
-						continue
-					}
-					wHeader.Set(key, value)
-				}
-				if status != nil {
-					w.WriteHeader(*status)
-				} else {
-					w.WriteHeader(http.StatusOK)
-				}
-				_, err := w.Write(d.Content)
-				return err
+				return writeFileDownload(w, status, *d)
 			}
 		}
 	}
 
-	f, ok := i.(*os.File)
-	if ok {
-		data, err := io.ReadAll(f)
-		if err != nil {
-			return err
-		}
-		model.SetSafeDownloadHeaders(wHeader, f.Name(), http.DetectContentType(data))
-		if status != nil {
-			w.WriteHeader(*status)
-		} else {
-			w.WriteHeader(http.StatusOK)
-		}
-		_, err = w.Write(data)
-		return err
-	}
 	wHeader.Set("Content-Type", "application/json; charset=UTF-8")
 
 	if status != nil {
@@ -141,60 +111,24 @@ func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error
 	return nil
 }
 
-// ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file
-func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
-	_, fileHeader, err := r.FormFile(key)
-	if err != nil {
-		return nil, err
+func writeFileDownload(w http.ResponseWriter, status *int, download FileDownload) error {
+	if download.Content == nil {
+		return errors.New("AASXFILES-DOWNLOAD-NILCONTENT download stream is required")
 	}
-
-	return readFileHeaderToTempFile(fileHeader)
-}
-
-// ReadFormFilesToTempFiles reads files array data from a request form and writes it to a temporary files
-func ReadFormFilesToTempFiles(r *http.Request, key string) ([]*os.File, error) {
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		return nil, err
-	}
-
-	files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
-
-	for _, fileHeader := range r.MultipartForm.File[key] {
-		file, err := readFileHeaderToTempFile(fileHeader)
-		if err != nil {
-			return nil, err
+	defer func() { _ = download.Content.Close() }()
+	model.SetSafeDownloadHeaders(w.Header(), download.Filename, download.ContentType)
+	for key, value := range download.Headers {
+		if strings.TrimSpace(key) != "" {
+			w.Header().Set(key, value)
 		}
-
-		files = append(files, file)
 	}
-
-	return files, nil
-}
-
-// readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
-func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
-	formFile, err := fileHeader.Open()
-	if err != nil {
-		return nil, err
+	responseStatus := http.StatusOK
+	if status != nil {
+		responseStatus = *status
 	}
-
-	defer formFile.Close()
-
-	// Use .* as suffix, because the asterisk is a placeholder for the random value,
-	// and the period allows consumers of this file to remove the suffix to obtain the original file name
-	file, err := os.CreateTemp("", fileHeader.Filename+".*")
-	if err != nil {
-		return nil, err
-	}
-
-	defer file.Close()
-
-	_, err = io.Copy(file, formFile)
-	if err != nil {
-		return nil, err
-	}
-
-	return file, nil
+	w.WriteHeader(responseStatus)
+	_, err := io.Copy(w, download.Content)
+	return err
 }
 
 func parseTimes(param string) ([]time.Time, error) {

--- a/pkg/aasxfileserverapi/go/staged_upload.go
+++ b/pkg/aasxfileserverapi/go/staged_upload.go
@@ -1,0 +1,41 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package openapi
+
+import (
+	"context"
+	"database/sql"
+	"io"
+)
+
+// StagedUpload is seekable package content owned by the current request.
+// Callers close the upload unless Promote succeeds.
+type StagedUpload interface {
+	io.ReadSeeker
+	Size() int64
+	Promote(context.Context, func(context.Context, *sql.Tx, int64, int64) error) error
+	Close() error
+}


### PR DESCRIPTION
## Summary

This updates AASX handling to `aas-package3-golang/v2@v2.0.0` and removes package-sized buffering and local temporary-file staging from the AASX File Server.

The change adds reusable AASX limits, sequential multipart parsing, typed payload-limit errors, and transaction-owned PostgreSQL large-object staging. Package creation and replacement promote the staged large object atomically, while downloads stream through a transaction-owning reader.

No database schema migration or writable local volume is required.

Fixes #449.
Fixes #418.

Follow-up: #505 builds the AAS Environment and `/verify` changes on these shared primitives.

## Validation

- `sh scripts/lint.sh`
- `go test -v ./internal/aasxfileserver/integration_tests`
- `go test -v ./internal/aasenvironment/integration_tests`
- `go test -v ./internal/submodelrepository/integration_tests`
- `go test ./...`
