### PR TITLE
Avoids loading Blob values excluded by extent

### DIFF
--- a/internal/aasenvironment/custom_aas_repository_service.go
+++ b/internal/aasenvironment/custom_aas_repository_service.go
@@ -833,7 +833,7 @@ func (s *CustomAASRepositoryService) buildSubmodelDescriptorForReference(ctx con
 		return commonmodel.SubmodelDescriptor{}, false, nil
 	}
 
-	submodel, getSubmodelErr := s.persistence.SubmodelRepository.GetSubmodelByID(ctx, submodelID, "core", true)
+	submodel, getSubmodelErr := s.persistence.SubmodelRepository.GetSubmodelByID(ctx, submodelID, "core", true, true)
 	if getSubmodelErr == nil {
 		descriptor, descriptorErr := s.syncConfig.buildSubmodelDescriptor(submodel)
 		return descriptor, true, descriptorErr

--- a/internal/aasenvironment/serialization_api_service.go
+++ b/internal/aasenvironment/serialization_api_service.go
@@ -373,7 +373,7 @@ func (s *SerializationAPIService) loadSubmodels(ctx context.Context, ids []strin
 	if len(ids) > 0 {
 		result := make([]aastypes.ISubmodel, 0, len(ids))
 		for _, id := range ids {
-			submodel, getErr := s.persistence.SubmodelRepository.GetSubmodelByID(ctx, id, "deep", false)
+			submodel, getErr := s.persistence.SubmodelRepository.GetSubmodelByID(ctx, id, "deep", false, true)
 			if getErr != nil {
 				return nil, getErr
 			}
@@ -401,7 +401,7 @@ func (s *SerializationAPIService) loadSubmodels(ctx context.Context, ids []strin
 			}
 
 			unlimited := -1
-			submodelElements, _, getElementsErr := s.persistence.SubmodelRepository.GetSubmodelElements(ctx, submodelID, &unlimited, "", false, "deep")
+			submodelElements, _, getElementsErr := s.persistence.SubmodelRepository.GetSubmodelElements(ctx, submodelID, &unlimited, "", true, "deep")
 			if getElementsErr != nil {
 				return nil, getElementsErr
 			}

--- a/internal/common/builder/submodel_element_builder.go
+++ b/internal/common/builder/submodel_element_builder.go
@@ -755,10 +755,13 @@ func buildBlob(smeRow model.SubmodelElementRow) (types.ISubmodelElement, error) 
 		return nil, err
 	}
 
+	blob := types.NewBlob()
+	blob.SetContentType(&valueRow.ContentType)
+
 	// Postgres bytea is commonly returned as: \x<hex>
 	raw := strings.TrimSpace(valueRow.Value)
 	if raw == "" {
-		return nil, fmt.Errorf("blob value is empty")
+		return blob, nil
 	}
 
 	var decoded []byte
@@ -783,8 +786,6 @@ func buildBlob(smeRow model.SubmodelElementRow) (types.ISubmodelElement, error) 
 		_, _ = fmt.Println("WARNING: Error while decoding Base64 - falling back to HEX Decoded Value as a fallback.")
 	}
 
-	blob := types.NewBlob()
-	blob.SetContentType(&valueRow.ContentType)
 	if string(decoded) != "" {
 		blob.SetValue(decoded)
 	}

--- a/internal/common/builder/submodel_element_builder_test.go
+++ b/internal/common/builder/submodel_element_builder_test.go
@@ -70,3 +70,22 @@ func TestBuildAnnotatedRelationshipElementAllowsNullOptionalReferences(t *testin
 	require.Nil(t, relationship.First())
 	require.Nil(t, relationship.Second())
 }
+
+func TestBuildBlobAllowsOmittedValue(t *testing.T) {
+	t.Parallel()
+
+	value := json.RawMessage(`{"content_type":"text/plain"}`)
+	element, err := buildBlob(model.SubmodelElementRow{
+		IDShort:   sql.NullString{String: "BlobWithoutValue", Valid: true},
+		ModelType: int64(types.ModelTypeBlob),
+		Value:     &value,
+	})
+
+	require.NoError(t, err)
+
+	blob, ok := element.(*types.Blob)
+	require.True(t, ok)
+	require.NotNil(t, blob.ContentType())
+	require.Equal(t, "text/plain", *blob.ContentType())
+	require.Nil(t, blob.Value())
+}

--- a/internal/submodelrepository/api/api_submodel_repository_api_service.go
+++ b/internal/submodelrepository/api/api_submodel_repository_api_service.go
@@ -395,7 +395,7 @@ func submodelElementMetadataToJSONPatch(metadata gen.SubmodelElementMetadata) (m
 }
 
 func loadOperationElement(ctx context.Context, backend persistencepostgresql.SubmodelDatabase, decodedSubmodelIdentifier string, idShortPath string, operation string) (types.ISubmodelElement, gen.ImplResponse, bool) {
-	element, err := backend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, "")
+	element, err := backend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, true, "")
 	if err != nil {
 		if common.IsErrNotFound(err) || errors.Is(err, sql.ErrNoRows) {
 			return nil, newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelElementNotFound"), false
@@ -531,7 +531,7 @@ func getModelTypeLiteral(element types.ISubmodelElement) string {
 //   - limit: Maximum number of submodels to return
 //   - cursor: Pagination cursor for continuing from previous results
 //   - level: Detail level for response (currently unused)
-//   - extent: Response extent specification (currently unused)
+//   - extent: Response extent specification for Blob values
 //
 // Returns:
 //   - gen.ImplResponse: Response containing paginated submodel results
@@ -586,15 +586,12 @@ func (s *SubmodelRepositoryAPIAPIService) GetAllSubmodels(
 		sm := sms[index]
 
 		eg.Go(func() error {
-			submodelElements, _, elementsErr := s.submodelBackend.GetSubmodelElements(ctx, sm.ID(), nil, "", false, level)
+			submodelElements, _, elementsErr := s.submodelBackend.GetSubmodelElements(ctx, sm.ID(), nil, "", normalizedExtent == extentWithBlobValue, level)
 			if elementsErr != nil {
 				return elementsErr
 			}
 
 			sm.SetSubmodelElements(submodelElements)
-			if normalizedExtent == extentWithoutBlobValue {
-				stripBlobValuesFromSubmodel(sm)
-			}
 			return nil
 		})
 	}
@@ -638,7 +635,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetAllSubmodels(
 //   - ctx: Request context (currently unused)
 //   - id: Base64-encoded submodel identifier
 //   - level: Detail level for response (currently unused)
-//   - extent: Response extent specification (currently unused)
+//   - extent: Response extent specification for Blob values
 //
 // Returns:
 //   - gen.ImplResponse: Response containing the requested submodel
@@ -664,7 +661,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelByID(
 		return newAPIErrorResponse(extentErr, http.StatusBadRequest, operation, "InvalidExtentParameter"), nil
 	}
 
-	sm, err := s.submodelBackend.GetSubmodelByID(ctx, string(decodedSubmodelIdentifier), level, false)
+	sm, err := s.submodelBackend.GetSubmodelByID(ctx, string(decodedSubmodelIdentifier), level, false, normalizedExtent == extentWithBlobValue)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelNotFound"), nil
@@ -674,9 +671,6 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelByID(
 		}
 		_, _ = fmt.Printf("[DEBUG] GetSubmodelByID: Error getting submodel '%s': %v\n", string(decodedSubmodelIdentifier), err)
 		return newAPIErrorResponse(err, http.StatusInternalServerError, operation, "GetSubmodelByID"), nil
-	}
-	if normalizedExtent == extentWithoutBlobValue {
-		stripBlobValuesFromSubmodel(sm)
 	}
 	jsonSubmodel, err := jsonization.ToJsonable(sm)
 	if err != nil {
@@ -809,7 +803,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelByIdAndDate(
 		pruneSubmodelToCore(sm)
 	}
 	if normalizedExtent == extentWithoutBlobValue {
-		stripBlobValuesFromSubmodel(sm)
+		stripBlobValuesFromHistoricalSubmodel(sm)
 	}
 
 	jsonSubmodel, err := jsonization.ToJsonable(sm)
@@ -1071,15 +1065,12 @@ func (s *SubmodelRepositoryAPIAPIService) GetAllSubmodelsValueOnly(ctx context.C
 		sm := sms[index]
 
 		eg.Go(func() error {
-			submodelElements, _, elementsErr := s.submodelBackend.GetSubmodelElements(ctx, sm.ID(), nil, "", false, level)
+			submodelElements, _, elementsErr := s.submodelBackend.GetSubmodelElements(ctx, sm.ID(), nil, "", normalizedExtent == extentWithBlobValue, level)
 			if elementsErr != nil {
 				return elementsErr
 			}
 
 			sm.SetSubmodelElements(submodelElements)
-			if normalizedExtent == extentWithoutBlobValue {
-				stripBlobValuesFromSubmodel(sm)
-			}
 
 			valueOnly, convErr := gen.SubmodelToValueOnly(sm)
 			if convErr != nil {
@@ -1453,7 +1444,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelByIDMetadata(ctx context.Co
 		return newAPIErrorResponse(decodeErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
 	}
 
-	sm, err := s.submodelBackend.GetSubmodelByID(ctx, string(decodedSubmodelIdentifier), "", true)
+	sm, err := s.submodelBackend.GetSubmodelByID(ctx, string(decodedSubmodelIdentifier), "", true, true)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelNotFound"), nil
@@ -1499,7 +1490,7 @@ func (s *SubmodelRepositoryAPIAPIService) PatchSubmodelByIDMetadata(ctx context.
 	}
 	patchJSON["id"] = decodedIdentifier
 
-	existingSubmodel, getErr := s.submodelBackend.GetSubmodelByID(ctx, decodedIdentifier, "core", true)
+	existingSubmodel, getErr := s.submodelBackend.GetSubmodelByID(ctx, decodedIdentifier, "core", true, true)
 	if getErr != nil {
 		if common.IsErrNotFound(getErr) || errors.Is(getErr, sql.ErrNoRows) {
 			return newAPIErrorResponse(getErr, http.StatusNotFound, operation, "SubmodelNotFound"), nil
@@ -1554,17 +1545,13 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelByIDValueOnly(ctx context.C
 		return newAPIErrorResponse(extentErr, http.StatusBadRequest, operation, "InvalidExtentParameter"), nil
 	}
 
-	sm, err := s.submodelBackend.GetSubmodelByID(ctx, string(decodedSubmodelIdentifier), level, false)
+	sm, err := s.submodelBackend.GetSubmodelByID(ctx, string(decodedSubmodelIdentifier), level, false, normalizedExtent == extentWithBlobValue)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelNotFound"), nil
 		}
 		return newAPIErrorResponse(err, http.StatusInternalServerError, operation, "GetSubmodelByID"), nil
 	}
-	if normalizedExtent == extentWithoutBlobValue {
-		stripBlobValuesFromSubmodel(sm)
-	}
-
 	valueOnly, convErr := gen.SubmodelToValueOnly(sm)
 	if convErr != nil {
 		return newAPIErrorResponse(convErr, http.StatusInternalServerError, operation, "SubmodelToValueOnly"), nil
@@ -1703,7 +1690,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetAllSubmodelElements(ctx context.Con
 		return newAPIErrorResponse(extentErr, http.StatusBadRequest, operation, "InvalidExtentParameter"), nil
 	}
 
-	elements, nextCursor, err := s.submodelBackend.GetSubmodelElements(ctx, string(decodedSubmodelIdentifier), limitPtr, decodedCursor, false, level)
+	elements, nextCursor, err := s.submodelBackend.GetSubmodelElements(ctx, string(decodedSubmodelIdentifier), limitPtr, decodedCursor, normalizedExtent == extentWithBlobValue, level)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelNotFound"), nil
@@ -1716,9 +1703,6 @@ func (s *SubmodelRepositoryAPIAPIService) GetAllSubmodelElements(ctx context.Con
 
 	converted := make([]map[string]any, 0, len(elements))
 	for _, element := range elements {
-		if normalizedExtent == extentWithoutBlobValue {
-			stripBlobValuesFromElement(element)
-		}
 		jsonSubmodelElement, convErr := jsonization.ToJsonable(element)
 		if convErr != nil {
 			return newAPIErrorResponse(convErr, http.StatusInternalServerError, operation, "ToJsonable"), nil
@@ -1799,7 +1783,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetAllSubmodelElementsMetadataSubmodel
 		return newAPIErrorResponse(cursorDecodeErr, http.StatusBadRequest, operation, "BadCursor"), nil
 	}
 
-	elements, nextCursor, err := s.submodelBackend.GetSubmodelElements(ctx, decodedSubmodelIdentifier, buildLimitPtr(limit), decodedCursor, false, "")
+	elements, nextCursor, err := s.submodelBackend.GetSubmodelElements(ctx, decodedSubmodelIdentifier, buildLimitPtr(limit), decodedCursor, true, "")
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelNotFound"), nil
@@ -1860,7 +1844,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetAllSubmodelElementsValueOnlySubmode
 		limitPtr = &parsedLimit
 	}
 
-	elements, nextCursor, err := s.submodelBackend.GetSubmodelElements(ctx, string(decodedSubmodelIdentifier), limitPtr, decodedCursor, true, level)
+	elements, nextCursor, err := s.submodelBackend.GetSubmodelElements(ctx, string(decodedSubmodelIdentifier), limitPtr, decodedCursor, normalizedExtent == extentWithBlobValue, level)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelNotFound"), nil
@@ -1873,9 +1857,6 @@ func (s *SubmodelRepositoryAPIAPIService) GetAllSubmodelElementsValueOnlySubmode
 
 	valueOnlyResults := make([]gen.SubmodelElementValue, 0, len(elements))
 	for _, element := range elements {
-		if normalizedExtent == extentWithoutBlobValue {
-			stripBlobValuesFromElement(element)
-		}
 		valueOnly, convErr := gen.SubmodelElementToValueOnly(element)
 		if convErr != nil {
 			return newAPIErrorResponse(convErr, http.StatusInternalServerError, operation, "SubmodelElementToValueOnly"), nil
@@ -2010,7 +1991,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathSubmodelRepo(c
 		return newAPIErrorResponse(decodeErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
 	}
 
-	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, level)
+	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, normalizedExtent == extentWithBlobValue, level)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelElementNotFound"), nil
@@ -2020,10 +2001,6 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathSubmodelRepo(c
 		}
 		return newAPIErrorResponse(err, http.StatusInternalServerError, operation, "GetSubmodelElement"), nil
 	}
-	if normalizedExtent == extentWithoutBlobValue {
-		stripBlobValuesFromElement(element)
-	}
-
 	converted, convErr := jsonization.ToJsonable(element)
 	if convErr != nil {
 		return newAPIErrorResponse(convErr, http.StatusInternalServerError, operation, "ToJsonable"), nil
@@ -2166,7 +2143,7 @@ func (s *SubmodelRepositoryAPIAPIService) PatchSubmodelElementByPathSubmodelRepo
 		return newAPIErrorResponse(errors.New("submodel element payload is required"), http.StatusBadRequest, operation, "MissingSubmodelElementPayload"), nil
 	}
 
-	existingElement, getErr := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, level)
+	existingElement, getErr := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, true, level)
 	if getErr != nil {
 		if common.IsErrNotFound(getErr) || errors.Is(getErr, sql.ErrNoRows) {
 			return newAPIErrorResponse(getErr, http.StatusNotFound, operation, "SubmodelElementNotFound"), nil
@@ -2224,7 +2201,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathMetadataSubmod
 		return newAPIErrorResponse(decodeErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
 	}
 
-	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, "")
+	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, true, "")
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelElementNotFound"), nil
@@ -2254,7 +2231,7 @@ func (s *SubmodelRepositoryAPIAPIService) PatchSubmodelElementByPathMetadataSubm
 		return newAPIErrorResponse(decodeErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
 	}
 
-	existingElement, getErr := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, "")
+	existingElement, getErr := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, true, "")
 	if getErr != nil {
 		if errors.Is(getErr, sql.ErrNoRows) || common.IsErrNotFound(getErr) {
 			return newAPIErrorResponse(getErr, http.StatusNotFound, operation, "SubmodelElementNotFound"), nil
@@ -2325,7 +2302,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathValueOnlySubmo
 		return newAPIErrorResponse(extentErr, http.StatusBadRequest, operation, "InvalidExtentParameter"), nil
 	}
 
-	element, err := s.submodelBackend.GetSubmodelElement(ctx, string(decodedSubmodelIdentifier), idShortPath, true, level)
+	element, err := s.submodelBackend.GetSubmodelElement(ctx, string(decodedSubmodelIdentifier), idShortPath, normalizedExtent == extentWithBlobValue, level)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelElementNotFound"), nil
@@ -2335,10 +2312,6 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathValueOnlySubmo
 		}
 		return newAPIErrorResponse(err, http.StatusInternalServerError, operation, "GetSubmodelElement"), nil
 	}
-	if normalizedExtent == extentWithoutBlobValue {
-		stripBlobValuesFromElement(element)
-	}
-
 	valueOnly, convErr := gen.SubmodelElementToValueOnly(element)
 	if convErr != nil {
 		return newAPIErrorResponse(convErr, http.StatusInternalServerError, operation, "SubmodelElementToValueOnly"), nil
@@ -2389,7 +2362,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathReferenceSubmo
 		return newAPIErrorResponse(decodeErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
 	}
 
-	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, "")
+	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, true, "")
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelElementNotFound"), nil
@@ -2410,7 +2383,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathReferenceSubmo
 		idShortPath,
 		modelTypeLiteral,
 		func(path string) (string, error) {
-			parentElement, parentErr := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, path, false, "")
+			parentElement, parentErr := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, path, true, "")
 			if parentErr != nil {
 				if common.IsErrBadRequest(parentErr) || common.IsErrNotFound(parentErr) {
 					return "", parentErr
@@ -2492,7 +2465,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetFileByPathSubmodelRepo(ctx context.
 		return newAPIErrorResponse(decodeErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
 	}
 
-	fileSme, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, "")
+	fileSme, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, true, "")
 	if err != nil {
 		if common.IsErrNotFound(err) || errors.Is(err, sql.ErrNoRows) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelElementNotFound"), nil
@@ -2553,7 +2526,7 @@ func (s *SubmodelRepositoryAPIAPIService) PutFileByPathSubmodelRepo(ctx context.
 
 	if shouldEnforceExtraSecurityCheck {
 		ctx = auth.SelectPutFormulaByExistence(ctx, hasAttachment)
-		_, err = s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, "")
+		_, err = s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, true, "")
 		if err != nil {
 			if common.IsErrNotFound(err) || errors.Is(err, sql.ErrNoRows) || common.IsErrDenied(err) {
 				deniedErr := common.NewErrDenied("SMREPO-PUTFILEBYPATH-ABACDENIED writing this file attachment is not allowed")
@@ -2906,7 +2879,7 @@ func (s *SubmodelRepositoryAPIAPIService) QuerySubmodels(
 		sm := sms[index]
 		eg.Go(func() error {
 			elementQueryCtx := auth.MergeQueryFilter(ctx, query)
-			submodelElements, _, elementsErr := s.submodelBackend.GetSubmodelElements(elementQueryCtx, sm.ID(), nil, "", false, "")
+			submodelElements, _, elementsErr := s.submodelBackend.GetSubmodelElements(elementQueryCtx, sm.ID(), nil, "", true, "")
 			if elementsErr != nil {
 				return elementsErr
 			}

--- a/internal/submodelrepository/api/api_submodel_repository_api_service.go
+++ b/internal/submodelrepository/api/api_submodel_repository_api_service.go
@@ -1783,7 +1783,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetAllSubmodelElementsMetadataSubmodel
 		return newAPIErrorResponse(cursorDecodeErr, http.StatusBadRequest, operation, "BadCursor"), nil
 	}
 
-	elements, nextCursor, err := s.submodelBackend.GetSubmodelElements(ctx, decodedSubmodelIdentifier, buildLimitPtr(limit), decodedCursor, true, "")
+	elements, nextCursor, err := s.submodelBackend.GetSubmodelElements(ctx, decodedSubmodelIdentifier, buildLimitPtr(limit), decodedCursor, false, "")
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelNotFound"), nil
@@ -2201,7 +2201,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathMetadataSubmod
 		return newAPIErrorResponse(decodeErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
 	}
 
-	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, true, "")
+	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, "")
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelElementNotFound"), nil
@@ -2362,7 +2362,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathReferenceSubmo
 		return newAPIErrorResponse(decodeErr, http.StatusBadRequest, operation, "MalformedSubmodelIdentifier"), nil
 	}
 
-	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, true, "")
+	element, err := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, idShortPath, false, "core")
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) || common.IsErrNotFound(err) {
 			return newAPIErrorResponse(err, http.StatusNotFound, operation, "SubmodelElementNotFound"), nil
@@ -2383,7 +2383,7 @@ func (s *SubmodelRepositoryAPIAPIService) GetSubmodelElementByPathReferenceSubmo
 		idShortPath,
 		modelTypeLiteral,
 		func(path string) (string, error) {
-			parentElement, parentErr := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, path, true, "")
+			parentElement, parentErr := s.submodelBackend.GetSubmodelElement(ctx, decodedSubmodelIdentifier, path, false, "core")
 			if parentErr != nil {
 				if common.IsErrBadRequest(parentErr) || common.IsErrNotFound(parentErr) {
 					return "", parentErr

--- a/internal/submodelrepository/api/api_utils.go
+++ b/internal/submodelrepository/api/api_utils.go
@@ -161,7 +161,7 @@ func normalizeExtent(extent string) (string, error) {
 	return "", common.NewErrBadRequest("SMREPO-NORMEXT-BADVALUE invalid extent parameter")
 }
 
-func stripBlobValuesFromSubmodel(submodel types.ISubmodel) {
+func stripBlobValuesFromHistoricalSubmodel(submodel types.ISubmodel) {
 	if submodel == nil {
 		return
 	}

--- a/internal/submodelrepository/integration_tests/submodelrepository_extent_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_extent_integration_test.go
@@ -43,8 +43,9 @@ func TestSubmodelRepositoryExtentShapesBlobValues(t *testing.T) {
 	submodelIDEncoded := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
 	topBlobValue := base64.StdEncoding.EncodeToString([]byte("top-blob-value"))
 	nestedBlobValue := base64.StdEncoding.EncodeToString([]byte("nested-blob-value"))
+	operationBlobValue := base64.StdEncoding.EncodeToString([]byte("operation-blob-value"))
 
-	payload := extentTestSubmodelPayload(submodelID, topBlobValue, nestedBlobValue)
+	payload := extentTestSubmodelPayload(submodelID, topBlobValue, nestedBlobValue, operationBlobValue)
 	statusCode, body, err := requestJSON(http.MethodPost, baseURL+"/submodels", payload)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
@@ -67,6 +68,9 @@ func TestSubmodelRepositoryExtentShapesBlobValues(t *testing.T) {
 			require.Equal(t, http.StatusOK, status, "response=%s", string(responseBody))
 			requireSubmodelBlobValueState(t, decodeMap(t, responseBody), "TopBlob", "text/plain", "", false)
 			requireSubmodelBlobValueState(t, decodeMap(t, responseBody), "NestedBlob", "application/octet-stream", "", false)
+			requireOperationVariableBlobValueState(t, decodeMap(t, responseBody), "inputVariables", "OperationInputBlob", "", false)
+			requireOperationVariableBlobValueState(t, decodeMap(t, responseBody), "outputVariables", "OperationOutputBlob", "", false)
+			requireOperationVariableBlobValueState(t, decodeMap(t, responseBody), "inoutputVariables", "OperationInoutputBlob", "", false)
 		}
 	})
 
@@ -77,6 +81,9 @@ func TestSubmodelRepositoryExtentShapesBlobValues(t *testing.T) {
 		payload := decodeMap(t, responseBody)
 		requireSubmodelBlobValueState(t, payload, "TopBlob", "text/plain", topBlobValue, true)
 		requireSubmodelBlobValueState(t, payload, "NestedBlob", "application/octet-stream", nestedBlobValue, true)
+		requireOperationVariableBlobValueState(t, payload, "inputVariables", "OperationInputBlob", operationBlobValue, true)
+		requireOperationVariableBlobValueState(t, payload, "outputVariables", "OperationOutputBlob", operationBlobValue, true)
+		requireOperationVariableBlobValueState(t, payload, "inoutputVariables", "OperationInoutputBlob", operationBlobValue, true)
 	})
 
 	t.Run("value-only submodel honors extent", func(t *testing.T) {
@@ -110,6 +117,31 @@ func TestSubmodelRepositoryExtentShapesBlobValues(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, status, "response=%s", string(responseBody))
 		requireElementBlobValueState(t, decodeMap(t, responseBody), "text/plain", topBlobValue, true)
+
+		status, responseBody, err = requestJSON(http.MethodGet, baseURL+"/submodels/"+submodelIDEncoded+"/submodel-elements/TestOperation", nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status, "response=%s", string(responseBody))
+		requireOperationBlobValueState(t, decodeMap(t, responseBody), "inputVariables", "OperationInputBlob", "", false)
+		requireOperationBlobValueState(t, decodeMap(t, responseBody), "outputVariables", "OperationOutputBlob", "", false)
+		requireOperationBlobValueState(t, decodeMap(t, responseBody), "inoutputVariables", "OperationInoutputBlob", "", false)
+
+		status, responseBody, err = requestJSON(http.MethodGet, baseURL+"/submodels/"+submodelIDEncoded+"/submodel-elements/TestOperation?extent=withBlobValue", nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status, "response=%s", string(responseBody))
+		requireOperationBlobValueState(t, decodeMap(t, responseBody), "inputVariables", "OperationInputBlob", operationBlobValue, true)
+		requireOperationBlobValueState(t, decodeMap(t, responseBody), "outputVariables", "OperationOutputBlob", operationBlobValue, true)
+		requireOperationBlobValueState(t, decodeMap(t, responseBody), "inoutputVariables", "OperationInoutputBlob", operationBlobValue, true)
+	})
+
+	t.Run("metadata and reference reads do not require blob values", func(t *testing.T) {
+		status, responseBody, err := requestJSON(http.MethodGet, baseURL+"/submodels/"+submodelIDEncoded+"/submodel-elements/TopBlob/$metadata", nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status, "response=%s", string(responseBody))
+		requireElementBlobValueState(t, decodeMap(t, responseBody), "text/plain", "", false)
+
+		status, responseBody, err = requestJSON(http.MethodGet, baseURL+"/submodels/"+submodelIDEncoded+"/submodel-elements/MainCollection.NestedBlob/$reference", nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, status, "response=%s", string(responseBody))
 	})
 
 	t.Run("value-only submodel element reads honor extent", func(t *testing.T) {
@@ -154,8 +186,9 @@ func TestSubmodelRepositoryHistoryExtentAndCoreLevel(t *testing.T) {
 	submodelIDEncoded := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
 	topBlobValue := base64.StdEncoding.EncodeToString([]byte("history-top-blob-value"))
 	nestedBlobValue := base64.StdEncoding.EncodeToString([]byte("history-nested-blob-value"))
+	operationBlobValue := base64.StdEncoding.EncodeToString([]byte("history-operation-blob-value"))
 
-	statusCode, body, err := requestJSON(http.MethodPost, baseURL+"/submodels", extentTestSubmodelPayload(submodelID, topBlobValue, nestedBlobValue))
+	statusCode, body, err := requestJSON(http.MethodPost, baseURL+"/submodels", extentTestSubmodelPayload(submodelID, topBlobValue, nestedBlobValue, operationBlobValue))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
 
@@ -171,12 +204,14 @@ func TestSubmodelRepositoryHistoryExtentAndCoreLevel(t *testing.T) {
 	require.Equal(t, http.StatusOK, status, "response=%s", string(responseBody))
 	requireSubmodelBlobValueState(t, decodeMap(t, responseBody), "TopBlob", "text/plain", topBlobValue, true)
 	requireSubmodelBlobValueState(t, decodeMap(t, responseBody), "NestedBlob", "application/octet-stream", nestedBlobValue, true)
+	requireOperationVariableBlobValueState(t, decodeMap(t, responseBody), "inputVariables", "OperationInputBlob", operationBlobValue, true)
 
 	status, responseBody, err = requestJSON(http.MethodGet, fmt.Sprintf("%s/submodels/%s/$history?date=%s&level=deep&extent=withoutBlobValue", baseURL, submodelIDEncoded, historyDate), nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, status, "response=%s", string(responseBody))
 	requireSubmodelBlobValueState(t, decodeMap(t, responseBody), "TopBlob", "text/plain", "", false)
 	requireSubmodelBlobValueState(t, decodeMap(t, responseBody), "NestedBlob", "application/octet-stream", "", false)
+	requireOperationVariableBlobValueState(t, decodeMap(t, responseBody), "inputVariables", "OperationInputBlob", "", false)
 
 	status, responseBody, err = requestJSON(http.MethodGet, fmt.Sprintf("%s/submodels/%s/$history?date=%s&level=core&extent=withBlobValue", baseURL, submodelIDEncoded, historyDate), nil)
 	require.NoError(t, err)
@@ -188,7 +223,7 @@ func TestSubmodelRepositoryHistoryExtentAndCoreLevel(t *testing.T) {
 	require.False(t, hasNestedValue, "core historical collection must not include nested value payload")
 }
 
-func extentTestSubmodelPayload(submodelID string, topBlobValue string, nestedBlobValue string) map[string]any {
+func extentTestSubmodelPayload(submodelID string, topBlobValue string, nestedBlobValue string, operationBlobValue string) map[string]any {
 	return map[string]any{
 		"id":        submodelID,
 		"idShort":   "ExtentSubmodel",
@@ -216,6 +251,46 @@ func extentTestSubmodelPayload(submodelID string, topBlobValue string, nestedBlo
 						"modelType": "Property",
 						"valueType": "xs:string",
 						"value":     "nested",
+					},
+				},
+			},
+			map[string]any{
+				"idShort":   "TestOperation",
+				"modelType": "Operation",
+				"inputVariables": []any{
+					map[string]any{
+						"value": map[string]any{
+							"idShort":     "OperationInputBlob",
+							"modelType":   "Blob",
+							"contentType": "application/octet-stream",
+							"value":       operationBlobValue,
+						},
+					},
+				},
+				"outputVariables": []any{
+					map[string]any{
+						"value": map[string]any{
+							"idShort":   "OperationOutputCollection",
+							"modelType": "SubmodelElementCollection",
+							"value": []any{
+								map[string]any{
+									"idShort":     "OperationOutputBlob",
+									"modelType":   "Blob",
+									"contentType": "application/octet-stream",
+									"value":       operationBlobValue,
+								},
+							},
+						},
+					},
+				},
+				"inoutputVariables": []any{
+					map[string]any{
+						"value": map[string]any{
+							"idShort":     "OperationInoutputBlob",
+							"modelType":   "Blob",
+							"contentType": "application/octet-stream",
+							"value":       operationBlobValue,
+						},
 					},
 				},
 			},
@@ -251,6 +326,28 @@ func requireValueOnlyBlobValueState(t *testing.T, raw any, contentType string, e
 	if expectValue {
 		require.Equal(t, expectedValue, actualValue)
 	}
+}
+
+func requireOperationVariableBlobValueState(t *testing.T, submodel map[string]any, variableField string, idShort string, expectedValue string, expectValue bool) {
+	t.Helper()
+	rawElements, ok := submodel["submodelElements"].([]any)
+	require.True(t, ok, "submodelElements must be an array")
+	requireOperationBlobValueState(t, findSubmodelElementInList(t, rawElements, "TestOperation"), variableField, idShort, expectedValue, expectValue)
+}
+
+func requireOperationBlobValueState(t *testing.T, operation map[string]any, variableField string, idShort string, expectedValue string, expectValue bool) {
+	t.Helper()
+	rawVariables, ok := operation[variableField].([]any)
+	require.True(t, ok, "%s must be an array: %#v", variableField, operation[variableField])
+
+	variableValues := make([]any, 0, len(rawVariables))
+	for _, rawVariable := range rawVariables {
+		variable, variableOK := rawVariable.(map[string]any)
+		require.True(t, variableOK, "operation variable must be an object: %#v", rawVariable)
+		variableValues = append(variableValues, variable["value"])
+	}
+
+	requireElementBlobValueState(t, findSubmodelElementInList(t, variableValues, idShort), "application/octet-stream", expectedValue, expectValue)
 }
 
 func findSubmodelElementInList(t *testing.T, rawElements []any, idShort string) map[string]any {

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
@@ -57,7 +57,7 @@ type dbQueryer interface {
 }
 
 // GetSubmodelElementByIDShortOrPath loads a submodel element by path and applies optional ABAC formula filters from ctx.
-func GetSubmodelElementByIDShortOrPath(ctx context.Context, db *sql.DB, submodelID string, idShortOrPath string, level string) (types.ISubmodelElement, error) {
+func GetSubmodelElementByIDShortOrPath(ctx context.Context, db *sql.DB, submodelID string, idShortOrPath string, includeBlobValue bool, level string) (types.ISubmodelElement, error) {
 	if submodelID == "" {
 		return nil, common.NewErrBadRequest("SMREPO-GETSMEBYPATH-EMPTYSMID Submodel id must not be empty")
 	}
@@ -76,11 +76,11 @@ func GetSubmodelElementByIDShortOrPath(ctx context.Context, db *sql.DB, submodel
 		return nil, common.NewInternalServerError("SMREPO-GETSMEBYPATH-GETSMDATABASEID " + submodelIDErr.Error())
 	}
 
-	return getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx, db, submodelID, int64(submodelDatabaseID), idShortOrPath, level)
+	return getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx, db, submodelID, int64(submodelDatabaseID), idShortOrPath, level, includeBlobValue)
 }
 
 // GetSubmodelElementByIDShortOrPathTx loads a submodel element by path from an existing transaction.
-func GetSubmodelElementByIDShortOrPathTx(ctx context.Context, tx *sql.Tx, submodelID string, idShortOrPath string, level string) (types.ISubmodelElement, error) {
+func GetSubmodelElementByIDShortOrPathTx(ctx context.Context, tx *sql.Tx, submodelID string, idShortOrPath string, includeBlobValue bool, level string) (types.ISubmodelElement, error) {
 	if tx == nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMEBYPATHTX-NILTX transaction must not be nil")
 	}
@@ -102,12 +102,12 @@ func GetSubmodelElementByIDShortOrPathTx(ctx context.Context, tx *sql.Tx, submod
 		return nil, common.NewInternalServerError("SMREPO-GETSMEBYPATHTX-GETSMDATABASEID " + submodelIDErr.Error())
 	}
 
-	return getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx, tx, submodelID, int64(submodelDatabaseID), idShortOrPath, level)
+	return getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx, tx, submodelID, int64(submodelDatabaseID), idShortOrPath, level, includeBlobValue)
 }
 
-func getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx context.Context, db dbQueryer, submodelID string, submodelDatabaseID int64, idShortOrPath string, level string) (types.ISubmodelElement, error) {
+func getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx context.Context, db dbQueryer, submodelID string, submodelDatabaseID int64, idShortOrPath string, level string, includeBlobValue bool) (types.ISubmodelElement, error) {
 	includeChildren := level != "core"
-	parsedRows, readRowsErr := readSubmodelElementRowsByPath(ctx, db, submodelDatabaseID, idShortOrPath, includeChildren)
+	parsedRows, readRowsErr := readSubmodelElementRowsByPath(ctx, db, submodelDatabaseID, idShortOrPath, includeChildren, includeBlobValue)
 
 	if readRowsErr != nil {
 		return nil, readRowsErr
@@ -413,7 +413,7 @@ func GetSubmodelElementPathsByPath(ctx context.Context, db *sql.DB, submodelID s
 
 // GetSubmodelElementsBySubmodelID loads top-level submodel elements and reconstructs
 // each complete subtree in original hierarchy.
-func GetSubmodelElementsBySubmodelID(ctx context.Context, db *sql.DB, submodelID string, limit *int, cursor string, level string) ([]types.ISubmodelElement, string, error) {
+func GetSubmodelElementsBySubmodelID(ctx context.Context, db *sql.DB, submodelID string, limit *int, cursor string, includeBlobValue bool, level string) ([]types.ISubmodelElement, string, error) {
 	if submodelID == "" {
 		return nil, "", common.NewErrBadRequest("SMREPO-GETSMES-EMPTYSMID Submodel id must not be empty")
 	}
@@ -434,11 +434,11 @@ func GetSubmodelElementsBySubmodelID(ctx context.Context, db *sql.DB, submodelID
 		return nil, "", common.NewInternalServerError("SMREPO-GETSMES-GETSMDATABASEID " + submodelIDErr.Error())
 	}
 
-	return getSubmodelElementsByDatabaseID(ctx, db, int64(submodelDatabaseID), limit, cursor, level)
+	return getSubmodelElementsByDatabaseID(ctx, db, int64(submodelDatabaseID), limit, cursor, level, includeBlobValue)
 }
 
 // GetSubmodelElementsBySubmodelIDTx loads top-level submodel elements from an existing transaction.
-func GetSubmodelElementsBySubmodelIDTx(ctx context.Context, tx *sql.Tx, submodelID string, limit *int, cursor string, level string) ([]types.ISubmodelElement, string, error) {
+func GetSubmodelElementsBySubmodelIDTx(ctx context.Context, tx *sql.Tx, submodelID string, limit *int, cursor string, includeBlobValue bool, level string) ([]types.ISubmodelElement, string, error) {
 	if tx == nil {
 		return nil, "", common.NewInternalServerError("SMREPO-GETSMES-NILTX transaction must not be nil")
 	}
@@ -460,10 +460,10 @@ func GetSubmodelElementsBySubmodelIDTx(ctx context.Context, tx *sql.Tx, submodel
 		return nil, "", common.NewInternalServerError("SMREPO-GETSMES-GETSMDATABASEID " + submodelIDErr.Error())
 	}
 
-	return getSubmodelElementsByDatabaseID(ctx, tx, int64(submodelDatabaseID), limit, cursor, level)
+	return getSubmodelElementsByDatabaseID(ctx, tx, int64(submodelDatabaseID), limit, cursor, level, includeBlobValue)
 }
 
-func getSubmodelElementsByDatabaseID(ctx context.Context, db dbQueryer, submodelDatabaseID int64, limit *int, cursor string, level string) ([]types.ISubmodelElement, string, error) {
+func getSubmodelElementsByDatabaseID(ctx context.Context, db dbQueryer, submodelDatabaseID int64, limit *int, cursor string, level string, includeBlobValue bool) ([]types.ISubmodelElement, string, error) {
 	rootElements, nextCursor, rootPathErr := getRootElementPage(ctx, db, submodelDatabaseID, limit, cursor)
 	if rootPathErr != nil {
 		return nil, "", rootPathErr
@@ -479,7 +479,7 @@ func getSubmodelElementsByDatabaseID(ctx context.Context, db dbQueryer, submodel
 
 	includeChildren := level != "core"
 	isGetSubmodelElements := true
-	parsedRows, readRowsErr := readSubmodelElementRowsByRootIDs(ctx, db, submodelDatabaseID, rootIDs, includeChildren, isGetSubmodelElements)
+	parsedRows, readRowsErr := readSubmodelElementRowsByRootIDs(ctx, db, submodelDatabaseID, rootIDs, includeChildren, isGetSubmodelElements, includeBlobValue)
 	if readRowsErr != nil {
 		return nil, "", readRowsErr
 	}
@@ -1222,7 +1222,7 @@ func buildMaskedSMEValuePayloadExpr(rawValueAlias string) exp.Expression {
 	return goqu.L("(COALESCE(?::jsonb, '{}'::jsonb) - 'value')", goqu.I(rawValueAlias))
 }
 
-func readSubmodelElementRowsByPath(ctx context.Context, db dbQueryer, submodelDatabaseID int64, idShortOrPath string, includeChildren bool) ([]loadedSMERow, error) {
+func readSubmodelElementRowsByPath(ctx context.Context, db dbQueryer, submodelDatabaseID int64, idShortOrPath string, includeChildren bool, includeBlobValue bool) ([]loadedSMERow, error) {
 	dialect := goqu.Dialect("postgres")
 	rowCollector, collectorErr := grammar.NewResolvedFieldPathCollectorForSMERow("sme")
 	if collectorErr != nil {
@@ -1246,7 +1246,7 @@ func readSubmodelElementRowsByPath(ctx context.Context, db dbQueryer, submodelDa
 	if valueVisibleErr != nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMEBYPATH-VALUEMASK " + valueVisibleErr.Error())
 	}
-	valueExpr := getSMEValueExpressionForRead(dialect)
+	valueExpr := getSMEValueExpressionForRead(dialect, includeBlobValue)
 	innerQuery := dialect.
 		From(goqu.T("submodel_element").As("sme")).
 		LeftJoin(
@@ -1348,7 +1348,7 @@ func readSubmodelElementRowsByPath(ctx context.Context, db dbQueryer, submodelDa
 	return executeLoadedSMERowQuery(ctx, db, sqlQuery, args, "SMREPO-GETSMEBYPATH")
 }
 
-func readSubmodelElementRowsByRootIDs(ctx context.Context, db dbQueryer, submodelDatabaseID int64, rootIDs []int64, includeChildren bool, isGetSubmodelElements bool) ([]loadedSMERow, error) {
+func readSubmodelElementRowsByRootIDs(ctx context.Context, db dbQueryer, submodelDatabaseID int64, rootIDs []int64, includeChildren bool, isGetSubmodelElements bool, includeBlobValue bool) ([]loadedSMERow, error) {
 	if len(rootIDs) == 0 {
 		return []loadedSMERow{}, nil
 	}
@@ -1394,7 +1394,7 @@ func readSubmodelElementRowsByRootIDs(ctx context.Context, db dbQueryer, submode
 		)
 	}
 
-	valueExpr := getSMEValueExpressionForRead(dialect)
+	valueExpr := getSMEValueExpressionForRead(dialect, includeBlobValue)
 	innerQuery := dialect.
 		From(goqu.T("submodel_element").As("sme")).
 		LeftJoin(

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
@@ -286,7 +286,7 @@ func TestGetSubmodelElementByPathCombinesAuthorizationAndPayloadQuery(t *testing
 			`.*sme_path_data`,
 	).WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
-	_, err = getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx, db, "submodel-id", 42, "Target", "deep")
+	_, err = getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx, db, "submodel-id", 42, "Target", "deep", true)
 	require.Error(t, err)
 	require.Truef(t, common.IsErrNotFound(err), "expected not found, got %v", err)
 	require.NoError(t, mock.ExpectationsWereMet())

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression.go
@@ -36,7 +36,14 @@ func temporalColumnAsText(column exp.IdentifierExpression) exp.LiteralExpression
 	return goqu.L(`trim(both '"' from to_json(?)::text)`, column)
 }
 
-func getSMEValueExpressionForRead(dialect goqu.DialectWrapper) exp.CaseExpression {
+func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue bool) exp.CaseExpression {
+	blobPayload := []interface{}{
+		goqu.V("content_type"), goqu.I("be.content_type"),
+	}
+	if includeBlobValue {
+		blobPayload = append(blobPayload, goqu.V("value"), goqu.I("be.value"))
+	}
+
 	return goqu.Case().
 		When(
 			goqu.I("sme.model_type").Eq(types.ModelTypeAnnotatedRelationshipElement),
@@ -67,10 +74,7 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper) exp.CaseExpressio
 		When(
 			goqu.I("sme.model_type").Eq(types.ModelTypeBlob),
 			dialect.From(goqu.T("blob_element").As("be")).
-				Select(goqu.Func("jsonb_build_object",
-					goqu.V("content_type"), goqu.I("be.content_type"),
-					goqu.V("value"), goqu.I("be.value"),
-				)).
+				Select(goqu.Func("jsonb_build_object", blobPayload...)).
 				Where(goqu.I("be.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
 		).

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression.go
@@ -36,6 +36,109 @@ func temporalColumnAsText(column exp.IdentifierExpression) exp.LiteralExpression
 	return goqu.L(`trim(both '"' from to_json(?)::text)`, column)
 }
 
+func operationValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue bool) exp.Expression {
+	var payload exp.Expression = goqu.Func("jsonb_build_object",
+		goqu.V("input_variables"), goqu.I("oe.input_variables"),
+		goqu.V("output_variables"), goqu.I("oe.output_variables"),
+		goqu.V("inoutput_variables"), goqu.I("oe.inoutput_variables"),
+	)
+	if !includeBlobValue {
+		payload = withoutEmbeddedBlobValues(dialect, payload)
+	}
+
+	return dialect.From(goqu.T("operation_element").As("oe")).
+		Select(payload).
+		Where(goqu.I("oe.id").Eq(goqu.I("sme.id"))).
+		Limit(1)
+}
+
+func withoutEmbeddedBlobValues(dialect goqu.DialectWrapper, payload exp.Expression) exp.Expression {
+	node := goqu.I("parent.node")
+	objectNode := goqu.Case().
+		When(goqu.Func("jsonb_typeof", node).Eq("object"), node).
+		Else(goqu.L("'{}'::jsonb"))
+	arrayNode := goqu.Case().
+		When(goqu.Func("jsonb_typeof", node).Eq("array"), node).
+		Else(goqu.L("'[]'::jsonb"))
+
+	objectChildren := dialect.
+		From(goqu.Func("jsonb_each", objectNode).As("object_child")).
+		Select(
+			goqu.I("object_child.key"),
+			goqu.I("object_child.value"),
+		)
+	arrayIndex := goqu.I("array_child.array_index")
+	arrayChildren := dialect.
+		From(goqu.L(
+			"? AS array_child(array_index)",
+			goqu.Func(
+				"generate_series",
+				0,
+				goqu.L("? - 1", goqu.Func("jsonb_array_length", arrayNode)),
+			),
+		)).
+		Select(
+			goqu.Cast(arrayIndex, "text"),
+			goqu.L("? -> ?", node, arrayIndex),
+		)
+	children := objectChildren.UnionAll(arrayChildren).As("child")
+
+	jsonNodes := dialect.
+		Select(
+			goqu.L("ARRAY[]::text[]"),
+			payload,
+		).
+		UnionAll(
+			dialect.
+				From(
+					goqu.T("operation_json_nodes").As("parent"),
+					goqu.Lateral(children),
+				).
+				Select(
+					goqu.L("? || ARRAY[?]", goqu.I("parent.path"), goqu.I("child.key")),
+					goqu.I("child.value"),
+				),
+		)
+	blobValuePaths := dialect.
+		From("operation_json_nodes").
+		Select(
+			goqu.ROW_NUMBER().Over(goqu.W().OrderBy(goqu.I("operation_json_nodes.path").Asc())),
+			goqu.L("? || ARRAY[?]", goqu.I("operation_json_nodes.path"), goqu.V("value")),
+		).
+		Where(goqu.L(
+			"? ->> ? = ?",
+			goqu.I("operation_json_nodes.node"),
+			goqu.V("modelType"),
+			goqu.V("Blob"),
+		))
+	strippedPayload := dialect.
+		Select(
+			goqu.L("0::bigint"),
+			payload,
+		).
+		UnionAll(
+			dialect.
+				From(goqu.T("stripped_operation_payload").As("current")).
+				Join(
+					goqu.T("blob_value_paths").As("target"),
+					goqu.On(goqu.I("target.position").Eq(goqu.L("? + 1", goqu.I("current.position")))),
+				).
+				Select(
+					goqu.L("? + 1", goqu.I("current.position")),
+					goqu.L("? #- ?", goqu.I("current.payload"), goqu.I("target.path")),
+				),
+		)
+
+	return dialect.
+		From("stripped_operation_payload").
+		Select("payload").
+		WithRecursive("operation_json_nodes(path, node)", jsonNodes).
+		With("blob_value_paths(position, path)", blobValuePaths).
+		With("stripped_operation_payload(position, payload)", strippedPayload).
+		Order(goqu.I("position").Desc()).
+		Limit(1)
+}
+
 func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue bool) exp.CaseExpression {
 	blobPayload := []interface{}{
 		goqu.V("content_type"), goqu.I("be.content_type"),
@@ -134,14 +237,7 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 		).
 		When(
 			goqu.I("sme.model_type").Eq(types.ModelTypeOperation),
-			dialect.From(goqu.T("operation_element").As("oe")).
-				Select(goqu.Func("jsonb_build_object",
-					goqu.V("input_variables"), goqu.I("oe.input_variables"),
-					goqu.V("output_variables"), goqu.I("oe.output_variables"),
-					goqu.V("inoutput_variables"), goqu.I("oe.inoutput_variables"),
-				)).
-				Where(goqu.I("oe.id").Eq(goqu.I("sme.id"))).
-				Limit(1),
+			operationValueExpressionForRead(dialect, includeBlobValue),
 		).
 		When(
 			goqu.I("sme.model_type").Eq(types.ModelTypeProperty),

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression_test.go
@@ -1,0 +1,53 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package submodelelements
+
+import (
+	"testing"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSMEValueExpressionForReadProjectsBlobValueOnlyWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	dialect := goqu.Dialect("postgres")
+
+	withoutBlobValueSQL, _, err := dialect.
+		Select(getSMEValueExpressionForRead(dialect, false)).
+		ToSQL()
+	require.NoError(t, err)
+	require.Contains(t, withoutBlobValueSQL, `"be"."content_type"`)
+	require.NotContains(t, withoutBlobValueSQL, `"be"."value"`)
+
+	withBlobValueSQL, _, err := dialect.
+		Select(getSMEValueExpressionForRead(dialect, true)).
+		ToSQL()
+	require.NoError(t, err)
+	require.Contains(t, withBlobValueSQL, `"be"."content_type"`)
+	require.Contains(t, withBlobValueSQL, `"be"."value"`)
+}

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression_test.go
@@ -51,3 +51,24 @@ func TestGetSMEValueExpressionForReadProjectsBlobValueOnlyWhenRequested(t *testi
 	require.Contains(t, withBlobValueSQL, `"be"."content_type"`)
 	require.Contains(t, withBlobValueSQL, `"be"."value"`)
 }
+
+func TestGetSMEValueExpressionForReadSanitizesOperationVariableBlobs(t *testing.T) {
+	t.Parallel()
+
+	dialect := goqu.Dialect("postgres")
+
+	withoutBlobValueSQL, _, err := dialect.
+		Select(getSMEValueExpressionForRead(dialect, false)).
+		ToSQL()
+	require.NoError(t, err)
+	require.Contains(t, withoutBlobValueSQL, "WITH RECURSIVE operation_json_nodes")
+	require.Contains(t, withoutBlobValueSQL, `"current"."payload" #- "target"."path"`)
+	require.Contains(t, withoutBlobValueSQL, `"operation_json_nodes"."node" ->> 'modelType' = 'Blob'`)
+
+	withBlobValueSQL, _, err := dialect.
+		Select(getSMEValueExpressionForRead(dialect, true)).
+		ToSQL()
+	require.NoError(t, err)
+	require.NotContains(t, withBlobValueSQL, "WITH RECURSIVE operation_json_nodes")
+	require.NotContains(t, withBlobValueSQL, `"current"."payload" #- "target"."path"`)
+}

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -108,7 +108,7 @@ func TestGetSubmodelByIDReturnsErrorWhenParallelReadsFail(t *testing.T) {
 
 	mock.ExpectQuery(`SELECT .*`).WillReturnError(errors.New("read failed"))
 
-	item, err := sut.GetSubmodelByID(contextWithABACDisabled(t), "", "", false)
+	item, err := sut.GetSubmodelByID(contextWithABACDisabled(t), "", "", false, true)
 	require.Error(t, err)
 	require.Nil(t, item)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -181,7 +181,7 @@ func TestGetSubmodelElementEmptyPathReturnsBadRequest(t *testing.T) {
 
 	sut := &SubmodelDatabase{db: db}
 
-	elem, err := sut.GetSubmodelElement(contextWithABACDisabled(t), "sm", "", false, "")
+	elem, err := sut.GetSubmodelElement(contextWithABACDisabled(t), "sm", "", true, "")
 	require.Error(t, err)
 	require.Nil(t, elem)
 	require.True(t, common.IsErrBadRequest(err))
@@ -199,7 +199,7 @@ func TestGetSubmodelElementWithLevelInvalidLevelReturnsBadRequest(t *testing.T) 
 
 	sut := &SubmodelDatabase{db: db}
 
-	elem, err := sut.GetSubmodelElement(contextWithABACDisabled(t), "sm", "root", false, "invalid")
+	elem, err := sut.GetSubmodelElement(contextWithABACDisabled(t), "sm", "root", true, "invalid")
 	require.Error(t, err)
 	require.Nil(t, elem)
 	require.True(t, common.IsErrBadRequest(err))
@@ -247,7 +247,7 @@ func TestGetSubmodelElementWithLevelCoreReturnsElementWithoutChildren(t *testing
 			),
 		)
 
-	elem, err := sut.GetSubmodelElement(contextWithABACDisabled(t), "sm-core", "RootCollection", false, "core")
+	elem, err := sut.GetSubmodelElement(contextWithABACDisabled(t), "sm-core", "RootCollection", true, "core")
 	require.NoError(t, err)
 	require.NotNil(t, elem)
 
@@ -269,7 +269,7 @@ func TestGetSubmodelElementsEmptySubmodelIDReturnsBadRequest(t *testing.T) {
 
 	sut := &SubmodelDatabase{db: db}
 
-	elems, cursor, err := sut.GetSubmodelElements(contextWithABACDisabled(t), "", nil, "", false, "")
+	elems, cursor, err := sut.GetSubmodelElements(contextWithABACDisabled(t), "", nil, "", true, "")
 	require.Error(t, err)
 	require.Nil(t, elems)
 	require.Empty(t, cursor)
@@ -320,7 +320,7 @@ func TestGetSubmodelElementsCoreReturnsOnlyRootElements(t *testing.T) {
 			),
 		)
 
-	elems, cursor, err := sut.GetSubmodelElements(contextWithABACDisabled(t), "sm-core", nil, "", false, "core")
+	elems, cursor, err := sut.GetSubmodelElements(contextWithABACDisabled(t), "sm-core", nil, "", true, "core")
 	require.NoError(t, err)
 	require.Empty(t, cursor)
 	require.Len(t, elems, 1)
@@ -397,7 +397,7 @@ func TestGetSubmodelElementsDeepReturnsRootWithChildren(t *testing.T) {
 			),
 		)
 
-	elems, cursor, err := sut.GetSubmodelElements(contextWithABACDisabled(t), "sm-deep", nil, "", false, "deep")
+	elems, cursor, err := sut.GetSubmodelElements(contextWithABACDisabled(t), "sm-deep", nil, "", true, "deep")
 	require.NoError(t, err)
 	require.Empty(t, cursor)
 	require.Len(t, elems, 1)

--- a/internal/submodelrepository/persistence/submodel_element_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_element_write_database.go
@@ -122,13 +122,13 @@ func (s *SubmodelDatabase) updateSubmodelElementInTransaction(tx *sql.Tx, submod
 }
 
 // GetSubmodelElement retrieves a submodel element by path and applies optional ABAC formula filters from ctx.
-func (s *SubmodelDatabase) GetSubmodelElement(ctx context.Context, submodelID string, idShortOrPath string, _ bool, level string) (types.ISubmodelElement, error) {
-	return submodelelements.GetSubmodelElementByIDShortOrPath(ctx, s.db, submodelID, idShortOrPath, level)
+func (s *SubmodelDatabase) GetSubmodelElement(ctx context.Context, submodelID string, idShortOrPath string, includeBlobValue bool, level string) (types.ISubmodelElement, error) {
+	return submodelelements.GetSubmodelElementByIDShortOrPath(ctx, s.db, submodelID, idShortOrPath, includeBlobValue, level)
 }
 
 // GetSubmodelElements retrieves submodel elements and applies optional ABAC formula filters from ctx.
-func (s *SubmodelDatabase) GetSubmodelElements(ctx context.Context, submodelID string, limit *int, cursor string, _ bool, level string) ([]types.ISubmodelElement, string, error) {
-	return submodelelements.GetSubmodelElementsBySubmodelID(ctx, s.db, submodelID, limit, cursor, level)
+func (s *SubmodelDatabase) GetSubmodelElements(ctx context.Context, submodelID string, limit *int, cursor string, includeBlobValue bool, level string) ([]types.ISubmodelElement, string, error) {
+	return submodelelements.GetSubmodelElementsBySubmodelID(ctx, s.db, submodelID, limit, cursor, includeBlobValue, level)
 }
 
 // GetSubmodelElementPaths retrieves submodel element paths directly from persisted idshort_path values.
@@ -208,7 +208,7 @@ func (s *SubmodelDatabase) addSubmodelElementWithPathInTransaction(ctx context.C
 		return err
 	}
 
-	parentElement, err := submodelelements.GetSubmodelElementByIDShortOrPath(ctx, s.db, submodelID, parentPath, "")
+	parentElement, err := submodelelements.GetSubmodelElementByIDShortOrPath(ctx, s.db, submodelID, parentPath, true, "")
 	if err != nil {
 		return err
 	}

--- a/internal/submodelrepository/persistence/submodel_history_snapshot.go
+++ b/internal/submodelrepository/persistence/submodel_history_snapshot.go
@@ -115,7 +115,7 @@ func loadSubmodelElementRootSnapshotTx(ctx context.Context, tx *sql.Tx, submodel
 	if history.ActiveConfig().EvidenceEnabled {
 		stateReadCtx = auth.ContextWithoutQueryFilter(ctx)
 	}
-	rootElement, err := submodelelements.GetSubmodelElementByIDShortOrPathTx(stateReadCtx, tx, submodelID, rootPath, "deep")
+	rootElement, err := submodelelements.GetSubmodelElementByIDShortOrPathTx(stateReadCtx, tx, submodelID, rootPath, true, "deep")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/submodelrepository/persistence/submodel_read_database.go
+++ b/internal/submodelrepository/persistence/submodel_read_database.go
@@ -48,7 +48,7 @@ import (
 )
 
 // GetSubmodelByID retrieves a submodel by identifier and applies optional ABAC formula filters from ctx.
-func (s *SubmodelDatabase) GetSubmodelByID(ctx context.Context, submodelIdentifier string, level string, metadataOnly bool) (types.ISubmodel, error) {
+func (s *SubmodelDatabase) GetSubmodelByID(ctx context.Context, submodelIdentifier string, level string, metadataOnly bool, includeBlobValue bool) (types.ISubmodel, error) {
 	eg := errgroup.Group{}
 	var submodels []types.ISubmodel
 	eg.Go(func() error {
@@ -69,7 +69,7 @@ func (s *SubmodelDatabase) GetSubmodelByID(ctx context.Context, submodelIdentifi
 	if !metadataOnly {
 		eg.Go(func() error {
 			unlimited := -1
-			smes, _, err := s.GetSubmodelElements(ctx, submodelIdentifier, &unlimited, "", false, level)
+			smes, _, err := s.GetSubmodelElements(ctx, submodelIdentifier, &unlimited, "", includeBlobValue, level)
 			if err != nil {
 				return err
 			}
@@ -166,7 +166,7 @@ func (s *SubmodelDatabase) getSubmodelByIDInTransaction(ctx context.Context, tx 
 	}
 
 	unlimited := -1
-	submodelElements, _, err := submodelelements.GetSubmodelElementsBySubmodelIDTx(ctx, tx, submodelIdentifier, &unlimited, "", level)
+	submodelElements, _, err := submodelelements.GetSubmodelElementsBySubmodelIDTx(ctx, tx, submodelIdentifier, &unlimited, "", true, level)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/submodelrepository/persistence/submodel_signing.go
+++ b/internal/submodelrepository/persistence/submodel_signing.go
@@ -62,7 +62,7 @@ func (s *SubmodelDatabase) GetSignedSubmodel(ctx context.Context, submodelID str
 		return "", errors.New("JWS signing not configured: private key not loaded")
 	}
 
-	submodel, err := s.GetSubmodelByID(ctx, submodelID, "deep", false)
+	submodel, err := s.GetSubmodelByID(ctx, submodelID, "deep", false, true)
 	if err != nil {
 		return "", err
 	}
@@ -103,7 +103,7 @@ func (s *SubmodelDatabase) GetSignedSubmodelValueOnly(ctx context.Context, submo
 		return "", errors.New("JWS signing not configured: private key not loaded")
 	}
 
-	submodel, err := s.GetSubmodelByID(ctx, submodelID, "deep", false)
+	submodel, err := s.GetSubmodelByID(ctx, submodelID, "deep", false, true)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/dppapiservice/go/dpp_repository_service.go
+++ b/pkg/dppapiservice/go/dpp_repository_service.go
@@ -486,7 +486,7 @@ func (s *DPPRepositoryService) ReadDataElement(ctx context.Context, dppID string
 	if err != nil {
 		return errorResponse(http.StatusBadRequest, err), nil
 	}
-	element, err := s.submodelRepo.GetSubmodelElement(ctx, submodelID, idShortPath, false, "deep")
+	element, err := s.submodelRepo.GetSubmodelElement(ctx, submodelID, idShortPath, true, "deep")
 	if err != nil {
 		return mapPersistenceError(err, http.StatusNotFound), nil
 	}
@@ -522,7 +522,7 @@ func (s *DPPRepositoryService) UpdateDataElementFromJSON(ctx context.Context, dp
 	if err != nil {
 		return errorResponse(http.StatusBadRequest, err), nil
 	}
-	existing, err := s.submodelRepo.GetSubmodelElement(ctx, submodelID, idShortPath, false, "deep")
+	existing, err := s.submodelRepo.GetSubmodelElement(ctx, submodelID, idShortPath, true, "deep")
 	if err != nil {
 		return mapPersistenceError(err, http.StatusNotFound), nil
 	}
@@ -721,7 +721,7 @@ func (s *DPPRepositoryService) resolveSubmodels(ctx context.Context, dppID strin
 		}
 		var submodel types.ISubmodel
 		if at.IsZero() {
-			submodel, err = s.submodelRepo.GetSubmodelByID(ctx, submodelID, "deep", false)
+			submodel, err = s.submodelRepo.GetSubmodelByID(ctx, submodelID, "deep", false, true)
 		} else {
 			submodel, err = s.submodelRepo.GetSubmodelByIDAndDate(ctx, submodelID, at)
 		}
@@ -971,7 +971,7 @@ func compressedContentSectionName(submodel types.ISubmodel, specificationSet map
 }
 
 func (s *DPPRepositoryService) updatedMetadata(ctx context.Context, dppID string) (types.ISubmodel, error) {
-	metadata, err := s.submodelRepo.GetSubmodelByID(ctx, metadataSubmodelID(dppID), "deep", false)
+	metadata, err := s.submodelRepo.GetSubmodelByID(ctx, metadataSubmodelID(dppID), "deep", false, true)
 	if err != nil {
 		return nil, fmt.Errorf("DPP-TOUCHMETA-GET get metadata: %w", err)
 	}


### PR DESCRIPTION
## Description of Changes

This PR improves the `extent` response handling by preventing excluded Blob values from being loaded from PostgreSQL.

Changes include:
- Passes the normalized extent into Submodel and SubmodelElement persistence reads.
- Omits `blob_element.value` from the SQL projection for the default and `withoutBlobValue` cases while keeping `contentType`.
- Keeps `withBlobValue` behavior unchanged.
- Removes in-memory Blob value stripping from live repository reads.
- Keeps historical reads unchanged because their hash-verified snapshots have to be reconstructed before response shaping.
- Adds persistence tests that verify the generated SQL only selects Blob values when requested.

No OpenAPI files or database schema files are changed in this PR.

## Related Issue

Closes #420

## BaSyx Configuration for Testing

Uses the existing Submodel Repository and AAS Repository integration test setup.

## AAS Files Used for Testing

No additional AAS files are required. The existing extent integration tests create temporary Submodels with Blob elements directly through the API.

## Additional Information

The current `extent` response behavior remains unchanged; this only moves live Blob omission into the database query path.

Validation included the Submodel Repository unit and integration suites, the AAS Repository integration suite, `gofmt`, `go vet ./...`, and `golangci-lint run`.
