### PR TITLE
Fix delegated operations example

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -52,8 +52,7 @@ jobs:
             compose_files: |
               examples/BaSyxDelegatedOperationsExample/docker-compose.yml
             image_builds: |
-              eclipsebasyx/aasrepository-go:SNAPSHOT|./cmd/aasrepositoryservice/Dockerfile
-              eclipsebasyx/submodelrepository-go:SNAPSHOT|./cmd/submodelrepositoryservice/Dockerfile
+              eclipsebasyx/aasenvironment-go:SNAPSHOT|./cmd/aasenvironmentservice/Dockerfile
               eclipsebasyx/basyxconfigurationservice-go:SNAPSHOT|./cmd/basyxconfigurationservice/Dockerfile
           - target_name: Submodel Repository Example
             compose_files: |

--- a/examples/BaSyxDelegatedOperationsExample/README.md
+++ b/examples/BaSyxDelegatedOperationsExample/README.md
@@ -18,6 +18,18 @@ Run from this folder:
 docker compose up --build
 ```
 
+## Delegation Trust
+
+To protect against DNS rebinding and server-side request forgery, the Submodel
+Repository validates both the configured delegation hostname and the IP address
+to which it resolves. This example therefore assigns
+`delegated-operation-service` the stable address `172.28.0.10` and allowlists
+both `delegated-operation-service:8080` and `172.28.0.10:8080`.
+
+If the `172.28.0.0/24` subnet conflicts with an existing Docker network, change
+the configured subnet, the delegated service address, and the corresponding IP
+entry in `SMREPO_DELEGATION_TRUSTED_HOSTS` together.
+
 ## Preloaded IDs
 
 - Submodel ID: `https://example.com/ids/sm/delegated-operations`

--- a/examples/BaSyxDelegatedOperationsExample/README.md
+++ b/examples/BaSyxDelegatedOperationsExample/README.md
@@ -1,10 +1,9 @@
 # BaSyx Delegated Operations Example (Sync + Async)
 
-This example provides a complete docker-compose setup for delegated operation invocation using the Go Submodel Repository.
+This example provides a complete docker-compose setup for delegated operation invocation using the Go AAS Environment.
 
 It includes:
-- AAS Repository (`http://localhost:8090`)
-- Submodel Repository (`http://localhost:8091`)
+- AAS Environment (`http://localhost:8091`)
 - Delegated microservice (`http://localhost:8099`) implemented in Go
 - AAS Web UI (`http://localhost:3000`)
 - PostgreSQL
@@ -97,12 +96,17 @@ Open:
 - `http://localhost:3000`
 
 The UI is configured to use:
-- `AAS_REPO_PATH=http://localhost:8090/shells`
-- `SUBMODEL_REPO_PATH=http://localhost:8091/submodels`
+
+- the `mono-all` infrastructure template
+- AAS Environment `http://localhost:8091`
+
+The infrastructure is preconfigured in `basyx-infra.yml` and mounted read-only
+into the UI container.
 
 ## Files
 
 - `docker-compose.yml` - complete stack
+- `basyx-infra.yml` - AAS Web UI infrastructure configuration
 - `startup.sh` - waits for services and preloads AAS/Submodel data
 - `data/aas-shell.json` - preloaded AAS payload
 - `data/submodel-delegated-operations.json` - preloaded submodel with delegated operations

--- a/examples/BaSyxDelegatedOperationsExample/basyx-infra.yml
+++ b/examples/BaSyxDelegatedOperationsExample/basyx-infra.yml
@@ -1,0 +1,11 @@
+infrastructures:
+  default: delegatedOperations
+
+  delegatedOperations:
+    name: Delegated Operations
+    template: mono-all
+    components:
+      aasEnvironment:
+        baseUrl: "http://localhost:8091"
+    security:
+      type: none

--- a/examples/BaSyxDelegatedOperationsExample/docker-compose.yml
+++ b/examples/BaSyxDelegatedOperationsExample/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - POSTGRES_CONNMAXLIFETIMEMINUTES=5
       - JWS_PRIVATEKEYPATH=/app/rsa-key.pem
       - ABAC_ENABLED=false
+      - SMREPO_DELEGATION_TRUSTED_HOSTS=delegated-operation-service:8080,172.28.0.10:8080
     volumes:
       - ./basyx/rsa-key.pem:/app/rsa-key.pem:ro
     ports:
@@ -79,6 +80,9 @@ services:
       dockerfile: Dockerfile
     environment:
       - PORT=8080
+    networks:
+      default:
+        ipv4_address: 172.28.0.10
     ports:
       - "8099:8080"
     restart: unless-stopped
@@ -126,3 +130,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
+
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24

--- a/examples/BaSyxDelegatedOperationsExample/docker-compose.yml
+++ b/examples/BaSyxDelegatedOperationsExample/docker-compose.yml
@@ -5,48 +5,20 @@ services:
     pull_policy: always
     ports:
       - "3000:3000"
+    volumes:
+      - ./basyx-infra.yml:/basyx-infra.yml:ro
     environment:
-      AAS_REPO_PATH: "http://localhost:8090/shells"
-      SUBMODEL_REPO_PATH: "http://localhost:8091/submodels"
+      ENDPOINT_CONFIG_AVAILABLE: "false"
     depends_on:
-      aas_repository:
-        condition: service_started
-      submodel_repository:
+      aas_environment:
         condition: service_started
     restart: unless-stopped
 
-  aas_repository:
-    container_name: delegated-operations-aas-repository
-    image: eclipsebasyx/aasrepository-go:SNAPSHOT
+  aas_environment:
+    container_name: delegated-operations-aas-environment
+    image: eclipsebasyx/aasenvironment-go:SNAPSHOT
     pull_policy: always
-    command: ["/app/aasrepositoryservice"]
-    environment:
-      - SERVER_PORT=5004
-      - CORS_ALLOWEDORIGINS=*
-      - CORS_ALLOWEDHEADERS=*
-      - CORS_ALLOWEDCREDENTIALS=true
-      - CORS_ALLOWEDMETHODS=GET,POST,PUT,PATCH,DELETE,OPTIONS
-      - POSTGRES_HOST=db
-      - POSTGRES_PORT=5432
-      - POSTGRES_USER=admin
-      - POSTGRES_PASSWORD=admin123
-      - POSTGRES_DBNAME=basyxDelegationDB
-      - POSTGRES_MAXOPENCONNECTIONS=500
-      - POSTGRES_MAXIDLECONNECTIONS=500
-      - POSTGRES_CONNMAXLIFETIMEMINUTES=5
-      - ABAC_ENABLED=false
-    ports:
-      - "8090:5004"
-    depends_on:
-      basyx_configuration:
-        condition: service_completed_successfully
-    restart: unless-stopped
-
-  submodel_repository:
-    container_name: delegated-operations-submodel-repository
-    image: eclipsebasyx/submodelrepository-go:SNAPSHOT
-    pull_policy: always
-    command: ["/app/submodelrepositoryservice"]
+    command: ["/app/aasenvironmentservice"]
     environment:
       - SERVER_PORT=5004
       - CORS_ALLOWEDORIGINS=*
@@ -63,6 +35,10 @@ services:
       - POSTGRES_CONNMAXLIFETIMEMINUTES=5
       - JWS_PRIVATEKEYPATH=/app/rsa-key.pem
       - ABAC_ENABLED=false
+      - GENERAL_EXTERNALURL=http://localhost:8091
+      - GENERAL_AASREGISTRYINTEGRATION=true
+      - GENERAL_SUBMODELREGISTRYINTEGRATION=true
+      - GENERAL_DISCOVERYINTEGRATION=true
       - SMREPO_DELEGATION_TRUSTED_HOSTS=delegated-operation-service:8080,172.28.0.10:8080
     volumes:
       - ./basyx/rsa-key.pem:/app/rsa-key.pem:ro
@@ -95,9 +71,7 @@ services:
       - ./data:/data:ro
     entrypoint: ["/bin/sh", "/startup.sh"]
     depends_on:
-      aas_repository:
-        condition: service_started
-      submodel_repository:
+      aas_environment:
         condition: service_started
 
   db:

--- a/examples/BaSyxDelegatedOperationsExample/startup.sh
+++ b/examples/BaSyxDelegatedOperationsExample/startup.sh
@@ -50,21 +50,20 @@ post_json_if_missing() {
   echo "${object_name} created"
 }
 
-wait_for_service "AAS Repository" "http://aas_repository:5004/health"
-wait_for_service "Submodel Repository" "http://submodel_repository:5004/health"
+wait_for_service "AAS Environment" "http://aas_environment:5004/health"
 
 encoded_submodel_id="aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvc20vZGVsZWdhdGVkLW9wZXJhdGlvbnM"
 encoded_aas_id="aHR0cHM6Ly9leGFtcGxlLmNvbS9pZHMvYWFzL2RlbGVnYXRlZC1vcGVyYXRpb25zLWV4YW1wbGU"
 
 post_json_if_missing \
-  "http://submodel_repository:5004/submodels/${encoded_submodel_id}" \
-  "http://submodel_repository:5004/submodels" \
+  "http://aas_environment:5004/submodels/${encoded_submodel_id}" \
+  "http://aas_environment:5004/submodels" \
   "/data/submodel-delegated-operations.json" \
   "submodel"
 
 post_json_if_missing \
-  "http://aas_repository:5004/shells/${encoded_aas_id}" \
-  "http://aas_repository:5004/shells" \
+  "http://aas_environment:5004/shells/${encoded_aas_id}" \
+  "http://aas_environment:5004/shells" \
   "/data/aas-shell.json" \
   "aas"
 


### PR DESCRIPTION
## Summary

- configure a stable network address for the delegated operation service
- add the service hostname and resolved address to the delegation allowlist
- document the delegation trust configuration

## Verification

- `go test -v ./internal/submodelrepository/integration_tests`
- synchronous and asynchronous delegated invocations return `sum = 8`
- Docker Compose configuration validation

The UI behavior mentioned in the follow-up comment is tracked separately in eclipse-basyx/basyx-aas-web-ui#1414.

Fixes #520
