### PR TITLE
Export PostgreSQL connection pool metrics through OpenTelemetry

### DIFF
--- a/docu/user/telemetry.md
+++ b/docu/user/telemetry.md
@@ -1,8 +1,9 @@
-# OpenTelemetry Tracing
+# OpenTelemetry Telemetry
 
 The 11 BaSyx commands that expose HTTP APIs support optional OpenTelemetry
-tracing. Tracing is configured only with standard OpenTelemetry environment
-variables; it does not add a BaSyx YAML section.
+tracing and PostgreSQL connection pool metrics. Telemetry is configured only
+with standard OpenTelemetry environment variables; it does not add a BaSyx
+YAML section.
 
 `basyxconfigurationservice` and `historyevidenceverifier` do not expose HTTP
 servers or traced operations, so they remain logging-only commands.
@@ -10,20 +11,24 @@ servers or traced operations, so they remain logging-only commands.
 ## Activation
 
 Tracing is disabled when `OTEL_TRACES_EXPORTER` is unset, empty, or `none`.
-`OTEL_SDK_DISABLED=true` also disables tracing regardless of the exporter.
+Metrics are independently disabled when `OTEL_METRICS_EXPORTER` is unset,
+empty, or `none`. `OTEL_SDK_DISABLED=true` disables both signals regardless of
+their exporters.
 
 Use an OTLP Collector in deployed environments:
 
 ```env
 OTEL_TRACES_EXPORTER=otlp
+OTEL_METRICS_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 ```
 
-The `console` exporter is available for local diagnostics:
+The `console` exporter is available independently for local diagnostics:
 
 ```env
 OTEL_TRACES_EXPORTER=console
+OTEL_METRICS_EXPORTER=console
 ```
 
 Unsupported explicit values stop startup with an `OTEL-CONFIG-*` error. A
@@ -33,27 +38,34 @@ without logging configured endpoints or OTLP headers.
 
 ## Standard Environment Variables
 
-BaSyx supports the standard trace settings provided by the OpenTelemetry Go
-SDK and auto-exporter:
+BaSyx supports these standard settings provided by the OpenTelemetry Go SDK
+and auto-exporter:
 
 - `OTEL_TRACES_EXPORTER`: `otlp`, `console`, or `none`
+- `OTEL_METRICS_EXPORTER`: `otlp`, `console`, or `none`
 - `OTEL_SDK_DISABLED`
 - `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
 - `OTEL_EXPORTER_OTLP_PROTOCOL` and `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`
+- `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`
 - `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_TRACES_HEADERS`
+- `OTEL_EXPORTER_OTLP_METRICS_HEADERS`
 - `OTEL_EXPORTER_OTLP_COMPRESSION` and
   `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION`
+- `OTEL_EXPORTER_OTLP_METRICS_COMPRESSION`
 - `OTEL_EXPORTER_OTLP_TIMEOUT` and `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`
+- `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`
 - `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`
 - `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG`
 - `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BSP_EXPORT_TIMEOUT`,
   `OTEL_BSP_MAX_QUEUE_SIZE`, and `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`
+- `OTEL_METRIC_EXPORT_INTERVAL` and `OTEL_METRIC_EXPORT_TIMEOUT`
 - `OTEL_PROPAGATORS`
 
-The default trace resource `service.name` is the lowercase command directory
-name, such as `aasenvironmentservice`. `OTEL_SERVICE_NAME` overrides it. BaSyx
-does not invent a `service.version`; operators can provide one through
-`OTEL_RESOURCE_ATTRIBUTES`.
+The default telemetry resource `service.name` is the lowercase command
+directory name, such as `aasenvironmentservice`. `OTEL_SERVICE_NAME` overrides
+it. BaSyx does not invent a `service.version`; operators can provide one
+through `OTEL_RESOURCE_ATTRIBUTES`.
 
 The default propagators are W3C Trace Context and Baggage. Supported
 `OTEL_PROPAGATORS` values are `tracecontext`, `baggage`, and `none`.
@@ -63,6 +75,36 @@ specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-enviro
 and [Go auto-exporter
 documentation](https://pkg.go.dev/go.opentelemetry.io/contrib/exporters/autoexport)
 for the detailed value formats.
+
+## PostgreSQL Pool Metrics
+
+Each service registers its single shared PostgreSQL writer pool once. The
+metrics read `database/sql.DBStats()` during collection and do not execute
+database queries.
+
+| Metric | Type | `DBStats` source |
+| --- | --- | --- |
+| `db.client.connection.max` | up/down counter | `MaxOpenConnections` |
+| `db.client.connection.count` with `state=used` | up/down counter | `InUse` |
+| `db.client.connection.count` with `state=idle` | up/down counter | `Idle` |
+| `basyx.db.client.connection.waits` | cumulative counter | `WaitCount` |
+| `basyx.db.client.connection.wait_time` | cumulative counter in seconds | `WaitDuration` |
+| `basyx.db.client.connection.closed` with `reason=idle_limit` | cumulative counter | `MaxIdleClosed` |
+| `basyx.db.client.connection.closed` with `reason=idle_time` | cumulative counter | `MaxIdleTimeClosed` |
+| `basyx.db.client.connection.closed` with `reason=max_lifetime` | cumulative counter | `MaxLifetimeClosed` |
+
+Open connections are the sum of the `used` and `idle`
+`db.client.connection.count` points. Every point has
+`db.system.name=postgresql` and
+`db.client.connection.pool.name=writer`. The `service.name` resource attribute
+identifies the BaSyx service. These values are bounded; database names, hosts,
+users, DSNs, SQL text, AAS identifiers, and request data are not metric
+attributes.
+
+Use rates for the cumulative wait and closure counters. A rising wait rate
+while `used` approaches `max` indicates that the service pool is constraining
+concurrency. Low pool utilization with slow requests points elsewhere, such as
+PostgreSQL query execution, server capacity, or storage latency.
 
 ## Sampling and Lifecycle
 
@@ -75,9 +117,10 @@ OTEL_TRACES_SAMPLER=parentbased_traceidratio
 OTEL_TRACES_SAMPLER_ARG=0.1
 ```
 
-Completed spans are exported in batches. When a service stops, BaSyx flushes
-and shuts down the tracer provider with a fresh bounded context after HTTP
-shutdown has completed.
+Completed spans are exported in batches. Metrics use the SDK export interval
+and timeout. When a service stops, BaSyx flushes and shuts down the enabled
+trace and metric providers with fresh bounded contexts after HTTP shutdown has
+completed.
 
 ## HTTP Spans and Propagation
 
@@ -113,7 +156,8 @@ third-party HTTP clients.
 Trace spans never capture query strings, request or response bodies,
 authorization values, arbitrary headers, tokens, user agents, or client IP
 addresses. Delegated client spans contain only the method, scheme, hostname and
-port, path, response status, and a generic error marker.
+port, path, response status, and a generic error marker. PostgreSQL metrics
+contain only the bounded attributes documented above.
 
 ## Log Correlation
 
@@ -149,6 +193,6 @@ from Jaeger traces back to Loki.
 
 ## Scope
 
-This tracing foundation does not add metrics, OTLP log export, database spans,
-PostgreSQL instrumentation, AAS-domain spans, runtime reconfiguration, or
-custom exporter plugins.
+This telemetry foundation does not add OTLP log export, database query spans,
+SQL statement capture, AAS-domain spans, runtime reconfiguration, or custom
+exporter plugins.

--- a/examples/BaSyxObservabilityExample/README.md
+++ b/examples/BaSyxObservabilityExample/README.md
@@ -1,30 +1,32 @@
 # BaSyx Observability Example
 
-This development example connects BaSyx SNAPSHOT images, request traces, and
-structured logs to a local observability stack:
+This development example connects BaSyx SNAPSHOT images, PostgreSQL pool
+metrics, request traces, and structured logs to a local observability stack:
 
 - AAS Environment Service `SNAPSHOT`
 - BaSyx Configuration Service `SNAPSHOT`
 - BaSyx Web UI `SNAPSHOT-20260724-064425-2b74f32`
 - PostgreSQL
 - OpenTelemetry Collector `0.157.0`
+- Prometheus `3.13.1`
 - Tempo `3.0.2`
 - Loki `3.7.4`
 - Grafana Alloy `1.18.0`
 - Grafana `13.1.1`
 
-BaSyx sends OTLP/HTTP traces to the Collector, which batches and forwards them
-to Tempo. BaSyx JSON logs remain on stderr; Alloy reads the explicitly labelled
+BaSyx sends OTLP/HTTP traces and PostgreSQL pool metrics to the Collector. The
+Collector forwards traces to Tempo and exposes the metrics for Prometheus to
+scrape. BaSyx JSON logs remain on stderr; Alloy reads the explicitly labelled
 BaSyx containers, parses their JSON timestamps, attaches trace and request
 identifiers as non-indexed structured metadata, and sends the records to Loki.
-Grafana provisions both data sources and trace-to-log/log-to-trace links.
+Grafana provisions all three data sources and trace-to-log/log-to-trace links.
 
 ## Prerequisites
 
 - Docker with Docker Compose
 - `curl`
 - Python 3 for the smoke verifier
-- Free loopback ports `3000`, `3001`, `3100`, `3200`, and `8083`
+- Free loopback ports `3000`, `3001`, `3100`, `3200`, `8083`, and `9090`
 
 ## Start
 
@@ -58,8 +60,10 @@ confirms:
 2. Grafana Explore is available to the anonymous development user.
 3. The preconfigured `IESEDriveMotorDM3000` AAS is available.
 4. BaSyx returns the canonical request and correlation headers.
-5. Tempo contains the trace and can calculate TraceQL metrics from it.
-6. Loki contains the matching structured `HTTP request completed` record.
+5. Prometheus contains the PostgreSQL writer pool capacity metric exported by
+   BaSyx.
+6. Tempo contains the trace and can calculate TraceQL metrics from it.
+7. Loki contains the matching structured `HTTP request completed` record.
 
 The optional outage check also stops the Collector briefly and verifies that
 BaSyx continues serving requests:
@@ -73,14 +77,16 @@ BaSyx continues serving requests:
 - BaSyx Web UI: [http://127.0.0.1:3000](http://127.0.0.1:3000)
 - Grafana: [http://127.0.0.1:3001](http://127.0.0.1:3001)
 - AAS Environment: [http://127.0.0.1:8083](http://127.0.0.1:8083)
+- Prometheus: [http://127.0.0.1:9090](http://127.0.0.1:9090)
 
 Grafana allows anonymous editor access in this example so Explore is available
-without a login. In Explore, select Loki to inspect structured logs or Tempo to
-inspect traces with TraceQL. The **Drilldown > Traces** page uses the same Tempo
-data source for a service-oriented view. Log records with a `trace_id` include a
-Tempo link, and trace views offer a Loki query for the
-same service, time range, and trace ID. Requests made while browsing the
-preconfigured AAS in the BaSyx Web UI appear in both data sources.
+without a login. In Explore, select Prometheus to inspect PostgreSQL pool
+metrics, Loki to inspect structured logs, or Tempo to inspect traces with
+TraceQL. The **Drilldown > Traces** page uses the same Tempo data source for a
+service-oriented view. Log records with a `trace_id` include a Tempo link, and
+trace views offer a Loki query for the same service, time range, and trace ID.
+Requests made while browsing the preconfigured AAS in the BaSyx Web UI appear
+across the data sources.
 
 ## Stop
 
@@ -105,6 +111,7 @@ This stack is not a production deployment reference:
 - The BaSyx Web UI and AAS Environment are unsecured.
 - The AAS Environment has ABAC disabled.
 - Tempo stores traces in a local Docker volume.
+- Prometheus stores metrics in a local Docker volume.
 - Loki uses local container filesystem storage.
 - Alloy mounts the Docker socket read-only. Docker socket access is still
   highly privileged because it exposes container metadata and log streams.

--- a/examples/BaSyxObservabilityExample/docker-compose.yml
+++ b/examples/BaSyxObservabilityExample/docker-compose.yml
@@ -23,8 +23,10 @@ services:
       LOGGING_FORMAT: json
       LOGGING_LEVEL: info
       OTEL_TRACES_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_METRIC_EXPORT_INTERVAL: "1000"
       OTEL_SERVICE_NAME: aasenvironmentservice
       OTEL_RESOURCE_ATTRIBUTES: deployment.environment.name=observability-example
     labels:
@@ -94,6 +96,19 @@ services:
         condition: service_started
     restart: unless-stopped
 
+  prometheus:
+    image: prom/prometheus:v3.13.1
+    command: ["--config.file=/etc/prometheus/prometheus.yml"]
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    depends_on:
+      otel-collector:
+        condition: service_started
+    restart: unless-stopped
+
   tempo:
     image: grafana/tempo:3.0.2
     command: ["-target=all", "-config.file=/etc/tempo.yaml"]
@@ -144,8 +159,11 @@ services:
         condition: service_started
       loki:
         condition: service_started
+      prometheus:
+        condition: service_started
     restart: unless-stopped
 
 volumes:
   alloy-data:
+  prometheus-data:
   tempo-data:

--- a/examples/BaSyxObservabilityExample/grafana/provisioning/datasources/datasources.yaml
+++ b/examples/BaSyxObservabilityExample/grafana/provisioning/datasources/datasources.yaml
@@ -1,6 +1,12 @@
 apiVersion: 1
 
 datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+
   - name: Loki
     type: loki
     uid: loki

--- a/examples/BaSyxObservabilityExample/otel-collector.yaml
+++ b/examples/BaSyxObservabilityExample/otel-collector.yaml
@@ -12,9 +12,17 @@ exporters:
     endpoint: tempo:4317
     tls:
       insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    resource_to_telemetry_conversion:
+      enabled: true
 
 service:
   pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
     traces:
       receivers: [otlp]
       processors: [batch]

--- a/examples/BaSyxObservabilityExample/prometheus.yml
+++ b/examples/BaSyxObservabilityExample/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 1s
+
+scrape_configs:
+  - job_name: otel-collector
+    static_configs:
+      - targets: [otel-collector:8889]

--- a/examples/BaSyxObservabilityExample/smoke.sh
+++ b/examples/BaSyxObservabilityExample/smoke.sh
@@ -65,6 +65,28 @@ if data_source.get("type") != "tempo" or data_source.get("url") != "http://tempo
   return 1
 }
 
+wait_for_grafana_prometheus() {
+  local attempts=40
+  local payload
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if payload=$(curl --fail --silent \
+      "http://127.0.0.1:3001/api/datasources/uid/prometheus" 2>/dev/null) &&
+      python3 -c '
+import json
+import sys
+
+data_source = json.load(sys.stdin)
+if data_source.get("type") != "prometheus" or data_source.get("url") != "http://prometheus:9090":
+    raise SystemExit(1)
+' <<<"${payload}"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Grafana Prometheus data source was not available" >&2
+  return 1
+}
+
 request_basyx() {
   curl --fail --silent --show-error \
     --dump-header "${response_headers}" \
@@ -84,6 +106,31 @@ shells = payload.get("result", [])
 if not any(shell.get("idShort") == "IESEDriveMotorDM3000" for shell in shells):
     raise SystemExit("preconfigured IESEDriveMotorDM3000 AAS was not found")
 ' <"${response_body}"
+}
+
+wait_for_pool_metric() {
+  local attempts=60
+  local payload
+  local query='db_client_connection_max{service_name="aasenvironmentservice",db_client_connection_pool_name="writer"}'
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if payload=$(curl --get --fail --silent \
+      "http://127.0.0.1:9090/api/v1/query" \
+      --data-urlencode "query=${query}" 2>/dev/null) &&
+      python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+results = payload.get("data", {}).get("result", [])
+if not any(float(result.get("value", [0, 0])[1]) > 0 for result in results):
+    raise SystemExit(1)
+' <<<"${payload}"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "PostgreSQL writer pool capacity metric was not found in Prometheus" >&2
+  return 1
 }
 
 wait_for_trace() {
@@ -168,7 +215,9 @@ raise SystemExit(1)
 wait_for_ui
 wait_for_grafana_explore
 wait_for_grafana_tempo
+wait_for_grafana_prometheus
 request_basyx
+wait_for_pool_metric
 wait_for_trace
 wait_for_traceql_metrics
 wait_for_log

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,9 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/exporters/autoexport v0.69.0
 	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/sync v0.22.0
 	gopkg.in/go-jose/go-jose.v2 v2.6.3
@@ -86,9 +88,7 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/internal/common/database.go
+++ b/internal/common/database.go
@@ -299,10 +299,21 @@ func OpenPostgresWithSchemaValidation(
 		return nil, err
 	}
 	if err = ValidateSchemaVersionContext(ctx, db, expectedVersion); err != nil {
-		_ = db.Close()
-		return nil, err
+		return nil, closePostgresAfterSchemaValidationFailure(db, err)
 	}
 	return db, nil
+}
+
+func closePostgresAfterSchemaValidationFailure(db *sql.DB, validationErr error) error {
+	unregisterErr := telemetry.UnregisterDatabasePool(db)
+	_ = db.Close()
+	if unregisterErr == nil {
+		return validationErr
+	}
+	return fmt.Errorf(
+		"COMMON-OPENPOSTGRES-METRICS failed to unregister PostgreSQL connection pool after schema validation failure: %w",
+		errors.Join(validationErr, unregisterErr),
+	)
 }
 
 // ValidateSchemaVersionByDSN opens a temporary database connection and validates the schema version.

--- a/internal/common/database.go
+++ b/internal/common/database.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/doug-martin/goqu/v9"
 	_ "github.com/doug-martin/goqu/v9/dialect/postgres"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/telemetry"
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
@@ -140,6 +141,10 @@ func OpenPostgres(ctx context.Context, cfg PostgresConfig, serviceName string) (
 	if err = db.PingContext(ctx); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("COMMON-OPENPOSTGRES-PING failed to connect to PostgreSQL: %w", err)
+	}
+	if err = telemetry.RegisterDatabasePool(db, telemetry.DatabasePoolRoleWriter); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("COMMON-OPENPOSTGRES-METRICS failed to register PostgreSQL connection pool: %w", err)
 	}
 
 	slog.InfoContext(

--- a/internal/common/database_test.go
+++ b/internal/common/database_test.go
@@ -27,10 +27,13 @@ package common
 
 import (
 	"context"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/telemetry"
 )
 
 func TestResolvePostgresPoolSettings(t *testing.T) {
@@ -255,5 +258,54 @@ func TestValidateSchemaVersionContext(t *testing.T) {
 	}
 	if err = mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestSchemaValidationFailureReleasesDatabasePoolRole(t *testing.T) {
+	clearOpenTelemetryEnvironment(t)
+	t.Setenv("OTEL_METRICS_EXPORTER", "console")
+	runtime, err := telemetry.Configure(t.Context(), "testservice")
+	if err != nil {
+		t.Fatalf("configure telemetry: %v", err)
+	}
+	t.Cleanup(func() { runtime.Shutdown(t.Context()) })
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() failed: %v", err)
+	}
+	mock.ExpectClose()
+	if err = telemetry.RegisterDatabasePool(db, telemetry.DatabasePoolRoleWriter); err != nil {
+		t.Fatalf("register database pool: %v", err)
+	}
+
+	validationErr := errors.New("DB-CHECKVER-MISMATCH test schema mismatch")
+	if got := closePostgresAfterSchemaValidationFailure(db, validationErr); !errors.Is(got, validationErr) {
+		t.Fatalf("schema validation error was not preserved: %v", got)
+	}
+	if err = mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+
+	replacementDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("replacement sqlmock.New() failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = telemetry.UnregisterDatabasePool(replacementDB)
+		_ = replacementDB.Close()
+	})
+	if err = telemetry.RegisterDatabasePool(replacementDB, telemetry.DatabasePoolRoleWriter); err != nil {
+		t.Fatalf("register replacement database pool: %v", err)
+	}
+}
+
+func clearOpenTelemetryEnvironment(t *testing.T) {
+	t.Helper()
+	for _, environment := range os.Environ() {
+		key, _, found := strings.Cut(environment, "=")
+		if found && strings.HasPrefix(key, "OTEL_") {
+			t.Setenv(key, "")
+		}
 	}
 }

--- a/internal/common/telemetry/database_pool.go
+++ b/internal/common/telemetry/database_pool.go
@@ -70,8 +70,11 @@ type databasePoolRegistry struct {
 	closed        bool
 }
 
-// RegisterDatabasePool registers db with the active metric runtime. Calling it
-// while metrics are disabled is a no-op.
+// RegisterDatabasePool registers db as the service's writer or reader pool.
+// Re-registering the same database and role is idempotent, while assigning
+// another database to an occupied role or changing a database's role returns an
+// error. Registration is a no-op while metrics are disabled. An error is also
+// returned for a nil database, an unsupported role, or a shutting-down runtime.
 func RegisterDatabasePool(db *sql.DB, role DatabasePoolRole) error {
 	if db == nil {
 		return fmt.Errorf("OTEL-DBPOOL-NILDB database handle is nil")
@@ -85,6 +88,21 @@ func RegisterDatabasePool(db *sql.DB, role DatabasePoolRole) error {
 		return nil
 	}
 	return runtime.databasePools.register(db, role, db.Stats)
+}
+
+// UnregisterDatabasePool removes db from the active metric runtime. It is
+// idempotent and is a no-op while metrics are disabled or db is not registered.
+// An error is returned for a nil database or when callback removal fails.
+func UnregisterDatabasePool(db *sql.DB) error {
+	if db == nil {
+		return fmt.Errorf("OTEL-DBPOOL-NILDB database handle is nil")
+	}
+
+	runtime := activeRuntime.Load()
+	if runtime == nil || !runtime.metricsEnabled {
+		return nil
+	}
+	return runtime.databasePools.unregisterPool(db)
 }
 
 func (registry *databasePoolRegistry) initialize(meter metric.Meter) error {
@@ -195,6 +213,22 @@ func (registry *databasePoolRegistry) registerCallback(
 		return nil, fmt.Errorf("OTEL-DBPOOL-REGISTER register database pool callback: %w", err)
 	}
 	return registration, nil
+}
+
+func (registry *databasePoolRegistry) unregisterPool(db *sql.DB) error {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	registeredPool, ok := registry.registrations[db]
+	if !ok {
+		return nil
+	}
+	if err := registeredPool.registration.Unregister(); err != nil {
+		return fmt.Errorf("OTEL-DBPOOL-UNREGISTER unregister database pool callback: %w", err)
+	}
+	delete(registry.registrations, db)
+	delete(registry.roles, registeredPool.role)
+	return nil
 }
 
 func observeDatabasePool(

--- a/internal/common/telemetry/database_pool.go
+++ b/internal/common/telemetry/database_pool.go
@@ -1,0 +1,274 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+)
+
+const databasePoolCloseReasonKey = attribute.Key("basyx.db.client.connection.close.reason")
+
+// DatabasePoolRole identifies a bounded database pool role within a service.
+type DatabasePoolRole string
+
+const (
+	// DatabasePoolRoleWriter identifies the shared read/write pool.
+	DatabasePoolRoleWriter DatabasePoolRole = "writer"
+	// DatabasePoolRoleReader identifies a future read-only pool.
+	DatabasePoolRoleReader DatabasePoolRole = "reader"
+)
+
+type databasePoolMetrics struct {
+	meter           metric.Meter
+	connectionMax   metric.Int64ObservableUpDownCounter
+	connectionCount metric.Int64ObservableUpDownCounter
+	waits           metric.Int64ObservableCounter
+	waitTime        metric.Float64ObservableCounter
+	closed          metric.Int64ObservableCounter
+}
+
+type databasePoolRegistration struct {
+	role         DatabasePoolRole
+	registration metric.Registration
+}
+
+type databasePoolRegistry struct {
+	mu            sync.Mutex
+	metrics       *databasePoolMetrics
+	registrations map[*sql.DB]databasePoolRegistration
+	roles         map[DatabasePoolRole]*sql.DB
+	closed        bool
+}
+
+// RegisterDatabasePool registers db with the active metric runtime. Calling it
+// while metrics are disabled is a no-op.
+func RegisterDatabasePool(db *sql.DB, role DatabasePoolRole) error {
+	if db == nil {
+		return fmt.Errorf("OTEL-DBPOOL-NILDB database handle is nil")
+	}
+	if !validDatabasePoolRole(role) {
+		return fmt.Errorf("OTEL-DBPOOL-ROLE unsupported database pool role %q", role)
+	}
+
+	runtime := activeRuntime.Load()
+	if runtime == nil || !runtime.metricsEnabled {
+		return nil
+	}
+	return runtime.databasePools.register(db, role, db.Stats)
+}
+
+func (registry *databasePoolRegistry) initialize(meter metric.Meter) error {
+	connectionMax, err := meter.Int64ObservableUpDownCounter(
+		"db.client.connection.max",
+		metric.WithDescription("The maximum number of open connections allowed."),
+		metric.WithUnit("{connection}"),
+	)
+	if err != nil {
+		return fmt.Errorf("OTEL-DBPOOL-INSTRUMENT create maximum connection instrument: %w", err)
+	}
+	connectionCount, err := meter.Int64ObservableUpDownCounter(
+		"db.client.connection.count",
+		metric.WithDescription("The number of connections that are currently in the described state."),
+		metric.WithUnit("{connection}"),
+	)
+	if err != nil {
+		return fmt.Errorf("OTEL-DBPOOL-INSTRUMENT create connection count instrument: %w", err)
+	}
+	waits, err := meter.Int64ObservableCounter(
+		"basyx.db.client.connection.waits",
+		metric.WithDescription("The cumulative number of waits for a database connection."),
+		metric.WithUnit("{wait}"),
+	)
+	if err != nil {
+		return fmt.Errorf("OTEL-DBPOOL-INSTRUMENT create connection wait instrument: %w", err)
+	}
+	waitTime, err := meter.Float64ObservableCounter(
+		"basyx.db.client.connection.wait_time",
+		metric.WithDescription("The cumulative time spent waiting for database connections."),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return fmt.Errorf("OTEL-DBPOOL-INSTRUMENT create connection wait time instrument: %w", err)
+	}
+	closed, err := meter.Int64ObservableCounter(
+		"basyx.db.client.connection.closed",
+		metric.WithDescription("The cumulative number of database connections closed by pool limits."),
+		metric.WithUnit("{connection}"),
+	)
+	if err != nil {
+		return fmt.Errorf("OTEL-DBPOOL-INSTRUMENT create closed connection instrument: %w", err)
+	}
+
+	registry.metrics = &databasePoolMetrics{
+		meter:           meter,
+		connectionMax:   connectionMax,
+		connectionCount: connectionCount,
+		waits:           waits,
+		waitTime:        waitTime,
+		closed:          closed,
+	}
+	registry.registrations = make(map[*sql.DB]databasePoolRegistration)
+	registry.roles = make(map[DatabasePoolRole]*sql.DB)
+	return nil
+}
+
+func (registry *databasePoolRegistry) register(
+	db *sql.DB,
+	role DatabasePoolRole,
+	stats func() sql.DBStats,
+) error {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	if registry.closed {
+		return fmt.Errorf("OTEL-DBPOOL-SHUTDOWN telemetry runtime is shutting down")
+	}
+	if existing, ok := registry.registrations[db]; ok {
+		if existing.role == role {
+			return nil
+		}
+		return fmt.Errorf("OTEL-DBPOOL-CONFLICT database pool is already registered as %q", existing.role)
+	}
+	if existingDB, ok := registry.roles[role]; ok && existingDB != db {
+		return fmt.Errorf("OTEL-DBPOOL-CONFLICT database pool role %q is already registered", role)
+	}
+
+	registration, err := registry.registerCallback(role, stats)
+	if err != nil {
+		return err
+	}
+	registry.registrations[db] = databasePoolRegistration{
+		role:         role,
+		registration: registration,
+	}
+	registry.roles[role] = db
+	return nil
+}
+
+func (registry *databasePoolRegistry) registerCallback(
+	role DatabasePoolRole,
+	stats func() sql.DBStats,
+) (metric.Registration, error) {
+	metrics := registry.metrics
+	registration, err := metrics.meter.RegisterCallback(
+		func(_ context.Context, observer metric.Observer) error {
+			observeDatabasePool(observer, metrics, role, stats())
+			return nil
+		},
+		metrics.connectionMax,
+		metrics.connectionCount,
+		metrics.waits,
+		metrics.waitTime,
+		metrics.closed,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("OTEL-DBPOOL-REGISTER register database pool callback: %w", err)
+	}
+	return registration, nil
+}
+
+func observeDatabasePool(
+	observer metric.Observer,
+	metrics *databasePoolMetrics,
+	role DatabasePoolRole,
+	stats sql.DBStats,
+) {
+	poolAttributes := metric.WithAttributes(
+		semconv.DBSystemNamePostgreSQL,
+		semconv.DBClientConnectionPoolName(string(role)),
+	)
+	observer.ObserveInt64(metrics.connectionMax, int64(stats.MaxOpenConnections), poolAttributes)
+	observer.ObserveInt64(
+		metrics.connectionCount,
+		int64(stats.InUse),
+		metric.WithAttributes(
+			semconv.DBSystemNamePostgreSQL,
+			semconv.DBClientConnectionPoolName(string(role)),
+			semconv.DBClientConnectionStateUsed,
+		),
+	)
+	observer.ObserveInt64(
+		metrics.connectionCount,
+		int64(stats.Idle),
+		metric.WithAttributes(
+			semconv.DBSystemNamePostgreSQL,
+			semconv.DBClientConnectionPoolName(string(role)),
+			semconv.DBClientConnectionStateIdle,
+		),
+	)
+	observer.ObserveInt64(metrics.waits, stats.WaitCount, poolAttributes)
+	observer.ObserveFloat64(metrics.waitTime, stats.WaitDuration.Seconds(), poolAttributes)
+	observeClosedConnections(observer, metrics.closed, role, "idle_limit", stats.MaxIdleClosed)
+	observeClosedConnections(observer, metrics.closed, role, "idle_time", stats.MaxIdleTimeClosed)
+	observeClosedConnections(observer, metrics.closed, role, "max_lifetime", stats.MaxLifetimeClosed)
+}
+
+func observeClosedConnections(
+	observer metric.Observer,
+	instrument metric.Int64ObservableCounter,
+	role DatabasePoolRole,
+	reason string,
+	value int64,
+) {
+	observer.ObserveInt64(
+		instrument,
+		value,
+		metric.WithAttributes(
+			semconv.DBSystemNamePostgreSQL,
+			semconv.DBClientConnectionPoolName(string(role)),
+			databasePoolCloseReasonKey.String(reason),
+		),
+	)
+}
+
+func (registry *databasePoolRegistry) unregister() {
+	registry.mu.Lock()
+	registry.closed = true
+	registrations := make([]metric.Registration, 0, len(registry.registrations))
+	for _, registeredPool := range registry.registrations {
+		registrations = append(registrations, registeredPool.registration)
+	}
+	clear(registry.registrations)
+	clear(registry.roles)
+	registry.mu.Unlock()
+
+	for _, registration := range registrations {
+		if err := registration.Unregister(); err != nil {
+			logRuntimeWarning("OpenTelemetry database pool unregister failed", "OTEL-DBPOOL-UNREGISTER", err)
+		}
+	}
+}
+
+func validDatabasePoolRole(role DatabasePoolRole) bool {
+	return role == DatabasePoolRoleWriter || role == DatabasePoolRoleReader
+}

--- a/internal/common/telemetry/database_pool_test.go
+++ b/internal/common/telemetry/database_pool_test.go
@@ -152,6 +152,58 @@ func TestRegisterDatabasePoolDoesNothingWhenMetricsAreDisabled(t *testing.T) {
 	if err := RegisterDatabasePool(new(sql.DB), DatabasePoolRoleWriter); err != nil {
 		t.Fatalf("disabled metric registration: %v", err)
 	}
+	if err := UnregisterDatabasePool(new(sql.DB)); err != nil {
+		t.Fatalf("disabled metric unregistration: %v", err)
+	}
+}
+
+func TestRegisterDatabasePoolUsesActiveRuntime(t *testing.T) {
+	runtime, reader := installDatabasePoolTestRuntime(t)
+	db := new(sql.DB)
+	db.SetMaxOpenConns(24)
+
+	if err := RegisterDatabasePool(db, DatabasePoolRoleWriter); err != nil {
+		t.Fatalf("register database pool: %v", err)
+	}
+	if got := len(runtime.databasePools.registrations); got != 1 {
+		t.Fatalf("active runtime contains %d registrations, want 1", got)
+	}
+
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &collected); err != nil {
+		t.Fatalf("collect database pool metrics: %v", err)
+	}
+	assertSingleInt64Point(t, collected, "db.client.connection.max", 24)
+}
+
+func TestUnregisterDatabasePoolAllowsRoleReplacement(t *testing.T) {
+	runtime, reader := installDatabasePoolTestRuntime(t)
+	firstDB := new(sql.DB)
+	firstDB.SetMaxOpenConns(12)
+	if err := RegisterDatabasePool(firstDB, DatabasePoolRoleWriter); err != nil {
+		t.Fatalf("register first database pool: %v", err)
+	}
+	if err := UnregisterDatabasePool(firstDB); err != nil {
+		t.Fatalf("unregister first database pool: %v", err)
+	}
+	if err := UnregisterDatabasePool(firstDB); err != nil {
+		t.Fatalf("repeat database pool unregistration: %v", err)
+	}
+
+	replacementDB := new(sql.DB)
+	replacementDB.SetMaxOpenConns(36)
+	if err := RegisterDatabasePool(replacementDB, DatabasePoolRoleWriter); err != nil {
+		t.Fatalf("register replacement database pool: %v", err)
+	}
+	if got := len(runtime.databasePools.registrations); got != 1 {
+		t.Fatalf("active runtime contains %d registrations, want 1", got)
+	}
+
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &collected); err != nil {
+		t.Fatalf("collect replacement database pool metrics: %v", err)
+	}
+	assertSingleInt64Point(t, collected, "db.client.connection.max", 36)
 }
 
 func TestRegisterDatabasePoolRejectsInvalidInputs(t *testing.T) {
@@ -161,6 +213,30 @@ func TestRegisterDatabasePoolRejectsInvalidInputs(t *testing.T) {
 	if err := RegisterDatabasePool(new(sql.DB), "tenant-123"); err == nil || !strings.Contains(err.Error(), "OTEL-DBPOOL-ROLE") {
 		t.Fatalf("expected invalid role error, got %v", err)
 	}
+	if err := UnregisterDatabasePool(nil); err == nil || !strings.Contains(err.Error(), "OTEL-DBPOOL-NILDB") {
+		t.Fatalf("expected nil database error, got %v", err)
+	}
+}
+
+func installDatabasePoolTestRuntime(t *testing.T) (*Runtime, *metric.ManualReader) {
+	t.Helper()
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	runtime := &Runtime{
+		enabled:        true,
+		metricsEnabled: true,
+		metricProvider: provider,
+	}
+	if err := runtime.databasePools.initialize(provider.Meter(instrumentationName)); err != nil {
+		t.Fatalf("initialize database pool metrics: %v", err)
+	}
+	previousRuntime := activeRuntime.Swap(runtime)
+	t.Cleanup(func() {
+		activeRuntime.Store(previousRuntime)
+		runtime.databasePools.unregister()
+		_ = provider.Shutdown(t.Context())
+	})
+	return runtime, reader
 }
 
 func int64Points(t *testing.T, collected metricdata.ResourceMetrics, name string) []metricdata.DataPoint[int64] {

--- a/internal/common/telemetry/database_pool_test.go
+++ b/internal/common/telemetry/database_pool_test.go
@@ -1,0 +1,275 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package telemetry
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+)
+
+func TestDatabasePoolMetricsReflectDBStats(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(
+		metric.WithReader(reader),
+		metric.WithResource(resource.NewSchemaless(semconv.ServiceName("testservice"))),
+	)
+	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
+
+	var registry databasePoolRegistry
+	if err := registry.initialize(provider.Meter(instrumentationName)); err != nil {
+		t.Fatalf("initialize database pool metrics: %v", err)
+	}
+	db := new(sql.DB)
+	stats := sql.DBStats{
+		MaxOpenConnections: 40,
+		OpenConnections:    17,
+		InUse:              12,
+		Idle:               5,
+		WaitCount:          23,
+		WaitDuration:       3500 * time.Millisecond,
+		MaxIdleClosed:      7,
+		MaxIdleTimeClosed:  11,
+		MaxLifetimeClosed:  13,
+	}
+	if err := registry.register(db, DatabasePoolRoleWriter, func() sql.DBStats { return stats }); err != nil {
+		t.Fatalf("register database pool: %v", err)
+	}
+	t.Cleanup(registry.unregister)
+
+	var collected metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &collected); err != nil {
+		t.Fatalf("collect database pool metrics: %v", err)
+	}
+
+	if serviceName, ok := collected.Resource.Set().Value(semconv.ServiceNameKey); !ok || serviceName.AsString() != "testservice" {
+		t.Fatalf("unexpected service resource: %v", serviceName)
+	}
+	assertSingleInt64Point(t, collected, "db.client.connection.max", 40)
+	countPoints := int64Points(t, collected, "db.client.connection.count")
+	if got := pointValueByAttribute(t, countPoints, semconv.DBClientConnectionStateKey, "used"); got != 12 {
+		t.Fatalf("unexpected in-use connection count: got %d want 12", got)
+	}
+	if got := pointValueByAttribute(t, countPoints, semconv.DBClientConnectionStateKey, "idle"); got != 5 {
+		t.Fatalf("unexpected idle connection count: got %d want 5", got)
+	}
+	if got := sumPointValues(countPoints); got != int64(stats.OpenConnections) {
+		t.Fatalf("unexpected open connection count: got %d want %d", got, stats.OpenConnections)
+	}
+	assertSingleInt64Point(t, collected, "basyx.db.client.connection.waits", 23)
+	assertSingleFloat64Point(t, collected, "basyx.db.client.connection.wait_time", 3.5)
+
+	closedPoints := int64Points(t, collected, "basyx.db.client.connection.closed")
+	if got := pointValueByAttribute(t, closedPoints, databasePoolCloseReasonKey, "idle_limit"); got != 7 {
+		t.Fatalf("unexpected idle-limit closure count: got %d want 7", got)
+	}
+	if got := pointValueByAttribute(t, closedPoints, databasePoolCloseReasonKey, "idle_time"); got != 11 {
+		t.Fatalf("unexpected idle-time closure count: got %d want 11", got)
+	}
+	if got := pointValueByAttribute(t, closedPoints, databasePoolCloseReasonKey, "max_lifetime"); got != 13 {
+		t.Fatalf("unexpected max-lifetime closure count: got %d want 13", got)
+	}
+
+	for _, point := range append(countPoints, closedPoints...) {
+		assertPoolAttributes(t, point.Attributes)
+	}
+	for _, metricName := range []string{
+		"db.client.connection.max",
+		"basyx.db.client.connection.waits",
+		"basyx.db.client.connection.wait_time",
+	} {
+		assertMetricPoolAttributes(t, collected, metricName)
+	}
+}
+
+func TestDatabasePoolRegistrationIsIdempotentAndRolesAreUnique(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
+
+	var registry databasePoolRegistry
+	if err := registry.initialize(provider.Meter(instrumentationName)); err != nil {
+		t.Fatalf("initialize database pool metrics: %v", err)
+	}
+	firstDB := new(sql.DB)
+	stats := func() sql.DBStats { return sql.DBStats{MaxOpenConnections: 10} }
+	if err := registry.register(firstDB, DatabasePoolRoleWriter, stats); err != nil {
+		t.Fatalf("register database pool: %v", err)
+	}
+	if err := registry.register(firstDB, DatabasePoolRoleWriter, stats); err != nil {
+		t.Fatalf("repeat database pool registration: %v", err)
+	}
+	if got := len(registry.registrations); got != 1 {
+		t.Fatalf("duplicate registration created %d callbacks", got)
+	}
+
+	if err := registry.register(firstDB, DatabasePoolRoleReader, stats); err == nil || !strings.Contains(err.Error(), "OTEL-DBPOOL-CONFLICT") {
+		t.Fatalf("expected conflicting role error, got %v", err)
+	}
+	if err := registry.register(new(sql.DB), DatabasePoolRoleWriter, stats); err == nil || !strings.Contains(err.Error(), "OTEL-DBPOOL-CONFLICT") {
+		t.Fatalf("expected duplicate role error, got %v", err)
+	}
+	registry.unregister()
+}
+
+func TestRegisterDatabasePoolDoesNothingWhenMetricsAreDisabled(t *testing.T) {
+	previousRuntime := activeRuntime.Swap(&Runtime{
+		enabled:        true,
+		tracingEnabled: true,
+	})
+	t.Cleanup(func() { activeRuntime.Store(previousRuntime) })
+
+	if err := RegisterDatabasePool(new(sql.DB), DatabasePoolRoleWriter); err != nil {
+		t.Fatalf("disabled metric registration: %v", err)
+	}
+}
+
+func TestRegisterDatabasePoolRejectsInvalidInputs(t *testing.T) {
+	if err := RegisterDatabasePool(nil, DatabasePoolRoleWriter); err == nil || !strings.Contains(err.Error(), "OTEL-DBPOOL-NILDB") {
+		t.Fatalf("expected nil database error, got %v", err)
+	}
+	if err := RegisterDatabasePool(new(sql.DB), "tenant-123"); err == nil || !strings.Contains(err.Error(), "OTEL-DBPOOL-ROLE") {
+		t.Fatalf("expected invalid role error, got %v", err)
+	}
+}
+
+func int64Points(t *testing.T, collected metricdata.ResourceMetrics, name string) []metricdata.DataPoint[int64] {
+	t.Helper()
+	for _, scope := range collected.ScopeMetrics {
+		for _, collectedMetric := range scope.Metrics {
+			if collectedMetric.Name != name {
+				continue
+			}
+			sum, ok := collectedMetric.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %s has data type %T", name, collectedMetric.Data)
+			}
+			return sum.DataPoints
+		}
+	}
+	t.Fatalf("metric %s was not collected", name)
+	return nil
+}
+
+func float64Points(t *testing.T, collected metricdata.ResourceMetrics, name string) []metricdata.DataPoint[float64] {
+	t.Helper()
+	for _, scope := range collected.ScopeMetrics {
+		for _, collectedMetric := range scope.Metrics {
+			if collectedMetric.Name != name {
+				continue
+			}
+			sum, ok := collectedMetric.Data.(metricdata.Sum[float64])
+			if !ok {
+				t.Fatalf("metric %s has data type %T", name, collectedMetric.Data)
+			}
+			return sum.DataPoints
+		}
+	}
+	t.Fatalf("metric %s was not collected", name)
+	return nil
+}
+
+func assertSingleInt64Point(
+	t *testing.T,
+	collected metricdata.ResourceMetrics,
+	name string,
+	want int64,
+) {
+	t.Helper()
+	points := int64Points(t, collected, name)
+	if len(points) != 1 {
+		t.Fatalf("metric %s has %d points, want 1", name, len(points))
+	}
+	if points[0].Value != want {
+		t.Fatalf("metric %s has value %d, want %d", name, points[0].Value, want)
+	}
+}
+
+func assertSingleFloat64Point(t *testing.T, collected metricdata.ResourceMetrics, name string, want float64) {
+	t.Helper()
+	points := float64Points(t, collected, name)
+	if len(points) != 1 || points[0].Value != want {
+		t.Fatalf("metric %s has points %v, want one point with value %v", name, points, want)
+	}
+}
+
+func pointValueByAttribute(
+	t *testing.T,
+	points []metricdata.DataPoint[int64],
+	key attribute.Key,
+	wantValue string,
+) int64 {
+	t.Helper()
+	for _, point := range points {
+		value, ok := point.Attributes.Value(key)
+		if ok && value.AsString() == wantValue {
+			return point.Value
+		}
+	}
+	t.Fatalf("point with %s=%q was not collected", key, wantValue)
+	return 0
+}
+
+func sumPointValues(points []metricdata.DataPoint[int64]) int64 {
+	var total int64
+	for _, point := range points {
+		total += point.Value
+	}
+	return total
+}
+
+func assertPoolAttributes(t *testing.T, attributes attribute.Set) {
+	t.Helper()
+	poolName, hasPoolName := attributes.Value(semconv.DBClientConnectionPoolNameKey)
+	if !hasPoolName || poolName.AsString() != string(DatabasePoolRoleWriter) {
+		t.Fatalf("unexpected pool name attribute: %v", poolName)
+	}
+	systemName, hasSystemName := attributes.Value(semconv.DBSystemNameKey)
+	if !hasSystemName || systemName.AsString() != "postgresql" {
+		t.Fatalf("unexpected database system attribute: %v", systemName)
+	}
+}
+
+func assertMetricPoolAttributes(t *testing.T, collected metricdata.ResourceMetrics, name string) {
+	t.Helper()
+	switch name {
+	case "basyx.db.client.connection.wait_time":
+		for _, point := range float64Points(t, collected, name) {
+			assertPoolAttributes(t, point.Attributes)
+		}
+	default:
+		for _, point := range int64Points(t, collected, name) {
+			assertPoolAttributes(t, point.Attributes)
+		}
+	}
+}

--- a/internal/common/telemetry/http_middleware.go
+++ b/internal/common/telemetry/http_middleware.go
@@ -53,7 +53,7 @@ type httpTracingMiddleware struct {
 // It returns next directly when tracing is disabled.
 func HTTPMiddleware(next http.Handler) http.Handler {
 	runtime := activeRuntime.Load()
-	if runtime == nil || !runtime.enabled {
+	if runtime == nil || !runtime.tracingEnabled || runtime.provider == nil {
 		return next
 	}
 	return newHTTPMiddleware(next, runtime.provider, otel.GetTextMapPropagator())

--- a/internal/common/telemetry/http_transport.go
+++ b/internal/common/telemetry/http_transport.go
@@ -49,7 +49,7 @@ func HTTPClientTransport(base http.RoundTripper) http.RoundTripper {
 		base = http.DefaultTransport
 	}
 	runtime := activeRuntime.Load()
-	if runtime == nil || !runtime.enabled {
+	if runtime == nil || !runtime.tracingEnabled || runtime.provider == nil {
 		return base
 	}
 	return newHTTPClientTransport(

--- a/internal/common/telemetry/telemetry.go
+++ b/internal/common/telemetry/telemetry.go
@@ -115,6 +115,14 @@ type telemetryConfiguration struct {
 	propagator     propagation.TextMapPropagator
 }
 
+type exporterEnvironment struct {
+	endpoint    string
+	headers     string
+	protocol    string
+	compression string
+	timeout     string
+}
+
 // Configure initializes optional telemetry from standard OpenTelemetry
 // environment variables.
 func Configure(ctx context.Context, serviceName string) (*Runtime, error) {
@@ -399,59 +407,67 @@ func sdkDisabled() (bool, error) {
 }
 
 func validateExporterEnvironment(traceEnabled bool, metricEnabled bool) error {
-	endpointKeys := []string{}
-	headerKeys := []string{}
-	protocolKeys := []string{}
-	compressionKeys := []string{}
-	timeoutKeys := []string{}
+	for _, environment := range exporterEnvironments(traceEnabled, metricEnabled) {
+		if err := validateExporterEnvironmentValues(environment); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func exporterEnvironments(traceEnabled bool, metricEnabled bool) []exporterEnvironment {
+	environments := make([]exporterEnvironment, 0, 3)
 	if traceEnabled || metricEnabled {
-		endpointKeys = append(endpointKeys, "OTEL_EXPORTER_OTLP_ENDPOINT")
-		headerKeys = append(headerKeys, "OTEL_EXPORTER_OTLP_HEADERS")
-		protocolKeys = append(protocolKeys, "OTEL_EXPORTER_OTLP_PROTOCOL")
-		compressionKeys = append(compressionKeys, "OTEL_EXPORTER_OTLP_COMPRESSION")
-		timeoutKeys = append(timeoutKeys, "OTEL_EXPORTER_OTLP_TIMEOUT")
+		environments = append(environments, newExporterEnvironment(""))
 	}
 	if traceEnabled {
-		endpointKeys = append(endpointKeys, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
-		headerKeys = append(headerKeys, "OTEL_EXPORTER_OTLP_TRACES_HEADERS")
-		protocolKeys = append(protocolKeys, "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
-		compressionKeys = append(compressionKeys, "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION")
-		timeoutKeys = append(timeoutKeys, "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT")
+		environments = append(environments, newExporterEnvironment("_TRACES"))
 	}
 	if metricEnabled {
-		endpointKeys = append(endpointKeys, "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
-		headerKeys = append(headerKeys, "OTEL_EXPORTER_OTLP_METRICS_HEADERS")
-		protocolKeys = append(protocolKeys, "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")
-		compressionKeys = append(compressionKeys, "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION")
-		timeoutKeys = append(timeoutKeys, "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT")
+		environments = append(environments, newExporterEnvironment("_METRICS"))
 	}
+	return environments
+}
 
-	for _, key := range endpointKeys {
-		if err := validateEndpointEnvironment(key); err != nil {
-			return err
-		}
+func newExporterEnvironment(signal string) exporterEnvironment {
+	const prefix = "OTEL_EXPORTER_OTLP"
+	return exporterEnvironment{
+		endpoint:    prefix + signal + "_ENDPOINT",
+		headers:     prefix + signal + "_HEADERS",
+		protocol:    prefix + signal + "_PROTOCOL",
+		compression: prefix + signal + "_COMPRESSION",
+		timeout:     prefix + signal + "_TIMEOUT",
 	}
-	for _, key := range headerKeys {
-		if err := validateHeaderEnvironment(key); err != nil {
-			return err
-		}
+}
+
+func validateExporterEnvironmentValues(environment exporterEnvironment) error {
+	if err := validateEndpointEnvironment(environment.endpoint); err != nil {
+		return err
 	}
-	for _, key := range protocolKeys {
-		value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
-		if value != "" && value != "grpc" && value != "http/protobuf" {
-			return fmt.Errorf("OTEL-CONFIG-EXPORTER unsupported %s %q", key, value)
-		}
+	if err := validateHeaderEnvironment(environment.headers); err != nil {
+		return err
 	}
-	for _, key := range compressionKeys {
-		value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
-		if value != "" && value != "gzip" && value != "none" {
-			return fmt.Errorf("OTEL-CONFIG-EXPORTER unsupported %s %q", key, value)
-		}
+	if err := validateProtocolEnvironment(environment.protocol); err != nil {
+		return err
 	}
-	for _, key := range timeoutKeys {
-		if err := validatePositiveIntegerEnvironment(key, "OTEL-CONFIG-EXPORTER"); err != nil {
-			return err
-		}
+	if err := validateCompressionEnvironment(environment.compression); err != nil {
+		return err
+	}
+	return validatePositiveIntegerEnvironment(environment.timeout, "OTEL-CONFIG-EXPORTER")
+}
+
+func validateProtocolEnvironment(key string) error {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	if value != "" && value != "grpc" && value != "http/protobuf" {
+		return fmt.Errorf("OTEL-CONFIG-EXPORTER unsupported %s %q", key, value)
+	}
+	return nil
+}
+
+func validateCompressionEnvironment(key string) error {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	if value != "" && value != "gzip" && value != "none" {
+		return fmt.Errorf("OTEL-CONFIG-EXPORTER unsupported %s %q", key, value)
 	}
 	return nil
 }

--- a/internal/common/telemetry/telemetry.go
+++ b/internal/common/telemetry/telemetry.go
@@ -23,7 +23,7 @@
 * SPDX-License-Identifier: MIT
 ******************************************************************************/
 
-// Package telemetry configures optional process-wide OpenTelemetry tracing.
+// Package telemetry configures optional process-wide OpenTelemetry signals.
 package telemetry
 
 import (
@@ -43,7 +43,9 @@ import (
 
 	"go.opentelemetry.io/contrib/exporters/autoexport"
 	"go.opentelemetry.io/otel"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
@@ -76,22 +78,44 @@ var telemetryEnvironmentKeys = []string{
 	"OTEL_BSP_MAX_QUEUE_SIZE",
 	"OTEL_BSP_MAX_EXPORT_BATCH_SIZE",
 	"OTEL_PROPAGATORS",
+	"OTEL_METRICS_EXPORTER",
+	"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+	"OTEL_EXPORTER_OTLP_METRICS_COMPRESSION",
+	"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT",
+	"OTEL_METRIC_EXPORT_INTERVAL",
+	"OTEL_METRIC_EXPORT_TIMEOUT",
 }
 
 var activeRuntime atomic.Pointer[Runtime]
 
-// Runtime owns the global tracing state installed by Configure.
+// Runtime owns the global OpenTelemetry state installed by Configure.
 type Runtime struct {
 	enabled            bool
+	tracingEnabled     bool
+	metricsEnabled     bool
 	serviceName        string
 	provider           *sdktrace.TracerProvider
+	metricProvider     *sdkmetric.MeterProvider
 	previousProvider   trace.TracerProvider
+	previousMeter      otelmetric.MeterProvider
 	previousPropagator propagation.TextMapPropagator
 	previousError      otel.ErrorHandler
+	databasePools      databasePoolRegistry
 	shutdownOnce       sync.Once
 }
 
-// Configure initializes optional tracing from standard OpenTelemetry
+type telemetryConfiguration struct {
+	enabled        bool
+	traceEnabled   bool
+	metricsEnabled bool
+	resource       *resource.Resource
+	sampler        sdktrace.Sampler
+	propagator     propagation.TextMapPropagator
+}
+
+// Configure initializes optional telemetry from standard OpenTelemetry
 // environment variables.
 func Configure(ctx context.Context, serviceName string) (*Runtime, error) {
 	if ctx == nil {
@@ -101,67 +125,161 @@ func Configure(ctx context.Context, serviceName string) (*Runtime, error) {
 		return nil, fmt.Errorf("OTEL-CONFIG-SERVICENAME invalid service name %q", serviceName)
 	}
 
-	disabled, err := sdkDisabled()
+	cfg, err := resolveTelemetryConfiguration(ctx, serviceName)
 	if err != nil {
 		return nil, err
 	}
-	exporterName := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_EXPORTER")))
-	if disabled || exporterName == "" || exporterName == "none" {
+	if !cfg.enabled {
 		return &Runtime{serviceName: serviceName}, nil
-	}
-	if exporterName != "otlp" && exporterName != "console" {
-		return nil, fmt.Errorf("OTEL-CONFIG-EXPORTER unsupported OTEL_TRACES_EXPORTER %q", exporterName)
-	}
-	if err := validateExporterEnvironment(); err != nil {
-		return nil, err
-	}
-	sampler, err := samplerFromEnvironment()
-	if err != nil {
-		return nil, err
-	}
-	if err := validateBatchEnvironment(); err != nil {
-		return nil, err
-	}
-	propagator, err := propagatorFromEnvironment()
-	if err != nil {
-		return nil, err
-	}
-	res, err := telemetryResource(ctx, serviceName)
-	if err != nil {
-		return nil, err
-	}
-	exporter, err := autoexport.NewSpanExporter(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("OTEL-CONFIG-EXPORTER invalid exporter configuration (%s)", telemetryErrorType(err))
 	}
 
 	runtime := &Runtime{
 		enabled:            true,
-		serviceName:        resourceServiceName(res, serviceName),
+		tracingEnabled:     cfg.traceEnabled,
+		metricsEnabled:     cfg.metricsEnabled,
+		serviceName:        resourceServiceName(cfg.resource, serviceName),
 		previousProvider:   otel.GetTracerProvider(),
+		previousMeter:      otel.GetMeterProvider(),
 		previousPropagator: otel.GetTextMapPropagator(),
 		previousError:      otel.GetErrorHandler(),
+	}
+	if err = runtime.initializeProviders(ctx, cfg); err != nil {
+		return nil, err
+	}
+	runtime.install(cfg.propagator)
+	return runtime, nil
+}
+
+func resolveTelemetryConfiguration(ctx context.Context, serviceName string) (*telemetryConfiguration, error) {
+	disabled, err := sdkDisabled()
+	if err != nil {
+		return nil, err
+	}
+	if disabled {
+		return &telemetryConfiguration{}, nil
+	}
+
+	_, traceEnabled, err := configuredExporter("OTEL_TRACES_EXPORTER")
+	if err != nil {
+		return nil, err
+	}
+	_, metricsEnabled, err := configuredExporter("OTEL_METRICS_EXPORTER")
+	if err != nil {
+		return nil, err
+	}
+	cfg := &telemetryConfiguration{
+		enabled:        traceEnabled || metricsEnabled,
+		traceEnabled:   traceEnabled,
+		metricsEnabled: metricsEnabled,
+	}
+	if !cfg.enabled {
+		return cfg, nil
+	}
+	if err = validateExporterEnvironment(traceEnabled, metricsEnabled); err != nil {
+		return nil, err
+	}
+	if traceEnabled {
+		cfg.sampler, cfg.propagator, err = resolveTraceConfiguration()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if metricsEnabled {
+		if err = validateMetricEnvironment(); err != nil {
+			return nil, err
+		}
+	}
+	cfg.resource, err = telemetryResource(ctx, serviceName)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func resolveTraceConfiguration() (sdktrace.Sampler, propagation.TextMapPropagator, error) {
+	sampler, err := samplerFromEnvironment()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err = validateBatchEnvironment(); err != nil {
+		return nil, nil, err
+	}
+	propagator, err := propagatorFromEnvironment()
+	if err != nil {
+		return nil, nil, err
+	}
+	return sampler, propagator, nil
+}
+
+func validateMetricEnvironment() error {
+	for _, key := range []string{"OTEL_METRIC_EXPORT_INTERVAL", "OTEL_METRIC_EXPORT_TIMEOUT"} {
+		if err := validatePositiveIntegerEnvironment(key, "OTEL-CONFIG-METRICS"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (runtime *Runtime) initializeProviders(ctx context.Context, cfg *telemetryConfiguration) error {
+	if cfg.traceEnabled {
+		if err := runtime.initializeTraceProvider(ctx, cfg); err != nil {
+			return err
+		}
+	}
+	if cfg.metricsEnabled {
+		if err := runtime.initializeMetricProvider(ctx, cfg); err != nil {
+			runtime.shutdownProviders(ctx)
+			return err
+		}
+	}
+	return nil
+}
+
+func (runtime *Runtime) initializeTraceProvider(ctx context.Context, cfg *telemetryConfiguration) error {
+	exporter, err := autoexport.NewSpanExporter(ctx)
+	if err != nil {
+		return fmt.Errorf("OTEL-CONFIG-EXPORTER invalid trace exporter configuration (%s)", telemetryErrorType(err))
 	}
 	restoreSamplerEnvironment := unsetEmptyEnvironment("OTEL_TRACES_SAMPLER")
 	defer restoreSamplerEnvironment()
 	runtime.provider = sdktrace.NewTracerProvider(
-		sdktrace.WithResource(res),
-		sdktrace.WithSampler(sampler),
+		sdktrace.WithResource(cfg.resource),
+		sdktrace.WithSampler(cfg.sampler),
 		sdktrace.WithBatcher(exporter),
 	)
-	otel.SetErrorHandler(otel.ErrorHandlerFunc(handleRuntimeError))
-	otel.SetTextMapPropagator(propagator)
-	otel.SetTracerProvider(runtime.provider)
-	activeRuntime.Store(runtime)
-	return runtime, nil
+	return nil
 }
 
-// Enabled reports whether this runtime installed active tracing.
+func (runtime *Runtime) initializeMetricProvider(ctx context.Context, cfg *telemetryConfiguration) error {
+	reader, err := autoexport.NewMetricReader(ctx)
+	if err != nil {
+		return fmt.Errorf("OTEL-CONFIG-EXPORTER invalid metric exporter configuration (%s)", telemetryErrorType(err))
+	}
+	runtime.metricProvider = sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(cfg.resource),
+		sdkmetric.WithReader(reader),
+	)
+	return runtime.databasePools.initialize(runtime.metricProvider.Meter(instrumentationName))
+}
+
+func (runtime *Runtime) install(propagator propagation.TextMapPropagator) {
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(handleRuntimeError))
+	if runtime.tracingEnabled {
+		otel.SetTextMapPropagator(propagator)
+		otel.SetTracerProvider(runtime.provider)
+	}
+	if runtime.metricsEnabled {
+		otel.SetMeterProvider(runtime.metricProvider)
+	}
+	activeRuntime.Store(runtime)
+}
+
+// Enabled reports whether this runtime installed any active telemetry signal.
 func (runtime *Runtime) Enabled() bool {
 	return runtime != nil && runtime.enabled
 }
 
-// ServiceName returns the effective trace resource service name.
+// ServiceName returns the effective telemetry resource service name.
 func (runtime *Runtime) ServiceName() string {
 	if runtime == nil {
 		return ""
@@ -169,7 +287,7 @@ func (runtime *Runtime) ServiceName() string {
 	return runtime.serviceName
 }
 
-// Shutdown flushes pending spans, shuts down the provider, and restores the
+// Shutdown flushes pending telemetry, shuts down the providers, and restores the
 // process-wide OpenTelemetry state that Configure replaced.
 func (runtime *Runtime) Shutdown(ctx context.Context) {
 	runtime.shutdown(ctx, shutdownTimeout)
@@ -180,28 +298,91 @@ func (runtime *Runtime) shutdown(ctx context.Context, timeout time.Duration) {
 		return
 	}
 	runtime.shutdownOnce.Do(func() {
+		traceActive := runtime.tracingEnabled || runtime.provider != nil
+		metricsActive := runtime.metricsEnabled || runtime.metricProvider != nil
 		shutdownParent := context.TODO()
 		if ctx != nil {
 			shutdownParent = context.WithoutCancel(ctx)
 		}
 
 		flushCtx, cancelFlush := context.WithTimeout(shutdownParent, timeout)
-		if err := runtime.provider.ForceFlush(flushCtx); err != nil {
-			logRuntimeWarning("OpenTelemetry flush failed", "OTEL-RUNTIME-FLUSH", err)
-		}
+		runtime.flushProviders(flushCtx, traceActive, metricsActive)
 		cancelFlush()
 
+		runtime.databasePools.unregister()
 		shutdownCtx, cancelShutdown := context.WithTimeout(shutdownParent, timeout)
-		if err := runtime.provider.Shutdown(shutdownCtx); err != nil {
-			logRuntimeWarning("OpenTelemetry shutdown failed", "OTEL-RUNTIME-SHUTDOWN", err)
-		}
+		runtime.shutdownActiveProviders(shutdownCtx, traceActive, metricsActive)
 		cancelShutdown()
 
-		otel.SetTracerProvider(runtime.previousProvider)
-		otel.SetTextMapPropagator(runtime.previousPropagator)
+		if traceActive {
+			otel.SetTracerProvider(runtime.previousProvider)
+			otel.SetTextMapPropagator(runtime.previousPropagator)
+		}
+		if metricsActive {
+			otel.SetMeterProvider(runtime.previousMeter)
+		}
 		otel.SetErrorHandler(runtime.previousError)
 		activeRuntime.CompareAndSwap(runtime, nil)
 	})
+}
+
+func (runtime *Runtime) flushProviders(ctx context.Context, traceActive bool, metricsActive bool) {
+	var waitGroup sync.WaitGroup
+	if metricsActive {
+		waitGroup.Go(func() {
+			if err := runtime.metricProvider.ForceFlush(ctx); err != nil {
+				logRuntimeWarning("OpenTelemetry metric flush failed", "OTEL-RUNTIME-METRICFLUSH", err)
+			}
+		})
+	}
+	if traceActive {
+		waitGroup.Go(func() {
+			if err := runtime.provider.ForceFlush(ctx); err != nil {
+				logRuntimeWarning("OpenTelemetry trace flush failed", "OTEL-RUNTIME-TRACEFLUSH", err)
+			}
+		})
+	}
+	waitGroup.Wait()
+}
+
+func (runtime *Runtime) shutdownActiveProviders(ctx context.Context, traceActive bool, metricsActive bool) {
+	var waitGroup sync.WaitGroup
+	if metricsActive {
+		waitGroup.Go(func() {
+			if err := runtime.metricProvider.Shutdown(ctx); err != nil {
+				logRuntimeWarning("OpenTelemetry metric shutdown failed", "OTEL-RUNTIME-METRICSHUTDOWN", err)
+			}
+		})
+	}
+	if traceActive {
+		waitGroup.Go(func() {
+			if err := runtime.provider.Shutdown(ctx); err != nil {
+				logRuntimeWarning("OpenTelemetry trace shutdown failed", "OTEL-RUNTIME-TRACESHUTDOWN", err)
+			}
+		})
+	}
+	waitGroup.Wait()
+}
+
+func (runtime *Runtime) shutdownProviders(ctx context.Context) {
+	if runtime.metricProvider != nil {
+		_ = runtime.metricProvider.Shutdown(ctx)
+	}
+	if runtime.provider != nil {
+		_ = runtime.provider.Shutdown(ctx)
+	}
+}
+
+func configuredExporter(key string) (string, bool, error) {
+	name := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	switch name {
+	case "", "none":
+		return name, false, nil
+	case "otlp", "console":
+		return name, true, nil
+	default:
+		return "", false, fmt.Errorf("OTEL-CONFIG-EXPORTER unsupported %s %q", key, name)
+	}
 }
 
 func sdkDisabled() (bool, error) {
@@ -217,30 +398,57 @@ func sdkDisabled() (bool, error) {
 	return disabled, nil
 }
 
-func validateExporterEnvironment() error {
-	for _, key := range []string{"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"} {
+func validateExporterEnvironment(traceEnabled bool, metricEnabled bool) error {
+	endpointKeys := []string{}
+	headerKeys := []string{}
+	protocolKeys := []string{}
+	compressionKeys := []string{}
+	timeoutKeys := []string{}
+	if traceEnabled || metricEnabled {
+		endpointKeys = append(endpointKeys, "OTEL_EXPORTER_OTLP_ENDPOINT")
+		headerKeys = append(headerKeys, "OTEL_EXPORTER_OTLP_HEADERS")
+		protocolKeys = append(protocolKeys, "OTEL_EXPORTER_OTLP_PROTOCOL")
+		compressionKeys = append(compressionKeys, "OTEL_EXPORTER_OTLP_COMPRESSION")
+		timeoutKeys = append(timeoutKeys, "OTEL_EXPORTER_OTLP_TIMEOUT")
+	}
+	if traceEnabled {
+		endpointKeys = append(endpointKeys, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+		headerKeys = append(headerKeys, "OTEL_EXPORTER_OTLP_TRACES_HEADERS")
+		protocolKeys = append(protocolKeys, "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
+		compressionKeys = append(compressionKeys, "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION")
+		timeoutKeys = append(timeoutKeys, "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT")
+	}
+	if metricEnabled {
+		endpointKeys = append(endpointKeys, "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
+		headerKeys = append(headerKeys, "OTEL_EXPORTER_OTLP_METRICS_HEADERS")
+		protocolKeys = append(protocolKeys, "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")
+		compressionKeys = append(compressionKeys, "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION")
+		timeoutKeys = append(timeoutKeys, "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT")
+	}
+
+	for _, key := range endpointKeys {
 		if err := validateEndpointEnvironment(key); err != nil {
 			return err
 		}
 	}
-	for _, key := range []string{"OTEL_EXPORTER_OTLP_HEADERS", "OTEL_EXPORTER_OTLP_TRACES_HEADERS"} {
+	for _, key := range headerKeys {
 		if err := validateHeaderEnvironment(key); err != nil {
 			return err
 		}
 	}
-	for _, key := range []string{"OTEL_EXPORTER_OTLP_PROTOCOL", "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"} {
+	for _, key := range protocolKeys {
 		value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
 		if value != "" && value != "grpc" && value != "http/protobuf" {
 			return fmt.Errorf("OTEL-CONFIG-EXPORTER unsupported %s %q", key, value)
 		}
 	}
-	for _, key := range []string{"OTEL_EXPORTER_OTLP_COMPRESSION", "OTEL_EXPORTER_OTLP_TRACES_COMPRESSION"} {
+	for _, key := range compressionKeys {
 		value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
 		if value != "" && value != "gzip" && value != "none" {
 			return fmt.Errorf("OTEL-CONFIG-EXPORTER unsupported %s %q", key, value)
 		}
 	}
-	for _, key := range []string{"OTEL_EXPORTER_OTLP_TIMEOUT", "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT"} {
+	for _, key := range timeoutKeys {
 		if err := validatePositiveIntegerEnvironment(key, "OTEL-CONFIG-EXPORTER"); err != nil {
 			return err
 		}

--- a/internal/common/telemetry/telemetry_test.go
+++ b/internal/common/telemetry/telemetry_test.go
@@ -35,7 +35,10 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
+	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
 )
@@ -43,6 +46,7 @@ import (
 func TestConfigureLeavesTelemetryDisabledByDefault(t *testing.T) {
 	clearTelemetryEnvironment(t)
 	previousProvider := otel.GetTracerProvider()
+	previousMeter := otel.GetMeterProvider()
 	previousPropagator := otel.GetTextMapPropagator()
 
 	runtime, err := Configure(t.Context(), "testservice")
@@ -54,6 +58,9 @@ func TestConfigureLeavesTelemetryDisabledByDefault(t *testing.T) {
 	}
 	if otel.GetTracerProvider() != previousProvider {
 		t.Fatal("disabled configuration replaced the tracer provider")
+	}
+	if otel.GetMeterProvider() != previousMeter {
+		t.Fatal("disabled configuration replaced the meter provider")
 	}
 	if otel.GetTextMapPropagator() != previousPropagator {
 		t.Fatal("disabled configuration replaced the propagator")
@@ -143,6 +150,36 @@ func TestConfigureEnablesOTLPExporter(t *testing.T) {
 	t.Cleanup(func() { runtime.Shutdown(t.Context()) })
 	if !runtime.Enabled() {
 		t.Fatal("OTLP telemetry was not enabled")
+	}
+}
+
+func TestConfigureEnablesMetricsWithoutChangingTracing(t *testing.T) {
+	clearTelemetryEnvironment(t)
+	t.Setenv("OTEL_METRICS_EXPORTER", "console")
+	originalMeter := otel.GetMeterProvider()
+	originalTracer := otel.GetTracerProvider()
+
+	runtime, err := Configure(t.Context(), "testservice")
+	if err != nil {
+		t.Fatalf("configure telemetry: %v", err)
+	}
+	if !runtime.Enabled() || !runtime.metricsEnabled {
+		t.Fatal("metrics were not enabled")
+	}
+	if runtime.tracingEnabled {
+		t.Fatal("tracing was unexpectedly enabled")
+	}
+	if otel.GetMeterProvider() == originalMeter {
+		t.Fatal("meter provider was not installed")
+	}
+	if otel.GetTracerProvider() != originalTracer {
+		t.Fatal("metrics-only configuration replaced the tracer provider")
+	}
+
+	runtime.Shutdown(t.Context())
+
+	if otel.GetMeterProvider() != originalMeter {
+		t.Fatal("meter provider was not restored")
 	}
 }
 
@@ -255,6 +292,39 @@ func TestConfigureDoesNotLogInvalidSensitiveExporterValues(t *testing.T) {
 	}
 }
 
+func TestConfigureRejectsInvalidMetricConfiguration(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		key   string
+		value string
+		code  string
+	}{
+		{name: "exporter", key: "OTEL_METRICS_EXPORTER", value: "statsd", code: "OTEL-CONFIG-EXPORTER"},
+		{name: "protocol", key: "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", value: "json", code: "OTEL-CONFIG-EXPORTER"},
+		{name: "endpoint", key: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", value: "postgres://private-token@db", code: "OTEL-CONFIG-EXPORTER"},
+		{name: "headers", key: "OTEL_EXPORTER_OTLP_METRICS_HEADERS", value: "Authorization=private-token%ZZ", code: "OTEL-CONFIG-EXPORTER"},
+		{name: "interval", key: "OTEL_METRIC_EXPORT_INTERVAL", value: "immediately", code: "OTEL-CONFIG-METRICS"},
+		{name: "timeout", key: "OTEL_METRIC_EXPORT_TIMEOUT", value: "0", code: "OTEL-CONFIG-METRICS"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clearTelemetryEnvironment(t)
+			t.Setenv("OTEL_METRICS_EXPORTER", "otlp")
+			t.Setenv(test.key, test.value)
+
+			runtime, err := Configure(t.Context(), "testservice")
+			if runtime != nil {
+				runtime.Shutdown(t.Context())
+			}
+			if err == nil || !strings.Contains(err.Error(), test.code) {
+				t.Fatalf("expected %s error, got %v", test.code, err)
+			}
+			if strings.Contains(err.Error(), "private-token") {
+				t.Fatalf("configuration error disclosed an operator-provided value: %v", err)
+			}
+		})
+	}
+}
+
 func TestShutdownUsesFreshContextForProviderCleanup(t *testing.T) {
 	processor := &blockingFlushProcessor{}
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(processor))
@@ -284,6 +354,37 @@ func TestShutdownUsesFreshContextForProviderCleanup(t *testing.T) {
 
 	if !processor.shutdownCalled.Load() {
 		t.Fatal("provider cleanup did not run after force flush timed out")
+	}
+}
+
+func TestShutdownFlushesAndCleansUpMetricProvider(t *testing.T) {
+	exporter := &blockingMetricExporter{}
+	reader := sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(time.Hour))
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	originalMeter := otel.GetMeterProvider()
+	previousMeter := noopmetric.NewMeterProvider()
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(originalMeter)
+	})
+	runtime := &Runtime{
+		enabled:        true,
+		metricsEnabled: true,
+		metricProvider: provider,
+		previousMeter:  previousMeter,
+		previousError:  otel.GetErrorHandler(),
+	}
+
+	runtime.shutdown(t.Context(), time.Millisecond)
+
+	if !exporter.flushCalled.Load() {
+		t.Fatal("metric provider was not flushed")
+	}
+	if !exporter.shutdownCalled.Load() {
+		t.Fatal("metric provider cleanup did not run after force flush timed out")
+	}
+	if otel.GetMeterProvider() != previousMeter {
+		t.Fatal("meter provider was not restored")
 	}
 }
 
@@ -335,5 +436,33 @@ func (*blockingFlushProcessor) ForceFlush(ctx context.Context) error {
 
 func (processor *blockingFlushProcessor) Shutdown(context.Context) error {
 	processor.shutdownCalled.Store(true)
+	return nil
+}
+
+type blockingMetricExporter struct {
+	flushCalled    atomic.Bool
+	shutdownCalled atomic.Bool
+}
+
+func (*blockingMetricExporter) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+	return metricdata.CumulativeTemporality
+}
+
+func (*blockingMetricExporter) Aggregation(kind sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.DefaultAggregationSelector(kind)
+}
+
+func (*blockingMetricExporter) Export(context.Context, *metricdata.ResourceMetrics) error {
+	return nil
+}
+
+func (exporter *blockingMetricExporter) ForceFlush(ctx context.Context) error {
+	exporter.flushCalled.Store(true)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (exporter *blockingMetricExporter) Shutdown(context.Context) error {
+	exporter.shutdownCalled.Store(true)
 	return nil
 }

--- a/internal/digitaltwinregistry/custom_registry_service_test.go
+++ b/internal/digitaltwinregistry/custom_registry_service_test.go
@@ -70,6 +70,7 @@ func TestDecodeRegistryAssetLinkQueryAssetIDsRejectsMissingRequiredFields(t *tes
 	}
 	if resp == nil {
 		t.Fatalf("expected bad request response")
+		return
 	}
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, resp.Code)


### PR DESCRIPTION
## What changed

- add optional OpenTelemetry metric export through `OTEL_METRICS_EXPORTER`
- register the shared PostgreSQL writer pool once and collect its `database/sql.DBStats`
- expose connection capacity, usage, waits, wait time, and closure reasons with bounded attributes
- flush and shut down trace and metric providers through the same telemetry lifecycle
- document activation, metric names, attributes, and interpretation

Open connections are represented by the sum of the `used` and `idle` points on `db.client.connection.count`. Wait and closure values are cumulative counters so dashboards can calculate rates.

## Testing

- `golangci-lint run ./...`
- `go vet ./...`
- `go test ./internal/common/telemetry ./internal/common ./cmd/...`
- `go test -v ./internal/submodelrepository/integration_tests`
- `go test ./internal/digitaltwinregistry/integration_tests`

Closes #536
