### PR TITLE
Keep replica reads on one database snapshot

### DIFF
--- a/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
+++ b/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
@@ -430,7 +430,13 @@ func (p *PostgreSQLAASRegistryDatabase) GetAssetAdministrationShellDescriptorByI
 	ctx context.Context,
 	aasIdentifier string,
 ) (model.AssetAdministrationShellDescriptor, error) {
-	return descriptors.GetAssetAdministrationShellDescriptorByID(ctx, p.readDB(ctx), aasIdentifier)
+	var result model.AssetAdministrationShellDescriptor
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "AASREG-GETAASDESC-STARTTX", "AASREG-GETAASDESC-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, txErr = descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasIdentifier)
+		return txErr
+	})
+	return result, err
 }
 
 // GetAssetAdministrationShellDescriptorByIDInTransaction returns the AAS descriptor
@@ -631,7 +637,14 @@ func (p *PostgreSQLAASRegistryDatabase) ListAssetAdministrationShellDescriptors(
 	createdFrom time.Time,
 	updatedFrom time.Time,
 ) ([]model.AssetAdministrationShellDescriptor, string, error) {
-	return descriptors.ListAssetAdministrationShellDescriptors(ctx, p.readDB(ctx), limit, cursor, assetKind, assetType, "", createdFrom, updatedFrom)
+	var result []model.AssetAdministrationShellDescriptor
+	var nextCursor string
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "AASREG-LISTAASDESC-STARTTX", "AASREG-LISTAASDESC-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, nextCursor, txErr = descriptors.ListAssetAdministrationShellDescriptors(ctx, tx, limit, cursor, assetKind, assetType, "", createdFrom, updatedFrom)
+		return txErr
+	})
+	return result, nextCursor, err
 }
 
 // ListSubmodelDescriptorsForAAS lists submodel descriptors for a given AAS ID
@@ -642,7 +655,14 @@ func (p *PostgreSQLAASRegistryDatabase) ListSubmodelDescriptorsForAAS(
 	limit int32,
 	cursor string,
 ) ([]model.SubmodelDescriptor, string, error) {
-	return descriptors.ListSubmodelDescriptorsForAAS(ctx, p.readDB(ctx), aasID, limit, cursor)
+	var result []model.SubmodelDescriptor
+	var nextCursor string
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "AASREG-LISTSMDESC-STARTTX", "AASREG-LISTSMDESC-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, nextCursor, txErr = descriptors.ListSubmodelDescriptorsForAAS(ctx, tx, aasID, limit, cursor)
+		return txErr
+	})
+	return result, nextCursor, err
 }
 
 // InsertSubmodelDescriptorForAAS inserts a submodel descriptor and associates
@@ -716,7 +736,13 @@ func (p *PostgreSQLAASRegistryDatabase) GetSubmodelDescriptorForAASByID(
 	aasID string,
 	submodelID string,
 ) (model.SubmodelDescriptor, error) {
-	return descriptors.GetSubmodelDescriptorForAASByID(ctx, p.readDB(ctx), aasID, submodelID)
+	var result model.SubmodelDescriptor
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "AASREG-GETSMDESC-STARTTX", "AASREG-GETSMDESC-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, txErr = descriptors.GetSubmodelDescriptorForAASByID(ctx, tx, aasID, submodelID)
+		return txErr
+	})
+	return result, err
 }
 
 // DeleteSubmodelDescriptorForAASByID deletes the submodel descriptor identified

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -753,7 +753,8 @@ func (s *AssetAdministrationShellDatabase) createSubmodelReferenceInAssetAdminis
 
 // CheckIfSubmodelReferenceExistsInAssetAdministrationShell checks whether a submodel reference exists in the specified AAS.
 func (s *AssetAdministrationShellDatabase) CheckIfSubmodelReferenceExistsInAssetAdministrationShell(ctx context.Context, aasIdentifier string, submodelIdentifier string) error {
-	return common.ExecuteInTransaction(
+	return common.ExecuteInReadTransaction(
+		ctx,
 		s.readDB(ctx),
 		"AASREPO-CHECKSMREFINAAS-STARTTX",
 		"AASREPO-CHECKSMREFINAAS-COMMIT",
@@ -800,14 +801,24 @@ func (s *AssetAdministrationShellDatabase) checkIfSubmodelReferenceExistsInAsset
 
 // GetAssetAdministrationShells returns a paginated list of AAS objects and the next cursor.
 func (s *AssetAdministrationShellDatabase) GetAssetAdministrationShells(ctx context.Context, limit int32, cursor string, idShort string, specificAssetIDs []types.ISpecificAssetID, createdFrom time.Time, updatedFrom time.Time) ([]types.IAssetAdministrationShell, string, error) {
+	var result []types.IAssetAdministrationShell
+	var nextCursor string
+	err := common.ExecuteInReadTransaction(ctx, s.readDB(ctx), "AASREPO-GETAASLIST-STARTTX", "AASREPO-GETAASLIST-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, nextCursor, txErr = s.getAssetAdministrationShellsInTransaction(ctx, tx, limit, cursor, idShort, specificAssetIDs, createdFrom, updatedFrom)
+		return txErr
+	})
+	return result, nextCursor, err
+}
+
+func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellsInTransaction(ctx context.Context, tx *sql.Tx, limit int32, cursor string, idShort string, specificAssetIDs []types.ISpecificAssetID, createdFrom time.Time, updatedFrom time.Time) ([]types.IAssetAdministrationShell, string, error) {
 	dialect := goqu.Dialect("postgres")
-	readDB := s.readDB(ctx)
 
 	if limit < 0 {
 		return nil, "", common.NewErrBadRequest("AASREPO-GETAASLIST-BADLIMIT Limit " + strconv.FormatInt(int64(limit), 10) + " too small")
 	}
 	if cursor != "" {
-		cursorExists, cursorErr := s.assetAdministrationShellCursorExists(ctx, &dialect, cursor)
+		cursorExists, cursorErr := s.assetAdministrationShellCursorExists(ctx, tx, &dialect, cursor)
 		if cursorErr != nil {
 			return nil, "", cursorErr
 		}
@@ -841,7 +852,7 @@ func (s *AssetAdministrationShellDatabase) GetAssetAdministrationShells(ctx cont
 		return nil, "", common.NewInternalServerError("AASREPO-GETAASLIST-BUILDSQL " + toSQLErr.Error())
 	}
 
-	rows, err := readDB.QueryContext(ctx, sqlQuery, args...)
+	rows, err := tx.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
 		return nil, "", common.NewInternalServerError("AASREPO-GETAASLIST-EXECSQL " + err.Error())
 	}
@@ -870,14 +881,14 @@ func (s *AssetAdministrationShellDatabase) GetAssetAdministrationShells(ctx cont
 		if cursorBuildErr != nil {
 			return nil, "", common.NewInternalServerError("AASREPO-GETAASLIST-BUILDCURSORSQL " + cursorBuildErr.Error())
 		}
-		if queryErr := readDB.QueryRow(cursorSQL, cursorArgs...).Scan(&nextCursor); queryErr != nil {
+		if queryErr := tx.QueryRow(cursorSQL, cursorArgs...).Scan(&nextCursor); queryErr != nil {
 			return nil, "", common.NewInternalServerError("AASREPO-GETAASLIST-GETCURSOR " + queryErr.Error())
 		}
 	}
 
 	result := make([]types.IAssetAdministrationShell, 0, len(aasIDs))
 	if len(aasIDs) > 0 {
-		result, err = s.getAssetAdministrationShellMapsByDBIDs(ctx, aasIDs)
+		result, err = s.getAssetAdministrationShellMapsByDBIDs(ctx, tx, aasIDs)
 		if err != nil {
 			return nil, "", err
 		}
@@ -961,14 +972,14 @@ func (s *AssetAdministrationShellDatabase) GetAssetAdministrationShellIDsByAsset
 	return identifiers, nextCursor, nil
 }
 
-func (s *AssetAdministrationShellDatabase) assetAdministrationShellCursorExists(ctx context.Context, dialect *goqu.DialectWrapper, cursor string) (bool, error) {
+func (s *AssetAdministrationShellDatabase) assetAdministrationShellCursorExists(ctx context.Context, db aasDBQueryer, dialect *goqu.DialectWrapper, cursor string) (bool, error) {
 	query, args, buildErr := dialect.From("aas").Select(goqu.V(1)).Where(goqu.I("aas_id").Eq(cursor)).Limit(1).ToSQL()
 	if buildErr != nil {
 		return false, common.NewInternalServerError("AASREPO-CHECKAASCURSOR-BUILDSQL " + buildErr.Error())
 	}
 
 	var one int
-	if queryErr := s.readDB(ctx).QueryRowContext(ctx, query, args...).Scan(&one); queryErr != nil {
+	if queryErr := db.QueryRowContext(ctx, query, args...).Scan(&one); queryErr != nil {
 		if errors.Is(queryErr, sql.ErrNoRows) {
 			return false, nil
 		}
@@ -979,6 +990,16 @@ func (s *AssetAdministrationShellDatabase) assetAdministrationShellCursorExists(
 
 // GetAssetAdministrationShellByID returns an AAS by identifier.
 func (s *AssetAdministrationShellDatabase) GetAssetAdministrationShellByID(ctx context.Context, aasIdentifier string) (types.IAssetAdministrationShell, error) {
+	var result types.IAssetAdministrationShell
+	err := common.ExecuteInReadTransaction(ctx, s.readDB(ctx), "AASREPO-GETAASBYID-STARTTX", "AASREPO-GETAASBYID-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, txErr = s.getAssetAdministrationShellByIDInTransaction(ctx, tx, aasIdentifier)
+		return txErr
+	})
+	return result, err
+}
+
+func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellByIDInTransaction(ctx context.Context, tx *sql.Tx, aasIdentifier string) (types.IAssetAdministrationShell, error) {
 	dialect := goqu.Dialect("postgres")
 	selectDS := buildGetAssetAdministrationShellDBIDByIdentifierDataset(&dialect, aasIdentifier)
 
@@ -1005,14 +1026,14 @@ func (s *AssetAdministrationShellDatabase) GetAssetAdministrationShellByID(ctx c
 	}
 
 	var aasDBID int64
-	if queryErr := s.readDB(ctx).QueryRowContext(ctx, sqlQuery, args...).Scan(&aasDBID); queryErr != nil {
+	if queryErr := tx.QueryRowContext(ctx, sqlQuery, args...).Scan(&aasDBID); queryErr != nil {
 		if queryErr == sql.ErrNoRows {
 			return nil, common.NewErrNotFound("AASREPO-GETAASBYID-AASNOTFOUND Asset Administration Shell with ID '" + aasIdentifier + "' not found")
 		}
 		return nil, common.NewInternalServerError("AASREPO-GETAASBYID-EXECSQL " + queryErr.Error())
 	}
 
-	return s.getAssetAdministrationShellMapByDBID(ctx, aasDBID)
+	return s.getAssetAdministrationShellMapByDBIDInTransaction(ctx, tx, aasDBID)
 }
 
 // PutAssetAdministrationShellByID upserts an AAS and performs ABAC write checks when enabled.
@@ -1948,11 +1969,13 @@ func (s *AssetAdministrationShellDatabase) DeleteThumbnailByAASID(ctx context.Co
 
 // GetAllSubmodelReferencesByAASID returns paginated submodel references while preserving ABAC visibility from ctx.
 func (s *AssetAdministrationShellDatabase) GetAllSubmodelReferencesByAASID(ctx context.Context, aasIdentifier string, limit int32, cursor string) ([]types.IReference, string, error) {
-	tx, cleanup, err := common.StartTransaction(s.readDB(ctx))
+	tx, err := common.BeginReadTransaction(ctx, s.readDB(ctx))
 	if err != nil {
 		return nil, "", common.NewInternalServerError("AASREPO-GETSMREFS-STARTTX " + err.Error())
 	}
-	defer cleanup(&err)
+	defer func() {
+		_ = tx.Rollback()
+	}()
 
 	if limit < 0 {
 		return nil, "", common.NewErrBadRequest("AASREPO-GETSMREFS-BADLIMIT Limit " + strconv.FormatInt(int64(limit), 10) + " too small")
@@ -2253,12 +2276,6 @@ type coreAssetAdministrationShellRow struct {
 	thumbnailContentType  sql.NullString
 }
 
-// nolint:revive // cyclomatic complexity of 32
-// getAssetAdministrationShellMapByDBID loads an AAS and maps it to a typed model.
-func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellMapByDBID(ctx context.Context, aasDBID int64) (types.IAssetAdministrationShell, error) {
-	return s.getAssetAdministrationShellMapByDBIDWithQueryer(ctx, s.readDB(ctx), aasDBID)
-}
-
 func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellMapByDBIDInTransaction(ctx context.Context, tx *sql.Tx, aasDBID int64) (types.IAssetAdministrationShell, error) {
 	if tx == nil {
 		return nil, common.NewInternalServerError("AASREPO-MAPAAS-NILTX transaction must not be nil")
@@ -2320,7 +2337,7 @@ func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellMapByDBIDW
 }
 
 // nolint:revive // cyclomatic complexity of 32
-func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellMapsByDBIDs(ctx context.Context, aasDBIDs []int64) ([]types.IAssetAdministrationShell, error) {
+func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellMapsByDBIDs(ctx context.Context, db aasDBQueryer, aasDBIDs []int64) ([]types.IAssetAdministrationShell, error) {
 	if len(aasDBIDs) == 0 {
 		return []types.IAssetAdministrationShell{}, nil
 	}
@@ -2340,8 +2357,7 @@ func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellMapsByDBID
 		return nil, common.NewInternalServerError("AASREPO-MAPAASBATCH-BUILDSQL " + buildErr.Error())
 	}
 
-	readDB := s.readDB(ctx)
-	rows, queryErr := readDB.QueryContext(ctx, querySQL, queryArgs...)
+	rows, queryErr := db.QueryContext(ctx, querySQL, queryArgs...)
 	if queryErr != nil {
 		return nil, common.NewInternalServerError("AASREPO-MAPAASBATCH-EXECSQL " + queryErr.Error())
 	}
@@ -2378,12 +2394,12 @@ func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellMapsByDBID
 		return nil, common.NewInternalServerError("AASREPO-MAPAASBATCH-ITERROWS " + rowsErr.Error())
 	}
 
-	submodelsByAASID, submodelErr := s.readSubmodelReferencePayloadsByAASDBIDs(ctx, readDB, aasDBIDs)
+	submodelsByAASID, submodelErr := s.readSubmodelReferencePayloadsByAASDBIDs(ctx, db, aasDBIDs)
 	if submodelErr != nil {
 		return nil, submodelErr
 	}
 
-	specificAssetIDsByAASID, specificErr := s.readSpecificAssetIDsByAssetInformationIDs(ctx, readDB, aasDBIDs)
+	specificAssetIDsByAASID, specificErr := s.readSpecificAssetIDsByAssetInformationIDs(ctx, db, aasDBIDs)
 	if specificErr != nil {
 		return nil, common.NewInternalServerError("AASREPO-MAPAASBATCH-READSPECIFICASSETIDS " + specificErr.Error())
 	}

--- a/internal/aasrepository/persistence/aas_database_signed_test.go
+++ b/internal/aasrepository/persistence/aas_database_signed_test.go
@@ -83,6 +83,7 @@ func TestGetSignedAssetAdministrationShellSignsCanonicalRepresentation(t *testin
 }
 
 func setupSignedAASHappyPathExpectations(mock sqlmock.Sqlmock, aasIdentifier string) {
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*"id".*FROM "aas"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
 
@@ -124,6 +125,7 @@ func setupSignedAASHappyPathExpectations(mock sqlmock.Sqlmock, aasIdentifier str
 
 	mock.ExpectQuery(`SELECT .*FROM "aas_submodel_reference" AS "aas_submodel_reference"`).
 		WillReturnRows(sqlmock.NewRows([]string{"aas_id", "parent_reference_payload"}))
+	mock.ExpectCommit()
 }
 
 func aasSigningTestContext(t *testing.T) context.Context {

--- a/internal/aasxfileserver/persistence/aasx_database.go
+++ b/internal/aasxfileserver/persistence/aasx_database.go
@@ -102,7 +102,17 @@ func (p *AASXFileServerDatabase) readDB(ctx context.Context) *sql.DB {
 
 // ListPackages returns package metadata for a page and the next cursor identifier, if any.
 func (p *AASXFileServerDatabase) ListPackages(ctx context.Context, limit int32, cursorID int64, aasID string) ([]PackageRecord, int64, error) {
-	readDB := p.readDB(ctx)
+	var records []PackageRecord
+	var nextCursor int64
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "AASXFS-LISTPACKAGES-STARTTX", "AASXFS-LISTPACKAGES-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		records, nextCursor, txErr = p.listPackagesInTransaction(ctx, tx, limit, cursorID, aasID)
+		return txErr
+	})
+	return records, nextCursor, err
+}
+
+func (p *AASXFileServerDatabase) listPackagesInTransaction(ctx context.Context, tx *sql.Tx, limit int32, cursorID int64, aasID string) ([]PackageRecord, int64, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -134,7 +144,7 @@ func (p *AASXFileServerDatabase) ListPackages(ctx context.Context, limit int32, 
 		return nil, 0, common.NewInternalServerError("AASXFS-LISTPACKAGES-BUILDSQL " + err.Error())
 	}
 
-	rows, err := readDB.QueryContext(ctx, sqlQuery, args...)
+	rows, err := tx.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
 		return nil, 0, common.NewInternalServerError("AASXFS-LISTPACKAGES-QUERY " + err.Error())
 	}
@@ -160,7 +170,7 @@ func (p *AASXFileServerDatabase) ListPackages(ctx context.Context, limit int32, 
 	}
 
 	for idx := range records {
-		aasIDs, aasErr := p.getAASIDs(ctx, readDB, records[idx].DBID)
+		aasIDs, aasErr := p.getAASIDsTx(ctx, tx, records[idx].DBID)
 		if aasErr != nil {
 			return nil, 0, aasErr
 		}
@@ -318,7 +328,7 @@ func persistStagedPackage(ctx context.Context, tx *sql.Tx, packageID string, new
 //   - *PackageBinary: Metadata and caller-owned content stream.
 //   - error: Not-found, query, transaction, or large-object open error.
 func (p *AASXFileServerDatabase) GetPackageByID(ctx context.Context, packageID string) (*PackageBinary, error) {
-	tx, err := p.readDB(ctx).BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	tx, err := common.BeginReadTransaction(ctx, p.readDB(ctx))
 	if err != nil {
 		return nil, common.NewInternalServerError("AASXFS-GETPACKAGE-STARTTX " + err.Error())
 	}
@@ -424,12 +434,6 @@ func (p *AASXFileServerDatabase) DeletePackageByID(ctx context.Context, packageI
 	}
 	committed = true
 	return nil
-}
-
-func (p *AASXFileServerDatabase) getAASIDs(ctx context.Context, queryable interface {
-	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
-}, packageDBID int64) ([]string, error) {
-	return p.getAASIDsTx(ctx, queryable, packageDBID)
 }
 
 func (p *AASXFileServerDatabase) getAASIDsTx(ctx context.Context, queryable interface {

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -873,8 +873,7 @@ func ListAssetAdministrationShellDescriptors(
 			slog.DebugContext(ctx, "AAS descriptor list completed", "duration", time.Since(start))
 		}(time.Now())
 	}
-	_, inTransaction := db.(*sql.Tx)
-	return listAssetAdministrationShellDescriptors(ctx, db, limit, cursor, assetKind, assetType, identifiable, createdFrom, updatedFrom, !inTransaction)
+	return listAssetAdministrationShellDescriptors(ctx, db, limit, cursor, assetKind, assetType, identifiable, createdFrom, updatedFrom, !isTransactionQueryer(db))
 }
 
 //nolint:revive // has to be refactored later. i have no time

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -859,7 +859,7 @@ func buildListAASDescriptorPageQuery(
 //nolint:revive // Its only 31 instead of 30 - 1 is okay
 func ListAssetAdministrationShellDescriptors(
 	ctx context.Context,
-	db *sql.DB,
+	db DBQueryer,
 	limit int32,
 	cursor string,
 	assetKind model.AssetKind,
@@ -873,7 +873,8 @@ func ListAssetAdministrationShellDescriptors(
 			slog.DebugContext(ctx, "AAS descriptor list completed", "duration", time.Since(start))
 		}(time.Now())
 	}
-	return listAssetAdministrationShellDescriptors(ctx, db, limit, cursor, assetKind, assetType, identifiable, createdFrom, updatedFrom, true)
+	_, inTransaction := db.(*sql.Tx)
+	return listAssetAdministrationShellDescriptors(ctx, db, limit, cursor, assetKind, assetType, identifiable, createdFrom, updatedFrom, !inTransaction)
 }
 
 //nolint:revive // has to be refactored later. i have no time

--- a/internal/common/descriptors/CompanyDescriptorHandler.go
+++ b/internal/common/descriptors/CompanyDescriptorHandler.go
@@ -466,7 +466,7 @@ func ReplaceCompanyDescriptor(ctx context.Context, db *sql.DB, companyDescriptor
 // nolint:revive // complexity is 31 which is +1 above the allowed threshold of 30
 func ListCompanyDescriptors(
 	ctx context.Context,
-	db *sql.DB,
+	db DBQueryer,
 	limit int32,
 	cursor string,
 	name string,
@@ -665,7 +665,7 @@ func ListCompanyDescriptors(
 
 // ExistsCompanyDescriptorByID performs a lightweight existence check for a company descriptor by its identifier
 // string. It returns true when a descriptor exists, false when it does not.
-func ExistsCompanyDescriptorByID(ctx context.Context, db *sql.DB, companyIdentifier string) (bool, error) {
+func ExistsCompanyDescriptorByID(ctx context.Context, db DBQueryer, companyIdentifier string) (bool, error) {
 	d := goqu.Dialect(common.Dialect)
 	comp := goqu.T(common.TblCompanyDescriptor).As("comp")
 

--- a/internal/common/descriptors/ReadSubmodelDescriptor.go
+++ b/internal/common/descriptors/ReadSubmodelDescriptor.go
@@ -28,7 +28,6 @@ package descriptors
 
 import (
 	"context"
-	"database/sql"
 	"log/slog"
 	"time"
 
@@ -88,10 +87,7 @@ func ReadSubmodelDescriptorsByDescriptorIDs(
 		return map[int64][]model.SubmodelDescriptor{}, nil
 	}
 
-	allowParallel := true
-	if _, ok := db.(*sql.Tx); ok {
-		allowParallel = false
-	}
+	allowParallel := !isTransactionQueryer(db)
 	uniqDesc := descriptorIDs
 
 	d := goqu.Dialect(common.Dialect)
@@ -230,10 +226,7 @@ func ReadSubmodelDescriptorsByAASDescriptorIDs(
 		return out, nil
 	}
 
-	allowParallel := true
-	if _, ok := db.(*sql.Tx); ok {
-		allowParallel = false
-	}
+	allowParallel := !isTransactionQueryer(db)
 	uniqAASDesc := aasDescriptorIDs
 
 	d := goqu.Dialect(common.Dialect)

--- a/internal/common/descriptors/SpecificAssetIdDiscovery.go
+++ b/internal/common/descriptors/SpecificAssetIdDiscovery.go
@@ -64,7 +64,7 @@ var bdColumns = []auth.FilterColumnSpec{
 // discovery aas_identifier table.
 func ReadSpecificAssetIDsByAASIdentifier(
 	ctx context.Context,
-	db *sql.DB,
+	db DBQueryer,
 	aasID string,
 ) ([]types.ISpecificAssetID, error) {
 	var aasRef int64

--- a/internal/common/descriptors/asset_admin_shell_descriptor_handler_query_test.go
+++ b/internal/common/descriptors/asset_admin_shell_descriptor_handler_query_test.go
@@ -27,6 +27,7 @@ package descriptors
 
 import (
 	"context"
+	stdsql "database/sql"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -37,6 +38,15 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 )
+
+func TestIsTransactionQueryerRecognizesDebugWrapper(t *testing.T) {
+	tx := &stdsql.Tx{}
+	wrapped := &descriptorDebugQueryer{db: tx}
+
+	if !isTransactionQueryer(wrapped) {
+		t.Fatal("expected a debug-wrapped transaction to retain transaction identity")
+	}
+}
 
 func contextWithABACDisabled(t *testing.T) context.Context {
 	t.Helper()

--- a/internal/common/descriptors/debug_queryer.go
+++ b/internal/common/descriptors/debug_queryer.go
@@ -50,6 +50,17 @@ func withDescriptorDebugQueryer(ctx context.Context, db DBQueryer) DBQueryer {
 	}
 }
 
+func isTransactionQueryer(db DBQueryer) bool {
+	switch queryer := db.(type) {
+	case *sql.Tx:
+		return true
+	case *descriptorDebugQueryer:
+		return isTransactionQueryer(queryer.db)
+	default:
+		return false
+	}
+}
+
 func (d *descriptorDebugQueryer) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
 	if debugEnabled(ctx) || debugEnabled(d.ctx) {
 		slog.DebugContext(ctx, "descriptor database query started")

--- a/internal/common/transaction.go
+++ b/internal/common/transaction.go
@@ -25,7 +25,21 @@
 
 package common
 
-import "database/sql"
+import (
+	"context"
+	"database/sql"
+)
+
+// BeginReadTransaction starts a read-only transaction with a stable PostgreSQL snapshot.
+func BeginReadTransaction(ctx context.Context, db *sql.DB) (*sql.Tx, error) {
+	if db == nil {
+		return nil, NewErrBadRequest("COMMON-BEGINREADTX-NILDB database handle must not be nil")
+	}
+	return db.BeginTx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelRepeatableRead,
+		ReadOnly:  true,
+	})
+}
 
 // ExecuteInTransaction starts a transaction, executes fn, and commits on success.
 func ExecuteInTransaction(db *sql.DB, startErrorCode string, commitErrorCode string, fn func(tx *sql.Tx) error) (err error) {
@@ -54,6 +68,47 @@ func ExecuteInTransaction(db *sql.DB, startErrorCode string, commitErrorCode str
 	if err != nil {
 		if commitErrorCode == "" {
 			return NewInternalServerError("COMMON-EXECINTX-COMMIT " + err.Error())
+		}
+		return NewInternalServerError(commitErrorCode + " " + err.Error())
+	}
+
+	return nil
+}
+
+// ExecuteInReadTransaction runs fn in a read-only transaction with one stable
+// PostgreSQL snapshot for all statements.
+func ExecuteInReadTransaction(
+	ctx context.Context,
+	db *sql.DB,
+	startErrorCode string,
+	commitErrorCode string,
+	fn func(tx *sql.Tx) error,
+) (err error) {
+	if db == nil {
+		return NewErrBadRequest("COMMON-EXECINREADTX-NILDB database handle must not be nil")
+	}
+	if fn == nil {
+		return NewErrBadRequest("COMMON-EXECINREADTX-NILFN transaction callback must not be nil")
+	}
+
+	tx, err := BeginReadTransaction(ctx, db)
+	if err != nil {
+		if startErrorCode == "" {
+			return NewInternalServerError("COMMON-EXECINREADTX-STARTTX " + err.Error())
+		}
+		return NewInternalServerError(startErrorCode + " " + err.Error())
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	if err = fn(tx); err != nil {
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		if commitErrorCode == "" {
+			return NewInternalServerError("COMMON-EXECINREADTX-COMMIT " + err.Error())
 		}
 		return NewInternalServerError(commitErrorCode + " " + err.Error())
 	}

--- a/internal/common/transaction_test.go
+++ b/internal/common/transaction_test.go
@@ -1,0 +1,99 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const readTransactionOptionsDriverName = "basyx-read-transaction-options-test"
+
+var (
+	registerReadTransactionOptionsDriver sync.Once
+	readTransactionOptions               = make(chan driver.TxOptions, 1)
+)
+
+type readTransactionOptionsDriver struct{}
+
+type readTransactionOptionsConn struct{}
+
+type readTransactionOptionsTx struct{}
+
+func (readTransactionOptionsDriver) Open(string) (driver.Conn, error) {
+	return readTransactionOptionsConn{}, nil
+}
+
+func (readTransactionOptionsConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare is not supported")
+}
+
+func (readTransactionOptionsConn) Close() error {
+	return nil
+}
+
+func (readTransactionOptionsConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions must use BeginTx")
+}
+
+func (readTransactionOptionsConn) BeginTx(_ context.Context, options driver.TxOptions) (driver.Tx, error) {
+	readTransactionOptions <- options
+	return readTransactionOptionsTx{}, nil
+}
+
+func (readTransactionOptionsTx) Commit() error {
+	return nil
+}
+
+func (readTransactionOptionsTx) Rollback() error {
+	return nil
+}
+
+func TestBeginReadTransactionUsesRepeatableReadAndReadOnly(t *testing.T) {
+	registerReadTransactionOptionsDriver.Do(func() {
+		sql.Register(readTransactionOptionsDriverName, readTransactionOptionsDriver{})
+	})
+
+	db, err := sql.Open(readTransactionOptionsDriverName, "")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	tx, err := BeginReadTransaction(t.Context(), db)
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+
+	options := <-readTransactionOptions
+	require.Equal(t, driver.IsolationLevel(sql.LevelRepeatableRead), options.Isolation)
+	require.True(t, options.ReadOnly)
+}

--- a/internal/companylookupservice/persistence/PostgreSQLCompanyLookupDatabase.go
+++ b/internal/companylookupservice/persistence/PostgreSQLCompanyLookupDatabase.go
@@ -127,7 +127,13 @@ func (p *PostgreSQLCompanyLookupDatabase) GetCompanyDescriptorByID(
 	ctx context.Context,
 	companyIdentifier string,
 ) (model.CompanyDescriptor, error) {
-	return descriptors.GetCompanyDescriptorByID(ctx, p.readDB(ctx), companyIdentifier)
+	var result model.CompanyDescriptor
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "COMPANYLOOKUP-GETDESC-STARTTX", "COMPANYLOOKUP-GETDESC-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, txErr = descriptors.GetCompanyDescriptorByIDTx(ctx, tx, companyIdentifier)
+		return txErr
+	})
+	return result, err
 }
 
 // DeleteCompanyDescriptorByID deletes the company descriptor
@@ -157,7 +163,14 @@ func (p *PostgreSQLCompanyLookupDatabase) ListCompanyDescriptors(
 	name string,
 	assetID string,
 ) ([]model.CompanyDescriptor, string, error) {
-	return descriptors.ListCompanyDescriptors(ctx, p.readDB(ctx), limit, cursor, name, assetID)
+	var result []model.CompanyDescriptor
+	var nextCursor string
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "COMPANYLOOKUP-LISTDESC-STARTTX", "COMPANYLOOKUP-LISTDESC-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, nextCursor, txErr = descriptors.ListCompanyDescriptors(ctx, tx, limit, cursor, name, assetID)
+		return txErr
+	})
+	return result, nextCursor, err
 }
 
 // ExistsCompanyDescriptorByID reports whether a company descriptor with the given ID exists.

--- a/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
+++ b/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
@@ -457,14 +457,13 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptions(ctx context.Context, 
 
 	if cursor != nil && strings.TrimSpace(*cursor) != "" {
 		trimmedCursor := strings.TrimSpace(*cursor)
-		cursorExists, cursorErr := b.conceptDescriptionCursorExists(ctx, trimmedCursor)
-		if cursorErr != nil {
-			return nil, "", cursorErr
-		}
-		if !cursorExists {
-			return []types.IConceptDescription{}, "", nil
-		}
-		query = query.Where(goqu.C("id").Gte(trimmedCursor))
+		cursorExists := goqu.
+			From(goqu.T("concept_description").As("cursor_cd")).
+			Select(goqu.V(1)).
+			Where(goqu.I("cursor_cd.id").Eq(trimmedCursor))
+		query = query.
+			Where(goqu.Func("EXISTS", cursorExists)).
+			Where(goqu.C("id").Gte(trimmedCursor))
 	}
 
 	shouldEnforceFormula, enforceErr := auth.ShouldEnforceFormula(ctx)
@@ -529,27 +528,6 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptions(ctx context.Context, 
 	}
 
 	return conceptDescriptions, nextCursor, nil
-}
-
-func (b *ConceptDescriptionBackend) conceptDescriptionCursorExists(ctx context.Context, cursor string) (bool, error) {
-	query, args, buildErr := goqu.
-		From("concept_description").
-		Select(goqu.V(1)).
-		Where(goqu.C("id").Eq(cursor)).
-		Limit(1).
-		ToSQL()
-	if buildErr != nil {
-		return false, common.NewInternalServerError("CDREPO-CHECKCURSOR-BUILDSQL " + buildErr.Error())
-	}
-
-	var one int
-	if queryErr := b.readDB(ctx).QueryRowContext(ctx, query, args...).Scan(&one); queryErr != nil {
-		if errors.Is(queryErr, sql.ErrNoRows) {
-			return false, nil
-		}
-		return false, common.NewInternalServerError("CDREPO-CHECKCURSOR-EXECSQL " + queryErr.Error())
-	}
-	return true, nil
 }
 
 // GetConceptDescriptionByID retrieves a concept description by its identifier.

--- a/internal/conceptdescriptionrepository/persistence/concept_description_create_visibility_test.go
+++ b/internal/conceptdescriptionrepository/persistence/concept_description_create_visibility_test.go
@@ -27,9 +27,12 @@ package persistence
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/FriedJannik/aas-go-sdk/types"
@@ -53,6 +56,48 @@ func TestConceptDescriptionRepositoryReadPoolSelection(t *testing.T) {
 	require.Same(t, reader, backend.readDB(t.Context()))
 	require.Same(t, writer, backend.readDB(common.WithWriterPostgresReads(t.Context())))
 	require.NoError(t, writerMock.ExpectationsWereMet())
+}
+
+func TestGetConceptDescriptionsValidatesCursorInPageQuery(t *testing.T) {
+	t.Parallel()
+
+	matcher := sqlmock.QueryMatcherFunc(func(_ string, actualSQL string) error {
+		for _, expected := range []string{
+			`SELECT 1 FROM "concept_description" AS "cursor_cd"`,
+			`"cursor_cd"."id" = 'urn:cd:cursor'`,
+			`"id" >= 'urn:cd:cursor'`,
+		} {
+			if !strings.Contains(actualSQL, expected) {
+				return fmt.Errorf("expected SQL to contain %q, got: %s", expected, actualSQL)
+			}
+		}
+		return nil
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(matcher))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	backend, err := NewConceptDescriptionBackendFromDB(db)
+	require.NoError(t, err)
+
+	mock.ExpectQuery("cursor query").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "id_short", "data"}))
+
+	cursor := "urn:cd:cursor"
+	items, nextCursor, err := backend.GetConceptDescriptions(
+		contextWithConceptDescriptionConfig(t),
+		nil,
+		nil,
+		nil,
+		10,
+		&cursor,
+		time.Time{},
+		time.Time{},
+	)
+	require.NoError(t, err)
+	require.Empty(t, items)
+	require.Empty(t, nextCursor)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestConceptDescriptionRepositoryCreateExistingUnauthorizedConceptDescriptionDoesNotReturnConflict(t *testing.T) {
@@ -86,6 +131,12 @@ func TestConceptDescriptionRepositoryCreateExistingUnauthorizedConceptDescriptio
 func contextWithRestrictedCreateConceptDescription(t *testing.T) context.Context {
 	t.Helper()
 
+	return auth.WithQueryFilter(contextWithConceptDescriptionConfig(t), limitedCreateQueryFilterForRepositoryTests())
+}
+
+func contextWithConceptDescriptionConfig(t *testing.T) context.Context {
+	t.Helper()
+
 	cfg := &common.Config{}
 	var cfgCtx context.Context
 	handler := common.ConfigMiddleware(cfg)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -94,7 +145,7 @@ func contextWithRestrictedCreateConceptDescription(t *testing.T) context.Context
 	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
 
 	require.NotNil(t, cfgCtx)
-	return auth.WithQueryFilter(cfgCtx, limitedCreateQueryFilterForRepositoryTests())
+	return cfgCtx
 }
 
 func limitedCreateQueryFilterForRepositoryTests() *auth.QueryFilter {

--- a/internal/discoveryservice/persistence/PostgreSQLDiscoveryDatabase.go
+++ b/internal/discoveryservice/persistence/PostgreSQLDiscoveryDatabase.go
@@ -35,7 +35,6 @@ package persistencepostgresql
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -144,7 +143,8 @@ func (p *PostgreSQLDiscoveryDatabase) GetAllAssetLinks(ctx context.Context, aasI
 		case common.IsErrNotFound(err):
 			return nil, err
 		default:
-			return nil, common.NewInternalServerError("Failed to query specific asset IDs. See console for information.")
+			slog.ErrorContext(ctx, "asset link query failed", "error.code", "DISC-GETASSETLINKS-QUERY", "error", err)
+			return nil, common.NewInternalServerError("DISC-GETASSETLINKS-QUERY failed to query specific asset IDs")
 		}
 	}
 	return links, nil
@@ -258,16 +258,6 @@ func (p *PostgreSQLDiscoveryDatabase) SearchAASIDsByAssetLinks(
 	if peekLimit < 0 {
 		return nil, "", common.NewErrBadRequest("Limit has to be higher than 0")
 	}
-	if cursor != "" {
-		cursorExists, cursorErr := p.discoveryCursorExists(ctx, cursor)
-		if cursorErr != nil {
-			return nil, "", cursorErr
-		}
-		if !cursorExists {
-			return []string{}, "", nil
-		}
-	}
-
 	d := goqu.Dialect("postgres")
 	ai := goqu.T("aas_identifier")
 	ad := goqu.T(common.TblAASDescriptor)
@@ -277,13 +267,16 @@ func (p *PostgreSQLDiscoveryDatabase) SearchAASIDsByAssetLinks(
 			ad,
 			goqu.On(ad.Col(common.ColAASID).Eq(ai.Col("aasid"))),
 		).
-		Select(ai.Col("aasid")).
-		Where(
-			goqu.Or(
-				goqu.V(cursor).Eq(""),
-				ai.Col("aasid").Gte(cursor),
-			),
-		)
+		Select(ai.Col("aasid"))
+	if cursor != "" {
+		cursorExists := d.
+			From(goqu.T("aas_identifier").As("cursor_ai")).
+			Select(goqu.V(1)).
+			Where(goqu.I("cursor_ai.aasid").Eq(cursor))
+		ds = ds.
+			Where(goqu.Func("EXISTS", cursorExists)).
+			Where(ai.Col("aasid").Gte(cursor))
+	}
 
 	uniqueLinks := uniqueAssetLinks(links)
 	if len(uniqueLinks) > 0 {
@@ -413,26 +406,4 @@ func uniqueAssetLinks(links []model.AssetLink) []model.AssetLink {
 		out = append(out, link)
 	}
 	return out
-}
-
-func (p *PostgreSQLDiscoveryDatabase) discoveryCursorExists(ctx context.Context, cursor string) (bool, error) {
-	d := goqu.Dialect("postgres")
-	query, args, buildErr := d.
-		From(goqu.T("aas_identifier").As("ai")).
-		Select(goqu.V(1)).
-		Where(goqu.I("ai.aasid").Eq(cursor)).
-		Limit(1).
-		ToSQL()
-	if buildErr != nil {
-		return false, common.NewInternalServerError("DISCOVERY-CHECKCURSOR-BUILDSQL " + buildErr.Error())
-	}
-
-	var one int
-	if queryErr := p.readDB(ctx).QueryRowContext(ctx, query, args...).Scan(&one); queryErr != nil {
-		if errors.Is(queryErr, sql.ErrNoRows) {
-			return false, nil
-		}
-		return false, common.NewInternalServerError("DISCOVERY-CHECKCURSOR-EXECSQL " + queryErr.Error())
-	}
-	return true, nil
 }

--- a/internal/discoveryservice/persistence/PostgreSQLDiscoveryDatabase.go
+++ b/internal/discoveryservice/persistence/PostgreSQLDiscoveryDatabase.go
@@ -133,7 +133,12 @@ func (p *PostgreSQLDiscoveryDatabase) readDB(ctx context.Context) *sql.DB {
 // read-only operations. If the AAS identifier is not found in the database, an ErrNotFound
 // error is returned.
 func (p *PostgreSQLDiscoveryDatabase) GetAllAssetLinks(ctx context.Context, aasID string) ([]types.ISpecificAssetID, error) {
-	links, err := descriptors.ReadSpecificAssetIDsByAASIdentifier(ctx, p.readDB(ctx), aasID)
+	var links []types.ISpecificAssetID
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "DISC-GETASSETLINKS-STARTTX", "DISC-GETASSETLINKS-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		links, txErr = descriptors.ReadSpecificAssetIDsByAASIdentifier(ctx, tx, aasID)
+		return txErr
+	})
 	if err != nil {
 		switch {
 		case common.IsErrNotFound(err):

--- a/internal/discoveryservice/persistence/postgresql_discovery_database_test.go
+++ b/internal/discoveryservice/persistence/postgresql_discovery_database_test.go
@@ -27,6 +27,7 @@ package persistencepostgresql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -85,6 +86,83 @@ func TestSearchAASIDsByAssetLinks_GlobalAssetIDUsesIndexedUnionCandidates(t *tes
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expected query to be executed: %v", err)
+	}
+}
+
+func TestSearchAASIDsByAssetLinks_ValidatesCursorInPageQuery(t *testing.T) {
+	t.Parallel()
+
+	matcher := sqlmock.QueryMatcherFunc(func(_ string, actualSQL string) error {
+		for _, expected := range []string{
+			`SELECT 1 FROM "aas_identifier" AS "cursor_ai"`,
+			`"cursor_ai"."aasid" = 'urn:aas:cursor'`,
+			`"aas_identifier"."aasid" >= 'urn:aas:cursor'`,
+		} {
+			if !strings.Contains(actualSQL, expected) {
+				return fmt.Errorf("expected SQL to contain %q, got: %s", expected, actualSQL)
+			}
+		}
+		return nil
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(matcher))
+	if err != nil {
+		t.Fatalf("failed to create sqlmock database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	backend, err := NewPostgreSQLDiscoveryBackendFromDB(db)
+	if err != nil {
+		t.Fatalf("failed to create backend: %v", err)
+	}
+
+	mock.ExpectQuery("cursor query").
+		WillReturnRows(sqlmock.NewRows([]string{"aasid"}))
+
+	ids, nextCursor, err := backend.SearchAASIDsByAssetLinks(
+		t.Context(),
+		nil,
+		10,
+		"urn:aas:cursor",
+	)
+	if err != nil {
+		t.Fatalf("expected cursor search to succeed: %v", err)
+	}
+	if len(ids) != 0 || nextCursor != "" {
+		t.Fatalf("expected an empty page without a next cursor, got ids=%#v cursor=%q", ids, nextCursor)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("cursor validation was not part of the page query: %v", err)
+	}
+}
+
+func TestGetAllAssetLinksReturnsCodedErrorWhenReadTransactionFails(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	backend, err := NewPostgreSQLDiscoveryBackendFromDB(db)
+	if err != nil {
+		t.Fatalf("failed to create backend: %v", err)
+	}
+
+	mock.ExpectBegin().WillReturnError(errors.New("begin failed"))
+
+	links, err := backend.GetAllAssetLinks(t.Context(), "urn:aas:test")
+	if err == nil {
+		t.Fatal("expected transaction start failure")
+	}
+	if links != nil {
+		t.Fatalf("expected no links, got %#v", links)
+	}
+	if !strings.Contains(err.Error(), "DISC-GETASSETLINKS-QUERY") {
+		t.Fatalf("expected coded discovery error, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expected transaction start attempt: %v", err)
 	}
 }
 

--- a/internal/smregistry/persistence/PostgreSQLSMDatabase.go
+++ b/internal/smregistry/persistence/PostgreSQLSMDatabase.go
@@ -108,7 +108,14 @@ func (p *PostgreSQLSMDatabase) ListSubmodelDescriptors(
 	createdFrom time.Time,
 	updatedFrom time.Time,
 ) ([]model.SubmodelDescriptor, string, error) {
-	return descriptors.ListSubmodelDescriptors(ctx, p.readDB(ctx), limit, cursor, createdFrom, updatedFrom)
+	var result []model.SubmodelDescriptor
+	var nextCursor string
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "SMREG-LISTSMDESC-STARTTX", "SMREG-LISTSMDESC-COMMITTX", func(tx *sql.Tx) error {
+		var txErr error
+		result, nextCursor, txErr = descriptors.ListSubmodelDescriptors(ctx, tx, limit, cursor, createdFrom, updatedFrom)
+		return txErr
+	})
+	return result, nextCursor, err
 }
 
 func appendSubmodelDescriptorHistoryTx(ctx context.Context, tx *sql.Tx, descriptor model.SubmodelDescriptor, previousSnapshot map[string]any, changeType string, deleted bool) error {
@@ -391,7 +398,13 @@ func (p *PostgreSQLSMDatabase) GetSubmodelDescriptorByID(
 	ctx context.Context,
 	submodelID string,
 ) (model.SubmodelDescriptor, error) {
-	return descriptors.GetSubmodelDescriptorByID(ctx, p.readDB(ctx), submodelID)
+	var result model.SubmodelDescriptor
+	err := common.ExecuteInReadTransaction(ctx, p.readDB(ctx), "SMREG-GETSMDESC-STARTTX", "SMREG-GETSMDESC-COMMITTX", func(tx *sql.Tx) error {
+		var txErr error
+		result, txErr = descriptors.GetSubmodelDescriptorByID(ctx, tx, submodelID)
+		return txErr
+	})
+	return result, err
 }
 
 // GetSubmodelDescriptorByIDInTransaction returns a global submodel descriptor

--- a/internal/submodelrepository/api/api_submodel_repository_api_service_test.go
+++ b/internal/submodelrepository/api/api_submodel_repository_api_service_test.go
@@ -197,7 +197,9 @@ func TestOperationInvocationReadsDefinitionFromWriter(t *testing.T) {
 
 			backend, err := persistencepostgresql.NewSubmodelDatabaseFromPools(writer, reader, nil, "off")
 			require.NoError(t, err)
+			writerMock.ExpectBegin()
 			writerMock.ExpectQuery("SELECT").WillReturnError(errors.New("writer lookup failed"))
+			writerMock.ExpectRollback()
 
 			service := NewSubmodelRepositoryAPIAPIService(t.Context(), *backend)
 			response, invokeErr := test.invoke(service, contextWithABACDisabled(t))

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
@@ -50,9 +50,11 @@ import (
 	persistenceutils "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence/utils"
 )
 
-type dbQueryer interface {
+// DBQueryer supports Submodel Element reads through a pool or transaction.
+type DBQueryer interface {
 	Query(query string, args ...any) (*sql.Rows, error)
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
@@ -105,7 +107,7 @@ func GetSubmodelElementByIDShortOrPathTx(ctx context.Context, tx *sql.Tx, submod
 	return getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx, tx, submodelID, int64(submodelDatabaseID), idShortOrPath, level, includeBlobValue)
 }
 
-func getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx context.Context, db dbQueryer, submodelID string, submodelDatabaseID int64, idShortOrPath string, level string, includeBlobValue bool) (types.ISubmodelElement, error) {
+func getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx context.Context, db DBQueryer, submodelID string, submodelDatabaseID int64, idShortOrPath string, level string, includeBlobValue bool) (types.ISubmodelElement, error) {
 	includeChildren := level != "core"
 	parsedRows, readRowsErr := readSubmodelElementRowsByPath(ctx, db, submodelDatabaseID, idShortOrPath, includeChildren, includeBlobValue)
 
@@ -125,7 +127,7 @@ func getSubmodelElementByIDShortOrPathWithSubmodelDBID(ctx context.Context, db d
 }
 
 // GetSubmodelElementPathsBySubmodelID returns submodel element paths directly from persisted idshort_path values.
-func GetSubmodelElementPathsBySubmodelID(ctx context.Context, db *sql.DB, submodelID string, level string) ([]string, error) {
+func GetSubmodelElementPathsBySubmodelID(ctx context.Context, db DBQueryer, submodelID string, level string) ([]string, error) {
 	if submodelID == "" {
 		return nil, common.NewErrBadRequest("SMREPO-GETSMEPATHS-EMPTYSMID Submodel id must not be empty")
 	}
@@ -133,7 +135,7 @@ func GetSubmodelElementPathsBySubmodelID(ctx context.Context, db *sql.DB, submod
 		return nil, common.NewErrBadRequest("SMREPO-GETSMEPATHS-BADLEVEL level must be one of '', 'core', or 'deep'")
 	}
 
-	submodelDatabaseID, submodelIDErr := persistenceutils.GetSubmodelDatabaseIDFromDB(db, submodelID)
+	submodelDatabaseID, submodelIDErr := persistenceutils.GetSubmodelDatabaseIDFromQueryer(db, submodelID)
 	if submodelIDErr != nil {
 		if errors.Is(submodelIDErr, sql.ErrNoRows) {
 			return nil, common.NewErrNotFound(submodelID)
@@ -202,7 +204,7 @@ func GetSubmodelElementPathsBySubmodelID(ctx context.Context, db *sql.DB, submod
 }
 
 // GetSubmodelElementPathsPageBySubmodelID returns paged submodel element paths directly from persisted idshort_path values.
-func GetSubmodelElementPathsPageBySubmodelID(ctx context.Context, db *sql.DB, submodelID string, limit *int, cursor string, level string) ([]string, string, error) {
+func GetSubmodelElementPathsPageBySubmodelID(ctx context.Context, db DBQueryer, submodelID string, limit *int, cursor string, level string) ([]string, string, error) {
 	if submodelID == "" {
 		return nil, "", common.NewErrBadRequest("SMREPO-GETSMEPATHSPAGE-EMPTYSMID Submodel id must not be empty")
 	}
@@ -221,7 +223,7 @@ func GetSubmodelElementPathsPageBySubmodelID(ctx context.Context, db *sql.DB, su
 		return []string{}, "", nil
 	}
 
-	submodelDatabaseID, submodelIDErr := persistenceutils.GetSubmodelDatabaseIDFromDB(db, submodelID)
+	submodelDatabaseID, submodelIDErr := persistenceutils.GetSubmodelDatabaseIDFromQueryer(db, submodelID)
 	if submodelIDErr != nil {
 		if errors.Is(submodelIDErr, sql.ErrNoRows) {
 			return nil, "", common.NewErrNotFound(submodelID)
@@ -316,7 +318,7 @@ func GetSubmodelElementPathsPageBySubmodelID(ctx context.Context, db *sql.DB, su
 }
 
 // GetSubmodelElementPathsByPath returns persisted idshort_path values for a submodel element path and, for deep level, its descendants.
-func GetSubmodelElementPathsByPath(ctx context.Context, db *sql.DB, submodelID string, idShortPath string, level string) ([]string, error) {
+func GetSubmodelElementPathsByPath(ctx context.Context, db DBQueryer, submodelID string, idShortPath string, level string) ([]string, error) {
 	if submodelID == "" {
 		return nil, common.NewErrBadRequest("SMREPO-GETSMEPATHSBYPATH-EMPTYSMID Submodel id must not be empty")
 	}
@@ -327,7 +329,7 @@ func GetSubmodelElementPathsByPath(ctx context.Context, db *sql.DB, submodelID s
 		return nil, common.NewErrBadRequest("SMREPO-GETSMEPATHSBYPATH-BADLEVEL level must be one of '', 'core', or 'deep'")
 	}
 
-	submodelDatabaseID, submodelIDErr := persistenceutils.GetSubmodelDatabaseIDFromDB(db, submodelID)
+	submodelDatabaseID, submodelIDErr := persistenceutils.GetSubmodelDatabaseIDFromQueryer(db, submodelID)
 	if submodelIDErr != nil {
 		if errors.Is(submodelIDErr, sql.ErrNoRows) {
 			return nil, common.NewErrNotFound(submodelID)
@@ -463,7 +465,7 @@ func GetSubmodelElementsBySubmodelIDTx(ctx context.Context, tx *sql.Tx, submodel
 	return getSubmodelElementsByDatabaseID(ctx, tx, int64(submodelDatabaseID), limit, cursor, level, includeBlobValue)
 }
 
-func getSubmodelElementsByDatabaseID(ctx context.Context, db dbQueryer, submodelDatabaseID int64, limit *int, cursor string, level string, includeBlobValue bool) ([]types.ISubmodelElement, string, error) {
+func getSubmodelElementsByDatabaseID(ctx context.Context, db DBQueryer, submodelDatabaseID int64, limit *int, cursor string, level string, includeBlobValue bool) ([]types.ISubmodelElement, string, error) {
 	rootElements, nextCursor, rootPathErr := getRootElementPage(ctx, db, submodelDatabaseID, limit, cursor)
 	if rootPathErr != nil {
 		return nil, "", rootPathErr
@@ -503,7 +505,7 @@ func getSubmodelElementsByDatabaseID(ctx context.Context, db dbQueryer, submodel
 }
 
 // GetSubmodelElementReferencesBySubmodelID retrieves references for top-level submodel elements of a submodel with optional pagination.
-func GetSubmodelElementReferencesBySubmodelID(ctx context.Context, db *sql.DB, submodelID string, limit *int, cursor string) ([]types.IReference, string, error) {
+func GetSubmodelElementReferencesBySubmodelID(ctx context.Context, db DBQueryer, submodelID string, limit *int, cursor string) ([]types.IReference, string, error) {
 	if submodelID == "" {
 		return nil, "", common.NewErrBadRequest("SMREPO-GETSMEREFS-EMPTYSMID Submodel id must not be empty")
 	}
@@ -517,7 +519,7 @@ func GetSubmodelElementReferencesBySubmodelID(ctx context.Context, db *sql.DB, s
 		*limit = 100
 	}
 
-	submodelDatabaseID, submodelIDErr := persistenceutils.GetSubmodelDatabaseIDFromDB(db, submodelID)
+	submodelDatabaseID, submodelIDErr := persistenceutils.GetSubmodelDatabaseIDFromQueryer(db, submodelID)
 	if submodelIDErr != nil {
 		if errors.Is(submodelIDErr, sql.ErrNoRows) {
 			return nil, "", common.NewErrNotFound(submodelID)
@@ -658,7 +660,7 @@ type rootElementCursorRow struct {
 	path string
 }
 
-func getRootElementPage(ctx context.Context, db dbQueryer, submodelDatabaseID int64, limit *int, cursor string) ([]rootElementCursorRow, string, error) {
+func getRootElementPage(ctx context.Context, db DBQueryer, submodelDatabaseID int64, limit *int, cursor string) ([]rootElementCursorRow, string, error) {
 	if limit != nil && *limit == 0 {
 		return []rootElementCursorRow{}, "", nil
 	}
@@ -794,7 +796,7 @@ func addSMECursorBoundary(query *goqu.SelectDataset, cursor string) *goqu.Select
 	)
 }
 
-func submodelElementCursorExists(ctx context.Context, db dbQueryer, query *goqu.SelectDataset, cursor string) (bool, error) {
+func submodelElementCursorExists(ctx context.Context, db DBQueryer, query *goqu.SelectDataset, cursor string) (bool, error) {
 	cursorPath, cursorID, hasCursorID := parseRootCursor(cursor)
 	cursorQuery := query.Where(goqu.I("sme.idshort_path").Eq(cursorPath))
 	if hasCursorID {
@@ -1222,7 +1224,7 @@ func buildMaskedSMEValuePayloadExpr(rawValueAlias string) exp.Expression {
 	return goqu.L("(COALESCE(?::jsonb, '{}'::jsonb) - 'value')", goqu.I(rawValueAlias))
 }
 
-func readSubmodelElementRowsByPath(ctx context.Context, db dbQueryer, submodelDatabaseID int64, idShortOrPath string, includeChildren bool, includeBlobValue bool) ([]loadedSMERow, error) {
+func readSubmodelElementRowsByPath(ctx context.Context, db DBQueryer, submodelDatabaseID int64, idShortOrPath string, includeChildren bool, includeBlobValue bool) ([]loadedSMERow, error) {
 	dialect := goqu.Dialect("postgres")
 	rowCollector, collectorErr := grammar.NewResolvedFieldPathCollectorForSMERow("sme")
 	if collectorErr != nil {
@@ -1348,7 +1350,7 @@ func readSubmodelElementRowsByPath(ctx context.Context, db dbQueryer, submodelDa
 	return executeLoadedSMERowQuery(ctx, db, sqlQuery, args, "SMREPO-GETSMEBYPATH")
 }
 
-func readSubmodelElementRowsByRootIDs(ctx context.Context, db dbQueryer, submodelDatabaseID int64, rootIDs []int64, includeChildren bool, isGetSubmodelElements bool, includeBlobValue bool) ([]loadedSMERow, error) {
+func readSubmodelElementRowsByRootIDs(ctx context.Context, db DBQueryer, submodelDatabaseID int64, rootIDs []int64, includeChildren bool, isGetSubmodelElements bool, includeBlobValue bool) ([]loadedSMERow, error) {
 	if len(rootIDs) == 0 {
 		return []loadedSMERow{}, nil
 	}
@@ -1477,7 +1479,7 @@ func readSubmodelElementRowsByRootIDs(ctx context.Context, db dbQueryer, submode
 
 func executeLoadedSMERowQuery(
 	ctx context.Context,
-	db dbQueryer,
+	db DBQueryer,
 	sqlQuery string,
 	args []interface{},
 	errorCodePrefix string,
@@ -1589,7 +1591,7 @@ func hasSMESupplementalSemanticIDFilter(ctx context.Context) bool {
 
 func applyFilteredSMESupplementalSemanticIDs(
 	ctx context.Context,
-	db dbQueryer,
+	db DBQueryer,
 	rows []loadedSMERow,
 ) error {
 	ownerIDs := make([]int64, 0, len(rows))
@@ -1646,7 +1648,7 @@ type loadedSMENode struct {
 	valueVisible bool
 }
 
-func buildSubmodelElementTreeFromRows(db dbQueryer, parsedRows []loadedSMERow, submodelID string, idShortOrPath string) (types.ISubmodelElement, error) {
+func buildSubmodelElementTreeFromRows(db DBQueryer, parsedRows []loadedSMERow, submodelID string, idShortOrPath string) (types.ISubmodelElement, error) {
 	nodes, children, rootNodes, buildNodesErr := buildLoadedSubmodelElementNodes(db, parsedRows, "SMREPO-GETSMEBYPATH")
 	if buildNodesErr != nil {
 		return nil, buildNodesErr
@@ -1713,7 +1715,7 @@ func isDirectEntityStatementPath(entityPath string, candidatePath string) bool {
 	return false
 }
 
-func buildSubmodelElementForestFromRows(db dbQueryer, parsedRows []loadedSMERow) (map[int64]types.ISubmodelElement, error) {
+func buildSubmodelElementForestFromRows(db DBQueryer, parsedRows []loadedSMERow) (map[int64]types.ISubmodelElement, error) {
 	nodes, children, rootNodes, buildNodesErr := buildLoadedSubmodelElementNodes(db, parsedRows, "SMREPO-GETSMES-BUILDFOREST")
 	if buildNodesErr != nil {
 		return nil, buildNodesErr
@@ -1729,7 +1731,7 @@ func buildSubmodelElementForestFromRows(db dbQueryer, parsedRows []loadedSMERow)
 	return result, nil
 }
 
-func buildLoadedSubmodelElementNodes(db dbQueryer, parsedRows []loadedSMERow, errorCodePrefix string) (map[int64]*loadedSMENode, map[int64][]*loadedSMENode, []*loadedSMENode, error) {
+func buildLoadedSubmodelElementNodes(db DBQueryer, parsedRows []loadedSMERow, errorCodePrefix string) (map[int64]*loadedSMENode, map[int64][]*loadedSMENode, []*loadedSMENode, error) {
 	nodes := make(map[int64]*loadedSMENode, len(parsedRows))
 	children := make(map[int64][]*loadedSMENode, len(parsedRows))
 	rootNodes := make([]*loadedSMENode, 0, 1)
@@ -1898,7 +1900,7 @@ func setEntityChildren(parent types.ISubmodelElement, kids []*loadedSMENode) {
 	p.SetStatements(statements)
 }
 
-func getReferencesFromKeyTables(db dbQueryer, referenceTable string, referenceKeyTable string, referenceIDs []int64, errorCodePrefix string) (map[int64]types.IReference, error) {
+func getReferencesFromKeyTables(db DBQueryer, referenceTable string, referenceKeyTable string, referenceIDs []int64, errorCodePrefix string) (map[int64]types.IReference, error) {
 	if len(referenceIDs) == 0 {
 		return map[int64]types.IReference{}, nil
 	}

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	gen "github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 )
@@ -104,6 +105,65 @@ func TestGetSubmodelsByListFiltersUsesIDShortColumn(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, items)
 	require.Empty(t, cursor)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetSubmodelsClosesLookaheadRowsBeforeSupplementalReferenceQuery(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	sut := &SubmodelDatabase{db: db}
+	visible := true
+	fragment := grammar.FragmentStringPattern("$sm#supplementalSemanticIds[]")
+	ctx := auth.WithQueryFilter(contextWithABACDisabled(t), &auth.QueryFilter{
+		Filters: auth.FragmentFilters{
+			fragment: {Boolean: &visible},
+		},
+	})
+
+	mock.ExpectBegin()
+	mainRows := sqlmock.NewRows([]string{
+		"submodel_identifier",
+		"id_short",
+		"category",
+		"kind",
+		"description",
+		"display_name",
+		"administrative_information",
+		"embedded_data_specification",
+		"supplemental_semantic_ids",
+		"extensions",
+		"qualifiers",
+		"semantic_id",
+		"supplemental_owner_id",
+	}).
+		AddRow("urn:sm:first", "First", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, int64(1)).
+		AddRow("urn:sm:lookahead", "Lookahead", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, int64(2))
+	mock.ExpectQuery(`SELECT .*FROM .*"submodel"`).
+		WillReturnRows(mainRows).
+		RowsWillBeClosed()
+	mock.ExpectQuery(`SELECT .*FROM .*"submodel_supplemental_semantic_id_reference"`).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"owner_id",
+			"ref_id",
+			"ref_type",
+			"key_id",
+			"key_type",
+			"key_value",
+			"parent_reference_payload",
+		}))
+	mock.ExpectCommit()
+
+	items, nextCursor, err := sut.GetSubmodels(ctx, 1, "", "", "", time.Time{}, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, "urn:sm:first", items[0].ID())
+	require.Equal(t, "urn:sm:lookahead", nextCursor)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -107,7 +107,7 @@ func TestGetSubmodelsByListFiltersUsesIDShortColumn(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestGetSubmodelByIDReturnsErrorWhenParallelReadsFail(t *testing.T) {
+func TestGetSubmodelByIDRollsBackWhenSnapshotReadFails(t *testing.T) {
 	t.Parallel()
 
 	db, mock, err := sqlmock.New()
@@ -116,11 +116,11 @@ func TestGetSubmodelByIDReturnsErrorWhenParallelReadsFail(t *testing.T) {
 		_ = db.Close()
 	}()
 
-	mock.MatchExpectationsInOrder(false)
-
 	sut := &SubmodelDatabase{db: db}
 
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*`).WillReturnError(errors.New("read failed"))
+	mock.ExpectRollback()
 
 	item, err := sut.GetSubmodelByID(contextWithABACDisabled(t), "", "", false, true)
 	require.Error(t, err)
@@ -232,6 +232,7 @@ func TestGetSubmodelElementWithLevelCoreReturnsElementWithoutChildren(t *testing
 
 	sut := &SubmodelDatabase{db: db}
 
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM "submodel"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 
@@ -260,6 +261,7 @@ func TestGetSubmodelElementWithLevelCoreReturnsElementWithoutChildren(t *testing
 				true,
 			),
 		)
+	mock.ExpectCommit()
 
 	elem, err := sut.GetSubmodelElement(contextWithABACDisabled(t), "sm-core", "RootCollection", true, "core")
 	require.NoError(t, err)
@@ -302,6 +304,7 @@ func TestGetSubmodelElementsCoreReturnsOnlyRootElements(t *testing.T) {
 
 	sut := &SubmodelDatabase{db: db}
 
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM "submodel"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 
@@ -333,6 +336,7 @@ func TestGetSubmodelElementsCoreReturnsOnlyRootElements(t *testing.T) {
 				true,
 			),
 		)
+	mock.ExpectCommit()
 
 	elems, cursor, err := sut.GetSubmodelElements(contextWithABACDisabled(t), "sm-core", nil, "", true, "core")
 	require.NoError(t, err)
@@ -357,6 +361,7 @@ func TestGetSubmodelElementsDeepReturnsRootWithChildren(t *testing.T) {
 
 	sut := &SubmodelDatabase{db: db}
 
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM "submodel"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 
@@ -410,6 +415,7 @@ func TestGetSubmodelElementsDeepReturnsRootWithChildren(t *testing.T) {
 				true,
 			),
 		)
+	mock.ExpectCommit()
 
 	elems, cursor, err := sut.GetSubmodelElements(contextWithABACDisabled(t), "sm-deep", nil, "", true, "deep")
 	require.NoError(t, err)
@@ -1048,6 +1054,7 @@ func TestGetSubmodelElementReferencesReturnsReferencesWithPaginationCursor(t *te
 	sut := &SubmodelDatabase{db: db}
 	limit := 1
 
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM "submodel"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
 
@@ -1060,6 +1067,7 @@ func TestGetSubmodelElementReferencesReturnsReferencesWithPaginationCursor(t *te
 		WillReturnRows(sqlmock.NewRows([]string{"id", "model_type"}).
 			AddRow(10, int64(types.ModelTypeProperty)).
 			AddRow(20, int64(types.ModelTypeRange)))
+	mock.ExpectCommit()
 
 	references, cursor, err := sut.GetSubmodelElementReferences(contextWithABACDisabled(t), "sm-1", &limit, "")
 	require.NoError(t, err)
@@ -1113,6 +1121,7 @@ func TestGetSubmodelElementPathPageReturnsCompositeCursorForDuplicatePaths(t *te
 	sut := &SubmodelDatabase{db: db}
 	limit := 1
 
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM "submodel"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
 
@@ -1120,6 +1129,7 @@ func TestGetSubmodelElementPathPageReturnsCompositeCursorForDuplicatePaths(t *te
 		WillReturnRows(sqlmock.NewRows([]string{"idshort_path", "id"}).
 			AddRow("A", int64(10)).
 			AddRow("A", int64(20)))
+	mock.ExpectCommit()
 
 	paths, cursor, err := sut.GetSubmodelElementPathPage(contextWithABACDisabled(t), "sm-1", &limit, "", "")
 	require.NoError(t, err)
@@ -1141,6 +1151,7 @@ func TestGetSubmodelElementPathPageAcceptsCompositeCursor(t *testing.T) {
 	sut := &SubmodelDatabase{db: db}
 	limit := 2
 
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM "submodel"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
 
@@ -1151,6 +1162,7 @@ func TestGetSubmodelElementPathPageAcceptsCompositeCursor(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"idshort_path", "id"}).
 			AddRow("A", int64(20)).
 			AddRow("B", int64(30)))
+	mock.ExpectCommit()
 
 	paths, cursor, err := sut.GetSubmodelElementPathPage(contextWithABACDisabled(t), "sm-1", &limit, "A|10", "")
 	require.NoError(t, err)

--- a/internal/submodelrepository/persistence/submodel_database_signed_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_signed_test.go
@@ -83,14 +83,13 @@ func TestGetSignedSubmodelPropagatesSubmodelLookupError(t *testing.T) {
 		_ = db.Close()
 	}()
 
-	mock.MatchExpectationsInOrder(false)
-
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
 	sut := &SubmodelDatabase{db: db, privateKey: privateKey}
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*`).WillReturnError(errors.New("lookup failed"))
-	mock.ExpectQuery(`SELECT .*`).WillReturnError(errors.New("lookup failed"))
+	mock.ExpectRollback()
 
 	jws, err := sut.GetSignedSubmodel(contextWithABACDisabled(t), "sm")
 	require.Error(t, err)
@@ -227,6 +226,7 @@ func requireCanonicalJSONPayload(t *testing.T, payload []byte) {
 }
 
 func setupSignedSubmodelHappyPathExpectations(mock sqlmock.Sqlmock, submodelIdentifier string) {
+	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM "submodel" INNER JOIN "submodel_payload"`).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"submodel_identifier",
@@ -241,6 +241,7 @@ func setupSignedSubmodelHappyPathExpectations(mock sqlmock.Sqlmock, submodelIden
 			"extensions",
 			"qualifiers",
 			"semantic_id",
+			"sort_submodel_identifier",
 		}).AddRow(
 			submodelIdentifier,
 			"idShort",
@@ -254,6 +255,7 @@ func setupSignedSubmodelHappyPathExpectations(mock sqlmock.Sqlmock, submodelIden
 			nil,
 			nil,
 			nil,
+			submodelIdentifier,
 		))
 
 	mock.ExpectQuery(`SELECT .*"id".*FROM "submodel"`).
@@ -261,4 +263,5 @@ func setupSignedSubmodelHappyPathExpectations(mock sqlmock.Sqlmock, submodelIden
 
 	mock.ExpectQuery(`SELECT .*"sme"\."idshort_path".*FROM "submodel_element" AS "sme"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "path"}))
+	mock.ExpectCommit()
 }

--- a/internal/submodelrepository/persistence/submodel_element_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_element_write_database.go
@@ -123,32 +123,89 @@ func (s *SubmodelDatabase) updateSubmodelElementInTransaction(tx *sql.Tx, submod
 
 // GetSubmodelElement retrieves a submodel element by path and applies optional ABAC formula filters from ctx.
 func (s *SubmodelDatabase) GetSubmodelElement(ctx context.Context, submodelID string, idShortOrPath string, includeBlobValue bool, level string) (types.ISubmodelElement, error) {
-	return submodelelements.GetSubmodelElementByIDShortOrPath(ctx, s.readDB(ctx), submodelID, idShortOrPath, includeBlobValue, level)
+	if submodelID == "" || idShortOrPath == "" || (level != "" && level != "core" && level != "deep") {
+		return submodelelements.GetSubmodelElementByIDShortOrPath(ctx, nil, submodelID, idShortOrPath, includeBlobValue, level)
+	}
+	var result types.ISubmodelElement
+	err := common.ExecuteInReadTransaction(ctx, s.readDB(ctx), "SMREPO-GETSME-STARTTX", "SMREPO-GETSME-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, txErr = submodelelements.GetSubmodelElementByIDShortOrPathTx(ctx, tx, submodelID, idShortOrPath, includeBlobValue, level)
+		return txErr
+	})
+	return result, err
 }
 
 // GetSubmodelElements retrieves submodel elements and applies optional ABAC formula filters from ctx.
 func (s *SubmodelDatabase) GetSubmodelElements(ctx context.Context, submodelID string, limit *int, cursor string, includeBlobValue bool, level string) ([]types.ISubmodelElement, string, error) {
-	return submodelelements.GetSubmodelElementsBySubmodelID(ctx, s.readDB(ctx), submodelID, limit, cursor, includeBlobValue, level)
+	if submodelID == "" || (limit != nil && *limit < -1) {
+		return submodelelements.GetSubmodelElementsBySubmodelID(ctx, nil, submodelID, limit, cursor, includeBlobValue, level)
+	}
+	var result []types.ISubmodelElement
+	var nextCursor string
+	err := common.ExecuteInReadTransaction(ctx, s.readDB(ctx), "SMREPO-GETSMES-STARTTX", "SMREPO-GETSMES-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, nextCursor, txErr = submodelelements.GetSubmodelElementsBySubmodelIDTx(ctx, tx, submodelID, limit, cursor, includeBlobValue, level)
+		return txErr
+	})
+	return result, nextCursor, err
 }
 
 // GetSubmodelElementPaths retrieves submodel element paths directly from persisted idshort_path values.
 func (s *SubmodelDatabase) GetSubmodelElementPaths(ctx context.Context, submodelID string, level string) ([]string, error) {
-	return submodelelements.GetSubmodelElementPathsBySubmodelID(ctx, s.readDB(ctx), submodelID, level)
+	if submodelID == "" || (level != "" && level != "core" && level != "deep") {
+		return submodelelements.GetSubmodelElementPathsBySubmodelID(ctx, nil, submodelID, level)
+	}
+	var result []string
+	err := common.ExecuteInReadTransaction(ctx, s.readDB(ctx), "SMREPO-GETSMEPATHS-STARTTX", "SMREPO-GETSMEPATHS-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, txErr = submodelelements.GetSubmodelElementPathsBySubmodelID(ctx, tx, submodelID, level)
+		return txErr
+	})
+	return result, err
 }
 
 // GetSubmodelElementPathPage retrieves paged submodel element paths directly from persisted idshort_path values.
 func (s *SubmodelDatabase) GetSubmodelElementPathPage(ctx context.Context, submodelID string, limit *int, cursor string, level string) ([]string, string, error) {
-	return submodelelements.GetSubmodelElementPathsPageBySubmodelID(ctx, s.readDB(ctx), submodelID, limit, cursor, level)
+	if submodelID == "" || (level != "" && level != "core" && level != "deep") || (limit != nil && *limit < 0) {
+		return submodelelements.GetSubmodelElementPathsPageBySubmodelID(ctx, nil, submodelID, limit, cursor, level)
+	}
+	var result []string
+	var nextCursor string
+	err := common.ExecuteInReadTransaction(ctx, s.readDB(ctx), "SMREPO-GETSMEPATHSPAGE-STARTTX", "SMREPO-GETSMEPATHSPAGE-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, nextCursor, txErr = submodelelements.GetSubmodelElementPathsPageBySubmodelID(ctx, tx, submodelID, limit, cursor, level)
+		return txErr
+	})
+	return result, nextCursor, err
 }
 
 // GetSubmodelElementPathsByPath retrieves path notation for a specific submodel element path.
 func (s *SubmodelDatabase) GetSubmodelElementPathsByPath(ctx context.Context, submodelID string, idShortPath string, level string) ([]string, error) {
-	return submodelelements.GetSubmodelElementPathsByPath(ctx, s.readDB(ctx), submodelID, idShortPath, level)
+	if submodelID == "" || idShortPath == "" || (level != "" && level != "core" && level != "deep") {
+		return submodelelements.GetSubmodelElementPathsByPath(ctx, nil, submodelID, idShortPath, level)
+	}
+	var result []string
+	err := common.ExecuteInReadTransaction(ctx, s.readDB(ctx), "SMREPO-GETSMEPATHSBYPATH-STARTTX", "SMREPO-GETSMEPATHSBYPATH-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, txErr = submodelelements.GetSubmodelElementPathsByPath(ctx, tx, submodelID, idShortPath, level)
+		return txErr
+	})
+	return result, err
 }
 
 // GetSubmodelElementReferences retrieves SME references and applies optional ABAC formula filters from ctx.
 func (s *SubmodelDatabase) GetSubmodelElementReferences(ctx context.Context, submodelID string, limit *int, cursor string) ([]types.IReference, string, error) {
-	return submodelelements.GetSubmodelElementReferencesBySubmodelID(ctx, s.readDB(ctx), submodelID, limit, cursor)
+	if submodelID == "" || (limit != nil && *limit < -1) {
+		return submodelelements.GetSubmodelElementReferencesBySubmodelID(ctx, nil, submodelID, limit, cursor)
+	}
+	var result []types.IReference
+	var nextCursor string
+	err := common.ExecuteInReadTransaction(ctx, s.readDB(ctx), "SMREPO-GETSMEREFS-STARTTX", "SMREPO-GETSMEREFS-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, nextCursor, txErr = submodelelements.GetSubmodelElementReferencesBySubmodelID(ctx, tx, submodelID, limit, cursor)
+		return txErr
+	})
+	return result, nextCursor, err
 }
 
 // AddSubmodelElement adds a top-level submodel element and performs an ABAC re-check before commit when ABAC is enabled.

--- a/internal/submodelrepository/persistence/submodel_history_database.go
+++ b/internal/submodelrepository/persistence/submodel_history_database.go
@@ -60,7 +60,7 @@ func (s *SubmodelDatabase) appendCurrentSubmodelHistoryTx(ctx context.Context, t
 	if history.ActiveConfig().EvidenceEnabled {
 		stateReadCtx = auth.ContextWithoutQueryFilter(ctx)
 	}
-	submodel, err := s.getSubmodelByIDInTransaction(stateReadCtx, tx, submodelIdentifier, "deep", false)
+	submodel, err := s.getSubmodelByIDInTransaction(stateReadCtx, tx, submodelIdentifier, "deep", false, true)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (s *SubmodelDatabase) loadSubmodelHistorySnapshotBeforeMutationTx(ctx conte
 	if err := history.LockMutationTx(ctx, tx, history.TableSubmodel, submodelIdentifier); err != nil {
 		return nil, err
 	}
-	submodel, err := s.getSubmodelByIDInTransaction(auth.ContextWithoutQueryFilter(ctx), tx, submodelIdentifier, "deep", false)
+	submodel, err := s.getSubmodelByIDInTransaction(auth.ContextWithoutQueryFilter(ctx), tx, submodelIdentifier, "deep", false, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/submodelrepository/persistence/submodel_read_database.go
+++ b/internal/submodelrepository/persistence/submodel_read_database.go
@@ -367,7 +367,7 @@ func (s *SubmodelDatabase) getSubmodelsWithOptionalFiltersWithQueryer(ctx contex
 
 		if pageLimit > 0 && len(submodels) == pageLimit {
 			nextCursor = identifier.String
-			break
+			continue
 		}
 
 		var submodel types.ISubmodel

--- a/internal/submodelrepository/persistence/submodel_read_database.go
+++ b/internal/submodelrepository/persistence/submodel_read_database.go
@@ -29,8 +29,6 @@ package persistence
 import (
 	"context"
 	"database/sql"
-	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -44,54 +42,29 @@ import (
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
 	submodelqueries "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence/queries"
 	submodelelements "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence/submodelElements"
-	"golang.org/x/sync/errgroup"
 )
 
 // GetSubmodelByID retrieves a submodel by identifier and applies optional ABAC formula filters from ctx.
 func (s *SubmodelDatabase) GetSubmodelByID(ctx context.Context, submodelIdentifier string, level string, metadataOnly bool, includeBlobValue bool) (types.ISubmodel, error) {
-	eg := errgroup.Group{}
-	var submodels []types.ISubmodel
-	eg.Go(func() error {
-		var err error
-		submodels, _, err = s.GetSubmodels(ctx, 0, "", submodelIdentifier, "", time.Time{}, time.Time{})
-		if err != nil {
-			return err
-		}
-		if len(submodels) == 0 {
-			return common.NewErrNotFound(submodelIdentifier)
-		}
-		if len(submodels) > 1 {
-			return fmt.Errorf("multiple submodels found with identifier '%s'", submodelIdentifier)
-		}
-		return nil
-	})
-	submodelElements := make([]types.ISubmodelElement, 0)
-	if !metadataOnly {
-		eg.Go(func() error {
-			unlimited := -1
-			smes, _, err := s.GetSubmodelElements(ctx, submodelIdentifier, &unlimited, "", includeBlobValue, level)
-			if err != nil {
-				return err
-			}
-			submodelElements = smes
-			return nil
-		})
-	}
-
-	err := eg.Wait()
+	var submodel types.ISubmodel
+	err := common.ExecuteInReadTransaction(
+		ctx,
+		s.readDB(ctx),
+		"SMREPO-GETSMBYID-STARTTX",
+		"SMREPO-GETSMBYID-COMMIT",
+		func(tx *sql.Tx) error {
+			var txErr error
+			submodel, txErr = s.getSubmodelByIDInTransaction(ctx, tx, submodelIdentifier, level, metadataOnly, includeBlobValue)
+			return txErr
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
-	if len(submodels) == 0 {
-		return nil, common.NewErrNotFound(submodelIdentifier)
-	}
-	if submodels[0] == nil {
+	if submodel == nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMBYID-NILSUBMODEL Loaded submodel is nil")
 	}
-
-	submodels[0].SetSubmodelElements(submodelElements)
-
-	return submodels[0], nil
+	return submodel, nil
 }
 
 // GetSubmodels retrieves submodels and applies optional ABAC formula filters from ctx.
@@ -151,7 +124,7 @@ func (s *SubmodelDatabase) GetSubmodelReference(ctx context.Context, submodelIde
 	return buildSubmodelModelReference(submodels[0].ID())
 }
 
-func (s *SubmodelDatabase) getSubmodelByIDInTransaction(ctx context.Context, tx *sql.Tx, submodelIdentifier string, level string, metadataOnly bool) (types.ISubmodel, error) {
+func (s *SubmodelDatabase) getSubmodelByIDInTransaction(ctx context.Context, tx *sql.Tx, submodelIdentifier string, level string, metadataOnly bool, includeBlobValue bool) (types.ISubmodel, error) {
 	if tx == nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMBYIDTX-NILTX transaction must not be nil")
 	}
@@ -166,7 +139,7 @@ func (s *SubmodelDatabase) getSubmodelByIDInTransaction(ctx context.Context, tx 
 	}
 
 	unlimited := -1
-	submodelElements, _, err := submodelelements.GetSubmodelElementsBySubmodelIDTx(ctx, tx, submodelIdentifier, &unlimited, "", true, level)
+	submodelElements, _, err := submodelelements.GetSubmodelElementsBySubmodelIDTx(ctx, tx, submodelIdentifier, &unlimited, "", includeBlobValue, level)
 	if err != nil {
 		return nil, err
 	}
@@ -217,6 +190,9 @@ func (s *SubmodelDatabase) getSubmodelMetadataByIDInTransaction(ctx context.Cont
 	if scanErr != nil {
 		return nil, scanErr
 	}
+	if closeErr := rows.Close(); closeErr != nil {
+		return nil, common.NewInternalServerError("SMREPO-GETSMBYIDTX-CLOSEROWS " + closeErr.Error())
+	}
 	return submodel, nil
 }
 
@@ -256,7 +232,22 @@ func (s *SubmodelDatabase) QuerySubmodels(ctx context.Context, limit int32, curs
 
 //nolint:revive // cyclomatic complexity is acceptable for this function due to query/filter orchestration in one flow
 func (s *SubmodelDatabase) getSubmodelsWithOptionalFilters(ctx context.Context, limit int32, cursor string, submodelIdentifier string, idShort string, semanticID string, createdFrom time.Time, updatedFrom time.Time) ([]types.ISubmodel, string, error) {
-	readDB := s.readDB(ctx)
+	if !hasFragmentFilterPrefix(ctx, "$sm#supplementalSemanticIds") {
+		return s.getSubmodelsWithOptionalFiltersWithQueryer(ctx, s.readDB(ctx), limit, cursor, submodelIdentifier, idShort, semanticID, createdFrom, updatedFrom)
+	}
+
+	var result []types.ISubmodel
+	var nextCursor string
+	err := common.ExecuteInReadTransaction(ctx, s.readDB(ctx), "SMREPO-GETSMS-STARTTX", "SMREPO-GETSMS-COMMIT", func(tx *sql.Tx) error {
+		var txErr error
+		result, nextCursor, txErr = s.getSubmodelsWithOptionalFiltersWithQueryer(ctx, tx, limit, cursor, submodelIdentifier, idShort, semanticID, createdFrom, updatedFrom)
+		return txErr
+	})
+	return result, nextCursor, err
+}
+
+//nolint:revive // cyclomatic complexity is acceptable for this function due to query/filter orchestration in one flow
+func (s *SubmodelDatabase) getSubmodelsWithOptionalFiltersWithQueryer(ctx context.Context, db descriptors.DBQueryer, limit int32, cursor string, submodelIdentifier string, idShort string, semanticID string, createdFrom time.Time, updatedFrom time.Time) ([]types.ISubmodel, string, error) {
 	var limitFilter *int32
 
 	if limit == 0 {
@@ -269,13 +260,6 @@ func (s *SubmodelDatabase) getSubmodelsWithOptionalFilters(ctx context.Context, 
 
 	var cursorFilter *string
 	if cursor != "" {
-		cursorExists, cursorErr := s.submodelCursorExists(ctx, cursor)
-		if cursorErr != nil {
-			return nil, "", cursorErr
-		}
-		if !cursorExists {
-			return []types.ISubmodel{}, "", nil
-		}
 		cursorFilter = &cursor
 	}
 
@@ -342,7 +326,7 @@ func (s *SubmodelDatabase) getSubmodelsWithOptionalFilters(ctx context.Context, 
 	var identifier, rawIDShort, category, descriptionJsonString, displayNameJsonString, administrativeInformationJsonString, embeddedDataSpecificationJsonString, supplementalSemanticIDsJsonString, extensionsJsonString, qualifiersJsonString, semanticIDJSONString sql.NullString
 	var kind sql.NullInt64
 
-	rows, err := readDB.QueryContext(ctx, query, args...)
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, "", err
 	}
@@ -429,7 +413,7 @@ func (s *SubmodelDatabase) getSubmodelsWithOptionalFilters(ctx context.Context, 
 	if filterSupplementalSemanticIDs {
 		filteredReferences, readErr := descriptors.ReadSubmodelSupplementalSemanticReferencesBySubmodelIDs(
 			ctx,
-			readDB,
+			db,
 			supplementalOwnerIDs,
 		)
 		if readErr != nil {
@@ -454,22 +438,6 @@ func hasFragmentFilterPrefix(ctx context.Context, prefix string) bool {
 		}
 	}
 	return false
-}
-
-func (s *SubmodelDatabase) submodelCursorExists(ctx context.Context, cursor string) (bool, error) {
-	query, args, buildErr := submodelqueries.BuildSubmodelCursorExistsSQL(cursor)
-	if buildErr != nil {
-		return false, common.NewInternalServerError("SMREPO-CHECKSMCURSOR-BUILDSQL " + buildErr.Error())
-	}
-
-	var one int
-	if queryErr := s.readDB(ctx).QueryRowContext(ctx, query, args...).Scan(&one); queryErr != nil {
-		if errors.Is(queryErr, sql.ErrNoRows) {
-			return false, nil
-		}
-		return false, common.NewInternalServerError("SMREPO-CHECKSMCURSOR-EXECSQL " + queryErr.Error())
-	}
-	return true, nil
 }
 
 func buildSubmodelModelReference(submodelIdentifier string) (types.IReference, error) {

--- a/internal/submodelrepository/persistence/utils/submodel_utils.go
+++ b/internal/submodelrepository/persistence/utils/submodel_utils.go
@@ -33,6 +33,12 @@ import (
 	"github.com/doug-martin/goqu/v9"
 )
 
+// SubmodelIDQueryer supports resolving a Submodel database ID through either a
+// database pool or a transaction.
+type SubmodelIDQueryer interface {
+	QueryRow(query string, args ...any) *sql.Row
+}
+
 // GetSubmodelDatabaseID resolves the internal database ID of a Submodel by its identifier.
 //
 // Description:
@@ -62,7 +68,7 @@ func GetSubmodelDatabaseIDForUpdate(tx *sql.Tx, submodelID string) (int, error) 
 	return getSubmodelDatabaseID(tx, submodelID, true)
 }
 
-func getSubmodelDatabaseID(tx *sql.Tx, submodelID string, forUpdate bool) (int, error) {
+func getSubmodelDatabaseID(db SubmodelIDQueryer, submodelID string, forUpdate bool) (int, error) {
 	var databaseID int
 	query := goqu.Select("id").
 		From("submodel").
@@ -75,7 +81,7 @@ func getSubmodelDatabaseID(tx *sql.Tx, submodelID string, forUpdate bool) (int, 
 	if err != nil {
 		return 0, err
 	}
-	err = tx.QueryRow(sqlQuery, args...).Scan(&databaseID)
+	err = db.QueryRow(sqlQuery, args...).Scan(&databaseID)
 	if err != nil {
 		return 0, err
 	}
@@ -103,14 +109,11 @@ func getSubmodelDatabaseID(tx *sql.Tx, submodelID string, forUpdate bool) (int, 
 //		return err
 //	}
 func GetSubmodelDatabaseIDFromDB(db *sql.DB, submodelID string) (int, error) {
-	var databaseID int
-	sqlQuery, args, err := goqu.Select("id").From("submodel").Where(goqu.I("submodel_identifier").Eq(submodelID)).ToSQL()
-	if err != nil {
-		return 0, err
-	}
-	err = db.QueryRow(sqlQuery, args...).Scan(&databaseID)
-	if err != nil {
-		return 0, err
-	}
-	return databaseID, nil
+	return getSubmodelDatabaseID(db, submodelID, false)
+}
+
+// GetSubmodelDatabaseIDFromQueryer resolves the internal database ID through
+// either a database pool or an existing transaction.
+func GetSubmodelDatabaseIDFromQueryer(db SubmodelIDQueryer, submodelID string) (int, error) {
+	return getSubmodelDatabaseID(db, submodelID, false)
 }


### PR DESCRIPTION
## Summary

- run compound reader operations in read-only repeatable-read transactions
- keep Submodel, Submodel Element, AAS, AASX, descriptor, company and discovery reads on one reader snapshot
- keep AASX large-object lookup and opening in the same stable snapshot
- preserve `includeBlobValue` when loading a Submodel through a transaction

## Why

#540 allowed reader services or poolers to distribute connections across replicas. Compound responses could therefore combine queries from different replay positions. It also left an AASX download race between reading the large-object OID and opening the object while a replacement or deletion commits on the writer.

This keeps eventual consistency between requests, but makes each individual response internally consistent.

Follow-up to #540.

## Validation

- `golangci-lint run`
- affected unit packages
- `go test -v ./internal/submodelrepository/integration_tests`
- `go test -v ./internal/aasenvironment/integration_tests`
