### PR TITLE
Index Submodel semantic ID payload lookups

### DIFF
--- a/cmd/basyxconfigurationservice/main.go
+++ b/cmd/basyxconfigurationservice/main.go
@@ -92,7 +92,8 @@ func main() {
 	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_7.sql"), "v1.1.7"))
 	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_8.sql"), "v1.1.8"))
 	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_9.sql"), "v1.1.9"))
-	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_10.sql"), common.CURRENT_DATABASE_VERSION))
+	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_10.sql"), "v1.1.10"))
+	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_11.sql"), common.CURRENT_DATABASE_VERSION))
 
 	if err = schemInit.Execute(); err != nil {
 		slog.Error("configuration failed", "error.code", "BASYXCFG-MAIN-EXECUTE", "error", err)

--- a/database/patches/1_1_11.sql
+++ b/database/patches/1_1_11.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- Project        : Eclipse BaSyx
+-- Organization   : Fraunhofer IESE
+-- File Type      : SQL Patch Script
+-- Patch Version  : 1.1.11
+-- Metamodel Ver. : 3.2
+-- ----------------------------------------------------------------------------
+-- Description:
+--   Adds the index required for efficient Submodel semantic ID payload lookups.
+--
+-- Copyright (c) Eclipse BaSyx Authors and Fraunhofer IESE
+-- SPDX-License-Identifier: MIT
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS ix_submodel_semantic_id_refpayload_refid
+  ON submodel_semantic_id_reference_payload(reference_id);
+
+UPDATE basyxsystem
+SET schema_version = 'v1.1.11',
+    state = 'clean'
+WHERE identifier = (
+  SELECT identifier
+  FROM basyxsystem
+  ORDER BY identifier ASC
+  LIMIT 1
+);

--- a/internal/aasenvironment/migration_integration_tests/aasenvironment_migration_integration_test.go
+++ b/internal/aasenvironment/migration_integration_tests/aasenvironment_migration_integration_test.go
@@ -133,6 +133,7 @@ func TestMigrationFromReleaseCandidate5PreservesEnvironmentData(t *testing.T) {
 
 	require.False(t, databaseTableExists(t, "submodel_supplemental_semantic_id_reference"))
 	require.False(t, databaseTableExists(t, "submodel_element_supplemental_semantic_id_reference"))
+	require.False(t, databaseIndexExists(t, "ix_submodel_semantic_id_refpayload_refid"))
 
 	for _, fixture := range fixtures {
 		postFixture(t, fixture)
@@ -162,6 +163,7 @@ func TestMigrationFromReleaseCandidate5PreservesEnvironmentData(t *testing.T) {
 
 	assertCollectionsContainFixtures(t, fixtures)
 	assertSchemaVersion(t, common.CURRENT_DATABASE_VERSION)
+	require.True(t, databaseIndexExists(t, "ix_submodel_semantic_id_refpayload_refid"))
 	assertLongIdentifierEvidenceCatalogAccepts(t, longIdentifier)
 	assertLegacyBinaryStateUnchanged(t, legacyFile, readLegacyFileState(t, "LegacyFile"))
 	assertLegacyBinaryStateUnchanged(t, legacyUntouched, readLegacyFileState(t, "LegacyFileUntouched"))
@@ -692,6 +694,31 @@ func databaseTableExists(t *testing.T, tableName string) bool {
 			goqu.Ex{
 				"table_schema": "public",
 				"table_name":   tableName,
+			},
+		).
+		ToSQL()
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.QueryRowContext(t.Context(), query, args...).Scan(&count))
+	return count > 0
+}
+
+func databaseIndexExists(t *testing.T, indexName string) bool {
+	t.Helper()
+
+	db := openMigrationDatabase(t)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	query, args, err := goqu.Dialect("postgres").
+		From(goqu.T("pg_indexes").Schema("pg_catalog")).
+		Select(goqu.COUNT("*")).
+		Where(
+			goqu.Ex{
+				"schemaname": "public",
+				"indexname":  indexName,
 			},
 		).
 		ToSQL()

--- a/internal/common/database.go
+++ b/internal/common/database.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	CURRENT_DATABASE_VERSION = "v1.1.10"
+	CURRENT_DATABASE_VERSION = "v1.1.11"
 	cleanSchemaState         = "clean"
 )
 


### PR DESCRIPTION
## What changed

- add database patch 1.1.11 with an index on `submodel_semantic_id_reference_payload(reference_id)`
- register the patch and update the expected database schema version
- verify that migration from the legacy schema creates the index

## Why

Submodel metadata reads look up the stored semantic ID payload by `reference_id`. That column was not indexed, so PostgreSQL performed a sequential scan for every Submodel read.

The index is created during the schema migration. Large installations should allow additional time for the index build during the pre-upgrade configuration job. No configuration changes are required.
