### PR TITLE
Reuse PostgreSQL query plans across read services

### DIFF
--- a/internal/aasrepository/persistence/aas_create_visibility_test.go
+++ b/internal/aasrepository/persistence/aas_create_visibility_test.go
@@ -58,7 +58,7 @@ func TestAASRepositoryCreateExistingUnauthorizedShellDoesNotReturnConflict(t *te
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	mock.ExpectQuery(`SELECT "id" FROM "aas"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
-	mock.ExpectQuery(`FROM "aas" AS "aas".*FALSE`).
+	mock.ExpectQuery(`FROM "aas" AS "aas".*\$2`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectRollback()
 

--- a/internal/aasrepository/persistence/aas_create_visibility_test.go
+++ b/internal/aasrepository/persistence/aas_create_visibility_test.go
@@ -59,6 +59,7 @@ func TestAASRepositoryCreateExistingUnauthorizedShellDoesNotReturnConflict(t *te
 	mock.ExpectQuery(`SELECT "id" FROM "aas"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 	mock.ExpectQuery(`FROM "aas" AS "aas".*\$2`).
+		WithArgs(aasID, false, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectRollback()
 

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -384,7 +384,7 @@ func (s *AssetAdministrationShellDatabase) checkAASVisibilityInTx(ctx context.Co
 		return false, false, common.NewInternalServerError("AASREPO-ABACCHKAAS-ADDFORMULA " + addFormulaErr.Error())
 	}
 
-	sqlQuery, args, toSQLErr := ds.ToSQL()
+	sqlQuery, args, toSQLErr := ds.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return false, false, common.NewInternalServerError("AASREPO-ABACCHKAAS-BUILDSQL " + toSQLErr.Error())
 	}
@@ -847,7 +847,7 @@ func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellsInTransac
 			return nil, "", common.NewInternalServerError("AASREPO-GETAASLIST-ABACFORMULA " + err.Error())
 		}
 	}
-	sqlQuery, args, toSQLErr := selectDS.ToSQL()
+	sqlQuery, args, toSQLErr := selectDS.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return nil, "", common.NewInternalServerError("AASREPO-GETAASLIST-BUILDSQL " + toSQLErr.Error())
 	}
@@ -940,7 +940,7 @@ func (s *AssetAdministrationShellDatabase) GetAssetAdministrationShellIDsByAsset
 		}
 	}
 
-	query, args, err := selectDS.ToSQL()
+	query, args, err := selectDS.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, "", common.NewInternalServerError("AASREPO-GETAASIDSBYASSETANDSMSEM-BUILDSQL " + err.Error())
 	}
@@ -973,7 +973,7 @@ func (s *AssetAdministrationShellDatabase) GetAssetAdministrationShellIDsByAsset
 }
 
 func (s *AssetAdministrationShellDatabase) assetAdministrationShellCursorExists(ctx context.Context, db aasDBQueryer, dialect *goqu.DialectWrapper, cursor string) (bool, error) {
-	query, args, buildErr := dialect.From("aas").Select(goqu.V(1)).Where(goqu.I("aas_id").Eq(cursor)).Limit(1).ToSQL()
+	query, args, buildErr := dialect.From("aas").Select(goqu.L("1")).Where(goqu.I("aas_id").Eq(cursor)).Limit(1).Prepared(true).ToSQL()
 	if buildErr != nil {
 		return false, common.NewInternalServerError("AASREPO-CHECKAASCURSOR-BUILDSQL " + buildErr.Error())
 	}
@@ -1020,7 +1020,7 @@ func (s *AssetAdministrationShellDatabase) getAssetAdministrationShellByIDInTran
 		}
 	}
 
-	sqlQuery, args, toSQLErr := selectDS.ToSQL()
+	sqlQuery, args, toSQLErr := selectDS.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return nil, common.NewInternalServerError("AASREPO-GETAASBYID-BUILDSQL " + toSQLErr.Error())
 	}
@@ -2009,7 +2009,7 @@ func (s *AssetAdministrationShellDatabase) GetAllSubmodelReferencesByAASID(ctx c
 		}
 	}
 
-	aasDBIDSQL, aasDBIDArgs, aasDBIDBuildErr := selectDS.ToSQL()
+	aasDBIDSQL, aasDBIDArgs, aasDBIDBuildErr := selectDS.Prepared(true).ToSQL()
 	if aasDBIDBuildErr != nil {
 		return nil, "", common.NewInternalServerError("AASREPO-GETSMREFS-BUILDAASSQL " + aasDBIDBuildErr.Error())
 	}
@@ -2149,12 +2149,13 @@ func (s *AssetAdministrationShellDatabase) ListAASIdentifiersBySubmodelIDInTrans
 func submodelReferenceCursorExists(ctx context.Context, tx *sql.Tx, dialect *goqu.DialectWrapper, aasDBID int64, cursorID int64) (bool, error) {
 	query, args, buildErr := dialect.
 		From(goqu.T("aas_submodel_reference").As("r")).
-		Select(goqu.V(1)).
+		Select(goqu.L("1")).
 		Where(
 			goqu.I("r.id").Eq(cursorID),
 			goqu.I("r.aas_id").Eq(aasDBID),
 		).
 		Limit(1).
+		Prepared(true).
 		ToSQL()
 	if buildErr != nil {
 		return false, common.NewInternalServerError("AASREPO-CHECKSMREFCURSOR-BUILDSQL " + buildErr.Error())
@@ -2447,7 +2448,7 @@ func (s *AssetAdministrationShellDatabase) readSubmodelReferencePayloadsByAASDBI
 		return nil, common.NewInternalServerError("AASREPO-READSMREFBATCH-ABACKEYFILTERS " + filterErr.Error())
 	}
 
-	submodelSQL, submodelArgs, submodelBuildErr := submodelDS.ToSQL()
+	submodelSQL, submodelArgs, submodelBuildErr := submodelDS.Prepared(true).ToSQL()
 	if submodelBuildErr != nil {
 		return nil, common.NewInternalServerError("AASREPO-READSMREFBATCH-BUILDSQL " + submodelBuildErr.Error())
 	}
@@ -2782,7 +2783,7 @@ func (s *AssetAdministrationShellDatabase) readSpecificAssetIDsByAssetInformatio
 		return nil, common.NewInternalServerError("AASREPO-READSPECIFIC-ABACFILTERS " + filterErr.Error())
 	}
 
-	querySQL, queryArgs, buildErr := queryDS.ToSQL()
+	querySQL, queryArgs, buildErr := queryDS.Prepared(true).ToSQL()
 	if buildErr != nil {
 		return nil, common.NewInternalServerError("AASREPO-READSPECIFIC-BUILDSQL " + buildErr.Error())
 	}
@@ -2868,7 +2869,7 @@ func (s *AssetAdministrationShellDatabase) readSpecificAssetIDsByAssetInformatio
 		return nil, common.NewInternalServerError("AASREPO-READSPECIFICBATCH-ABACFILTERS " + filterErr.Error())
 	}
 
-	querySQL, queryArgs, buildErr := queryDS.ToSQL()
+	querySQL, queryArgs, buildErr := queryDS.Prepared(true).ToSQL()
 	if buildErr != nil {
 		return nil, common.NewInternalServerError("AASREPO-READSPECIFICBATCH-BUILDSQL " + buildErr.Error())
 	}

--- a/internal/aasrepository/persistence/aas_database_query_utils.go
+++ b/internal/aasrepository/persistence/aas_database_query_utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/FriedJannik/aas-go-sdk/jsonization"
 	"github.com/FriedJannik/aas-go-sdk/types"
 	"github.com/doug-martin/goqu/v9"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	jsoniter "github.com/json-iterator/go"
 )
 
@@ -224,8 +225,8 @@ func buildGetAssetAdministrationShellIDsByAssetAndSubmodelSemanticIDsDataset(
 		Select(goqu.I("aas.aas_id")).
 		Distinct().
 		Where(
-			goqu.I("asset_information.global_asset_id").In(globalAssetIDs),
-			goqu.I("semantic_id_key.value").In(submodelSemanticIDs),
+			common.PostgreSQLTextArrayContains(goqu.I("asset_information.global_asset_id"), globalAssetIDs),
+			common.PostgreSQLTextArrayContains(goqu.I("semantic_id_key.value"), submodelSemanticIDs),
 		).
 		Order(goqu.I("aas.aas_id").Asc())
 
@@ -249,7 +250,7 @@ func buildSpecificAssetIDFilterExpression(dialect *goqu.DialectWrapper, specific
 
 	specificAssetIDTable := goqu.T("specific_asset_id").As("specific_asset_id_filter")
 	existsSub := dialect.From(specificAssetIDTable).
-		Select(goqu.V(1)).
+		Select(goqu.L("1")).
 		Where(goqu.And(
 			goqu.I("specific_asset_id_filter.asset_information_id").Eq(goqu.I("asset_information.asset_information_id")),
 			goqu.I("specific_asset_id_filter.name").Eq(specificAssetID.Name()),
@@ -276,7 +277,7 @@ func uniqueSpecificAssetIDs(specificAssetIDs []types.ISpecificAssetID) []types.I
 }
 
 func buildGetAssetAdministrationShellCursorByDBIDQuery(dialect *goqu.DialectWrapper, aasDBID int64) (string, []any, error) {
-	return dialect.From("aas").Select("aas_id").Where(goqu.I("id").Eq(aasDBID)).ToSQL()
+	return dialect.From("aas").Select("aas_id").Where(goqu.I("id").Eq(aasDBID)).Prepared(true).ToSQL()
 }
 
 func buildGetAssetAdministrationShellDBIDByIdentifierDataset(dialect *goqu.DialectWrapper, aasIdentifier string) *goqu.SelectDataset {
@@ -309,6 +310,7 @@ func buildGetAssetInformationCurrentStateQuery(dialect *goqu.DialectWrapper, aas
 	return dialect.From("asset_information").
 		Select("asset_kind", "global_asset_id", "asset_type").
 		Where(goqu.I("asset_information_id").Eq(aasDBID)).
+		Prepared(true).
 		ToSQL()
 }
 
@@ -344,7 +346,7 @@ func buildGetAllSubmodelReferencesByAASIDQuery(dialect *goqu.DialectWrapper, aas
 		ds = ds.Where(goqu.I("r.id").Gte(cursorID))
 	}
 
-	return ds.ToSQL()
+	return ds.Prepared(true).ToSQL()
 }
 
 func buildFindSubmodelReferenceIDByAASIDAndSubmodelIdentifierQuery(dialect *goqu.DialectWrapper, aasDBID int64, submodelIdentifier string) (string, []any, error) {
@@ -357,6 +359,7 @@ func buildFindSubmodelReferenceIDByAASIDAndSubmodelIdentifierQuery(dialect *goqu
 			goqu.I("k.value").Eq(submodelIdentifier),
 		).
 		Limit(1).
+		Prepared(true).
 		ToSQL()
 }
 
@@ -368,6 +371,7 @@ func buildListAASIdentifiersBySubmodelIdentifierQuery(dialect *goqu.DialectWrapp
 		SelectDistinct(goqu.I("a.aas_id")).
 		Where(goqu.I("k.value").Eq(submodelIdentifier)).
 		Order(goqu.I("a.aas_id").Asc()).
+		Prepared(true).
 		ToSQL()
 }
 
@@ -406,6 +410,7 @@ func buildGetAssetAdministrationShellMapByDBIDQueryWithSelect(dialect *goqu.Dial
 		LeftJoin(goqu.T("thumbnail_file_element").As("tfe"), goqu.On(goqu.I("tfe.id").Eq(goqu.I("aas.id")))).
 		Select(selectExpressions...).
 		Where(goqu.I("aas.id").Eq(aasDBID)).
+		Prepared(true).
 		ToSQL()
 }
 
@@ -416,7 +421,8 @@ func buildGetAssetAdministrationShellMapsByDBIDsQueryWithSelect(dialect *goqu.Di
 		LeftJoin(goqu.T("asset_information").As("asset_information"), goqu.On(goqu.I("asset_information.asset_information_id").Eq(goqu.I("aas.id")))).
 		LeftJoin(goqu.T("thumbnail_file_element").As("tfe"), goqu.On(goqu.I("tfe.id").Eq(goqu.I("aas.id")))).
 		Select(selectExpressions...).
-		Where(goqu.I("aas.id").In(aasDBIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(goqu.I("aas.id"), aasDBIDs)).
+		Prepared(true).
 		ToSQL()
 }
 
@@ -435,7 +441,7 @@ func buildGetSubmodelReferencePayloadsByAASIDsDataset(dialect *goqu.DialectWrapp
 			goqu.I("aas_submodel_reference.aas_id"),
 			goqu.I("rp.parent_reference_payload"),
 		).
-		Where(goqu.I("aas_submodel_reference.aas_id").In(aasDBIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(goqu.I("aas_submodel_reference.aas_id"), aasDBIDs)).
 		GroupBy(
 			goqu.I("aas_submodel_reference.id"),
 			goqu.I("aas_submodel_reference.aas_id"),
@@ -477,7 +483,7 @@ func buildReadSpecificAssetIDsByAssetInformationIDsDataset(dialect *goqu.Dialect
 			goqu.I("specific_asset_id.value"),
 			goqu.I("sp.semantic_id_payload"),
 		).
-		Where(goqu.I("specific_asset_id.asset_information_id").In(assetInformationIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(goqu.I("specific_asset_id.asset_information_id"), assetInformationIDs)).
 		GroupBy(
 			goqu.I("specific_asset_id.asset_information_id"),
 			goqu.I("specific_asset_id.id"),

--- a/internal/aasrepository/persistence/aas_dpp_lookup_test.go
+++ b/internal/aasrepository/persistence/aas_dpp_lookup_test.go
@@ -104,10 +104,11 @@ func TestGetAssetAdministrationShellIDsByAssetAndSubmodelSemanticIDsUsesJoinedQu
 			`INNER JOIN "aas_submodel_reference_key" AS "submodel_reference_key" ON ("submodel_reference_key"."reference_id" = "submodel_reference"."id") ` +
 			`INNER JOIN "submodel" AS "submodel" ON ("submodel"."submodel_identifier" = "submodel_reference_key"."value") ` +
 			`INNER JOIN "submodel_semantic_id_reference_key" AS "semantic_id_key" ON ("semantic_id_key"."reference_id" = "submodel"."id") ` +
-			`WHERE (("asset_information"."global_asset_id" IN ('product-1', 'product-2')) AND ("semantic_id_key"."value" IN ('https://admin-shell.io/idta/cds/dppMetadata/1'))) ` +
-			`ORDER BY "aas"."aas_id" ASC LIMIT 2`,
+			`WHERE ("asset_information"."global_asset_id" = ANY($1::text[]) AND "semantic_id_key"."value" = ANY($2::text[])) ` +
+			`ORDER BY "aas"."aas_id" ASC LIMIT $3`,
 	)
 	mock.ExpectQuery(queryPattern).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), 2).
 		WillReturnRows(sqlmock.NewRows([]string{"aas_id"}).
 			AddRow("dpp-1").
 			AddRow("dpp-2"))

--- a/internal/aasrepository/persistence/aas_read_query_shape_test.go
+++ b/internal/aasrepository/persistence/aas_read_query_shape_test.go
@@ -23,43 +23,42 @@
 * SPDX-License-Identifier: MIT
 ******************************************************************************/
 
-// Package aas_repository_utils contains utility functions for the Asset Administration Shell Repository component, such as parsing and handling of aas-related data.
-package aas_repository_utils
+package persistence
 
 import (
-	"database/sql"
+	"testing"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/stretchr/testify/require"
 )
 
-// GetAssetAdministrationShellDatabaseID returns the internal database ID for a given AAS identifier.
-func GetAssetAdministrationShellDatabaseID(tx *sql.Tx, aasId string) (int64, error) {
-	return getAssetAdministrationShellDatabaseID(tx, aasId, false)
-}
+func TestAssetAdministrationShellBatchReadQueriesReuseSQLShape(t *testing.T) {
+	t.Parallel()
 
-// GetAssetAdministrationShellDatabaseIDForUpdate returns and locks the internal database ID for a given AAS identifier.
-func GetAssetAdministrationShellDatabaseIDForUpdate(tx *sql.Tx, aasId string) (int64, error) {
-	return getAssetAdministrationShellDatabaseID(tx, aasId, true)
-}
-
-func getAssetAdministrationShellDatabaseID(tx *sql.Tx, aasId string, forUpdate bool) (int64, error) {
-	var databaseID int64
 	dialect := goqu.Dialect("postgres")
-	query := dialect.Select("id").
-		From("aas").
-		Where(goqu.I("aas_id").Eq(aasId)).
-		Prepared(true)
-	if forUpdate {
-		query = query.ForUpdate(goqu.Wait)
+	build := func(ids []int64) []string {
+		core, coreArgs, coreErr := buildGetAssetAdministrationShellMapsByDBIDsQueryWithSelect(
+			&dialect,
+			ids,
+			unmaskedCoreAssetAdministrationShellSelectExpressions(true),
+		)
+		require.NoError(t, coreErr)
+		require.Len(t, coreArgs, 1)
+
+		references, referenceArgs, referenceErr := buildGetSubmodelReferencePayloadsByAASIDsDataset(&dialect, ids).
+			Prepared(true).
+			ToSQL()
+		require.NoError(t, referenceErr)
+		require.Len(t, referenceArgs, 1)
+
+		specificAssetIDs, specificAssetIDArgs, specificAssetIDErr := buildReadSpecificAssetIDsByAssetInformationIDsDataset(&dialect, ids).
+			Prepared(true).
+			ToSQL()
+		require.NoError(t, specificAssetIDErr)
+		require.Len(t, specificAssetIDArgs, 1)
+
+		return []string{core, references, specificAssetIDs}
 	}
 
-	sqlQuery, args, err := query.ToSQL()
-	if err != nil {
-		return 0, err
-	}
-	err = tx.QueryRow(sqlQuery, args...).Scan(&databaseID)
-	if err != nil {
-		return 0, err
-	}
-	return databaseID, nil
+	require.Equal(t, build([]int64{1}), build([]int64{1, 2, 3}))
 }

--- a/internal/aasrepository/persistence/aas_thumbnail_stream_test.go
+++ b/internal/aasrepository/persistence/aas_thumbnail_stream_test.go
@@ -45,7 +45,9 @@ func TestStreamThumbnailDoesNotExposeABACHiddenAAS(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT "id" FROM "aas"`).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
-	mock.ExpectQuery(`FROM "aas" AS "aas".*\$2`).WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`FROM "aas" AS "aas".*\$2`).
+		WithArgs("aas-id", false, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectRollback()
 	consumed := false
 

--- a/internal/aasrepository/persistence/aas_thumbnail_stream_test.go
+++ b/internal/aasrepository/persistence/aas_thumbnail_stream_test.go
@@ -45,7 +45,7 @@ func TestStreamThumbnailDoesNotExposeABACHiddenAAS(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT "id" FROM "aas"`).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
-	mock.ExpectQuery(`FROM "aas" AS "aas".*FALSE`).WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`FROM "aas" AS "aas".*\$2`).WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectRollback()
 	consumed := false
 

--- a/internal/aasxfileserver/persistence/aasx_database.go
+++ b/internal/aasxfileserver/persistence/aasx_database.go
@@ -139,7 +139,7 @@ func (p *AASXFileServerDatabase) listPackagesInTransaction(ctx context.Context, 
 	// #nosec G115 -- limit is normalized to a positive int32 value above.
 	ds = ds.Limit(uint(limit + 1))
 
-	sqlQuery, args, err := ds.ToSQL()
+	sqlQuery, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, 0, common.NewInternalServerError("AASXFS-LISTPACKAGES-BUILDSQL " + err.Error())
 	}
@@ -343,6 +343,7 @@ func (p *AASXFileServerDatabase) GetPackageByID(ctx context.Context, packageID s
 	query, args, err := dialect.From("aasx_package").
 		Select("id", "file_oid", "file_name", "content_type").
 		Where(goqu.C("package_id").Eq(packageID)).
+		Prepared(true).
 		ToSQL()
 	if err != nil {
 		return nil, common.NewInternalServerError("AASXFS-GETPACKAGE-BUILDSQL " + err.Error())
@@ -444,6 +445,7 @@ func (p *AASXFileServerDatabase) getAASIDsTx(ctx context.Context, queryable inte
 		Select("aas_id").
 		Where(goqu.C("package_db_id").Eq(packageDBID)).
 		Order(goqu.I("position").Asc()).
+		Prepared(true).
 		ToSQL()
 	if err != nil {
 		return nil, common.NewInternalServerError("AASXFS-GETAASIDS-BUILDSQL " + err.Error())

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -908,7 +908,7 @@ func listAssetAdministrationShellDescriptors(
 	if err != nil {
 		return nil, "", err
 	}
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if debugEnabled(ctx) {
 		slog.DebugContext(ctx, "AAS descriptor database query prepared")
 	}
@@ -1088,7 +1088,7 @@ func existsAASByID(ctx context.Context, db DBQueryer, aasID string) (bool, error
 	aas := goqu.T(common.TblAASDescriptor).As("aas")
 
 	ds := d.From(aas).Select(goqu.L("1")).Where(aas.Col(common.ColAASID).Eq(aasID)).Limit(1)
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return false, err
 	}

--- a/internal/common/descriptors/CompanyDescriptorHandler.go
+++ b/internal/common/descriptors/CompanyDescriptorHandler.go
@@ -535,7 +535,7 @@ func ListCompanyDescriptors(
 	if strings.TrimSpace(assetID) != "" {
 		assetIdRegexExists := d.
 			From(assetIdPattern).
-			Select(goqu.V(true)).
+			Select(goqu.L("TRUE")).
 			Where(
 				assetIdPattern.Col(common.ColDescriptorID).Eq(comp.Col(common.ColDescriptorID)),
 				goqu.L("? ~ ?", assetID, assetIdPattern.Col(common.ColRegexPattern)),
@@ -552,7 +552,7 @@ func ListCompanyDescriptors(
 		Order(comp.Col(common.ColCompanyDomain).Asc()).
 		Limit(uint(peekLimit))
 
-	sqlStr, args, buildErr := ds.ToSQL()
+	sqlStr, args, buildErr := ds.Prepared(true).ToSQL()
 	if buildErr != nil {
 		return nil, "", common.NewInternalServerError("Failed to build Company Descriptor query. See server logs for details.")
 	}
@@ -670,7 +670,7 @@ func ExistsCompanyDescriptorByID(ctx context.Context, db DBQueryer, companyIdent
 	comp := goqu.T(common.TblCompanyDescriptor).As("comp")
 
 	ds := d.From(comp).Select(goqu.L("1")).Where(comp.Col(common.ColCompanyDomain).Eq(companyIdentifier)).Limit(1)
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return false, err
 	}

--- a/internal/common/descriptors/NameOptions.go
+++ b/internal/common/descriptors/NameOptions.go
@@ -82,8 +82,9 @@ func readCompanyNameOptionsByDescriptorIDs(ctx context.Context, db DBQueryer, de
 			nameOpt.Col(common.ColDescriptorID),
 			nameOpt.Col(common.ColNameOption),
 		).
-		Where(nameOpt.Col(common.ColDescriptorID).In(descriptorIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(nameOpt.Col(common.ColDescriptorID), descriptorIDs)).
 		Order(nameOpt.Col(common.ColDescriptorID).Asc(), nameOpt.Col(common.ColPosition).Asc()).
+		Prepared(true).
 		ToSQL()
 	if err != nil {
 		return nil, err

--- a/internal/common/descriptors/ReadEndpoint.go
+++ b/internal/common/descriptors/ReadEndpoint.go
@@ -139,7 +139,7 @@ func ReadEndpointsByDescriptorIDs(
 	}
 
 	ds = ds.
-		Where(joinOn.Col(common.ColDescriptorID).In(descriptorIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(joinOn.Col(common.ColDescriptorID), descriptorIDs)).
 		Select(
 			joinOn.Col(common.ColDescriptorID),
 			joinOn.Col(common.ColID),

--- a/internal/common/descriptors/ReadEndpoint.go
+++ b/internal/common/descriptors/ReadEndpoint.go
@@ -79,9 +79,10 @@ func ReadEndpointsByDescriptorID(
 //   - Nullable text columns are COALESCE'd to empty strings; JSON arrays default to empty.
 //
 // Implementation notes:
-// - Uses SQL ANY with pgx slice parameters for efficient multi-key filtering.
-// - Uses LEFT JOINs so descriptors without endpoints are still handled.
-// - Prepared statements are enabled via goqu to allow DB plan caching.
+//   - Uses a typed PostgreSQL array parameter with prepared Goqu rendering for
+//     stable, efficient multi-key filtering.
+//   - Uses LEFT JOINs so descriptors without endpoints are still handled.
+//   - Prepared statements are enabled via goqu to allow DB plan caching.
 //
 // Errors may occur while building the SQL statement, executing the query,
 // scanning columns, or decoding the aggregated JSON payload of security

--- a/internal/common/descriptors/ReadExtension.go
+++ b/internal/common/descriptors/ReadExtension.go
@@ -101,8 +101,9 @@ func ReadExtensionsByDescriptorIDs(
 			dp.Col(common.ColDescriptorID),
 			dp.Col(common.ColExtensionsPayload),
 		).
-		Where(dp.Col(common.ColDescriptorID).In(descriptorIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(dp.Col(common.ColDescriptorID), descriptorIDs)).
 		Order(dp.Col(common.ColDescriptorID).Asc()).
+		Prepared(true).
 		ToSQL()
 	if err != nil {
 		return nil, err

--- a/internal/common/descriptors/ReadExtension.go
+++ b/internal/common/descriptors/ReadExtension.go
@@ -74,7 +74,8 @@ func ReadExtensionsByDescriptorID(
 //     references are loaded via the respective link tables.
 //
 // Implementation notes:
-//   - Uses SQL ANY with pgx slice parameters for efficient multi-key filtering.
+//   - Uses a typed PostgreSQL array parameter with prepared Goqu rendering for
+//     stable, efficient multi-key filtering.
 //   - Performs a single join to fetch base extension rows, then batches lookups
 //     for references to minimize round trips.
 //   - Converts ValueType strings to model.DataTypeDefXsd via

--- a/internal/common/descriptors/ReadReferences.go
+++ b/internal/common/descriptors/ReadReferences.go
@@ -414,7 +414,7 @@ func queryReferenceRowsByOwnerIDs(
 			rkt.Col(common.ColValue).As("key_value"),
 			rpt.Col("parent_reference_payload").As("parent_reference_payload"),
 		).
-		Where(ot.Col(spec.ownerIDColumn).In(ownerIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(ot.Col(spec.ownerIDColumn), ownerIDs)).
 		Order(
 			ot.Col(spec.ownerIDColumn).Asc(),
 			rkt.Col(common.ColPosition).Asc(),
@@ -429,7 +429,7 @@ func queryReferenceRowsByOwnerIDs(
 		}
 	}
 
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("REFREAD-BUILDQUERY: %w", err)
 	}
@@ -522,7 +522,7 @@ func readContextReferences1ToManyByOwnerIDs(
 			rkt.Col(common.ColValue).As("key_value"),
 			rpt.Col("parent_reference_payload").As("parent_reference_payload"),
 		).
-		Where(rt.Col(spec.ownerIDColumn).In(ownerIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(rt.Col(spec.ownerIDColumn), ownerIDs)).
 		Order(
 			rt.Col(spec.ownerIDColumn).Asc(),
 			rt.Col(common.ColPosition).Asc(),
@@ -547,7 +547,7 @@ func readContextReferences1ToManyByOwnerIDs(
 		}
 	}
 
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, fmt.Errorf("%s-BUILDQUERY: %w", spec.errPrefix, err)
 	}

--- a/internal/common/descriptors/ReadSpecificAssetId.go
+++ b/internal/common/descriptors/ReadSpecificAssetId.go
@@ -83,9 +83,10 @@ func ReadSpecificAssetIDsByDescriptorID(
 // present in the map with a nil slice to distinguish from absent keys.
 //
 // Implementation notes:
-// - Uses goqu to build SQL and pgx slice parameters for efficient ANY(bigint[]) filtering.
-// - Preloads semantic and external subject references in one pass to avoid N+1.
-// - Preserves a stable order by descriptor_id, id to ensure deterministic output.
+//   - Uses Goqu with a typed PostgreSQL array parameter and prepared rendering
+//     for stable, efficient ANY(bigint[]) filtering.
+//   - Preloads semantic and external subject references in one pass to avoid N+1.
+//   - Preserves a stable order by descriptor_id, id to ensure deterministic output.
 func ReadSpecificAssetIDsByDescriptorIDs(
 	ctx context.Context,
 	db DBQueryer,

--- a/internal/common/descriptors/ReadSpecificAssetId.go
+++ b/internal/common/descriptors/ReadSpecificAssetId.go
@@ -162,7 +162,7 @@ func ReadSpecificAssetIDsByDescriptorIDs(
 		common.TSpecificAssetID.Col(common.ColPosition).As("sort_specific_asset_position"),
 	}, maskRuntime.Projections()...)...).
 		Where(
-			specificAssetIDAlias.Col(common.ColDescriptorID).In(descriptorIDs),
+			common.PostgreSQLBigIntArrayContains(specificAssetIDAlias.Col(common.ColDescriptorID), descriptorIDs),
 			common.TSpecificAssetID.Col(common.ColName).Neq(globalAssetIDSpecificAssetIDName),
 		)
 
@@ -187,7 +187,7 @@ func ReadSpecificAssetIDsByDescriptorIDs(
 		).
 		Order(goqu.I(dataAlias + ".sort_specific_asset_position").Asc())
 
-	sqlStr, args, err := base.ToSQL()
+	sqlStr, args, err := base.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/common/descriptors/ReadSubmodelDescriptor.go
+++ b/internal/common/descriptors/ReadSubmodelDescriptor.go
@@ -134,7 +134,7 @@ func ReadSubmodelDescriptorsByDescriptorIDs(
 		}, maskRuntime.Projections()...)...).
 		Where(
 			goqu.And(
-				submodelDescriptorAlias.Col(common.ColDescriptorID).In(uniqDesc),
+				common.PostgreSQLBigIntArrayContains(submodelDescriptorAlias.Col(common.ColDescriptorID), uniqDesc),
 				submodelDescriptorAlias.Col(common.ColAASDescriptorID).IsNull(),
 			),
 		)
@@ -278,7 +278,7 @@ func ReadSubmodelDescriptorsByAASDescriptorIDs(
 			submodelDescriptorAlias.Col(common.ColPosition).As("sort_smd_position"),
 			submodelDescriptorAlias.Col(common.ColDescriptorID).As("sort_smd_descriptor_id"),
 		}, maskRuntime.Projections()...)...).
-		Where(submodelDescriptorAlias.Col(common.ColAASDescriptorID).In(uniqAASDesc))
+		Where(common.PostgreSQLBigIntArrayContains(submodelDescriptorAlias.Col(common.ColAASDescriptorID), uniqAASDesc))
 
 	inner = inner.Order(
 		submodelDescriptorAlias.Col(common.ColPosition).Asc(),
@@ -510,7 +510,7 @@ func readSubmodelDescriptorRows(
 	perGroupCap int,
 	allSmdDescCap int,
 ) (map[int64][]model.SubmodelDescriptorRow, []int64, error) {
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/common/descriptors/SpecificAssetIdDiscovery.go
+++ b/internal/common/descriptors/SpecificAssetIdDiscovery.go
@@ -154,7 +154,7 @@ func ReadSpecificAssetIDsByAASRef(
 		}
 	}
 
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func descriptorIDForAASIDTx(ctx context.Context, tx *sql.Tx, aasID string) (sql.
 		Where(common.TAASDescriptor.Col(common.ColAASID).Eq(aasID)).
 		Limit(1)
 
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return sql.NullInt64{}, err
 	}
@@ -331,7 +331,7 @@ func nextSpecificAssetIDPositionByAASRefTx(ctx context.Context, tx *sql.Tx, aasR
 		Select(goqu.L("COALESCE(MAX(position), -1) + 1")).
 		Where(common.TSpecificAssetID.Col(common.ColAASRef).Eq(aasRef))
 
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return 0, err
 	}

--- a/internal/common/descriptors/SubModelDescriptorHandler.go
+++ b/internal/common/descriptors/SubModelDescriptorHandler.go
@@ -85,7 +85,7 @@ func ListSubmodelDescriptorsForAAS(
 		Where(aas.Col(common.ColAASID).Eq(aasID)).
 		Limit(1)
 
-	sqlStr, args, buildErr := ds.ToSQL()
+	sqlStr, args, buildErr := ds.Prepared(true).ToSQL()
 	if buildErr != nil {
 		return nil, "", common.NewInternalServerError("Failed to build AAS lookup query. See server logs for details.")
 	}

--- a/internal/common/descriptors/SubModelDescriptorHandler.go
+++ b/internal/common/descriptors/SubModelDescriptorHandler.go
@@ -410,7 +410,7 @@ func ExistsSubmodelForAAS(ctx context.Context, db *sql.DB, aasID, submodelID str
 		).
 		Limit(1)
 
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return false, err
 	}
@@ -687,7 +687,7 @@ func existsSubmodelByID(ctx context.Context, db DBQueryer, submodelID string) (b
 			),
 		).
 		Limit(1)
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	if err != nil {
 		return false, err
 	}
@@ -749,7 +749,7 @@ func listSubmodelDescriptorIDsWithoutAAS(
 	}
 	ds = ds.Order(smd.Col(common.ColAASID).Asc()).Limit(uint(peekLimit))
 
-	sqlStr, args, buildErr := ds.ToSQL()
+	sqlStr, args, buildErr := ds.Prepared(true).ToSQL()
 	if buildErr != nil {
 		return nil, "", common.NewInternalServerError("Failed to build submodel descriptor lookup query. See server logs for details.")
 	}
@@ -795,7 +795,7 @@ func lookupSubmodelDescriptorID(ctx context.Context, db DBQueryer, submodelID st
 			),
 		).
 		Limit(1)
-	sqlStr, args, buildErr := ds.ToSQL()
+	sqlStr, args, buildErr := ds.Prepared(true).ToSQL()
 	if buildErr != nil {
 		return 0, common.NewInternalServerError("Failed to build submodel lookup query. See server logs for details.")
 	}

--- a/internal/common/descriptors/companyregexpatterns.go
+++ b/internal/common/descriptors/companyregexpatterns.go
@@ -90,8 +90,9 @@ func readCompanyRegexPatternsByDescriptorIDs(ctx context.Context, db DBQueryer, 
 			patternTbl.Col(common.ColDescriptorID),
 			patternTbl.Col(common.ColRegexPattern),
 		).
-		Where(patternTbl.Col(common.ColDescriptorID).In(descriptorIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(patternTbl.Col(common.ColDescriptorID), descriptorIDs)).
 		Order(patternTbl.Col(common.ColDescriptorID).Asc(), patternTbl.Col(common.ColPosition).Asc()).
+		Prepared(true).
 		ToSQL()
 	if err != nil {
 		return nil, err

--- a/internal/common/descriptors/read_query_shape_test.go
+++ b/internal/common/descriptors/read_query_shape_test.go
@@ -1,0 +1,61 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package descriptors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescriptorBatchReadReusesSQLShape(t *testing.T) {
+	t.Parallel()
+
+	build := func(ids []int64) string {
+		var query string
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherFunc(func(_ string, actual string) error {
+			query = actual
+			return nil
+		})))
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		mock.ExpectQuery("descriptor batch read").
+			WillReturnRows(sqlmock.NewRows([]string{"descriptor_id", "extensions_payload"}))
+		_, err = ReadExtensionsByDescriptorIDs(context.Background(), db, ids)
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+		return query
+	}
+
+	oneIDQuery := build([]int64{1})
+	manyIDsQuery := build([]int64{1, 2, 3})
+
+	require.Equal(t, oneIDQuery, manyIDsQuery)
+	require.Contains(t, oneIDQuery, `= ANY($1::bigint[])`)
+}

--- a/internal/common/descriptors/read_query_shape_test.go
+++ b/internal/common/descriptors/read_query_shape_test.go
@@ -59,3 +59,33 @@ func TestDescriptorBatchReadReusesSQLShape(t *testing.T) {
 	require.Equal(t, oneIDQuery, manyIDsQuery)
 	require.Contains(t, oneIDQuery, `= ANY($1::bigint[])`)
 }
+
+func TestListSubmodelDescriptorsForAASReusesLookupSQLShape(t *testing.T) {
+	t.Parallel()
+
+	build := func(aasID string) string {
+		var query string
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherFunc(func(_ string, actual string) error {
+			query = actual
+			return nil
+		})))
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		mock.ExpectQuery("AAS descriptor lookup").
+			WithArgs(aasID, sqlmock.AnyArg()).
+			WillReturnRows(sqlmock.NewRows([]string{"descriptor_id"}))
+		descriptors, cursor, err := ListSubmodelDescriptorsForAAS(context.Background(), db, aasID, 100, "")
+		require.NoError(t, err)
+		require.Empty(t, descriptors)
+		require.Empty(t, cursor)
+		require.NoError(t, mock.ExpectationsWereMet())
+		return query
+	}
+
+	firstQuery := build("urn:example:aas:first")
+	secondQuery := build("urn:example:aas:second")
+
+	require.Equal(t, firstQuery, secondQuery)
+	require.Equal(t, `SELECT "aas"."descriptor_id" FROM "aas_descriptor" AS "aas" WHERE ("aas"."id" = $1) LIMIT $2`, firstQuery)
+}

--- a/internal/common/descriptors/read_references_test.go
+++ b/internal/common/descriptors/read_references_test.go
@@ -73,7 +73,6 @@ func TestReadSubmodelDescriptorSupplementalSemanticReferencesAppliesFragmentFilt
 			`submodel_descriptor_supplemental_semantic_id_reference`,
 			`aasdesc_submodel_descriptor_supplemental_semantic_id_reference_key`,
 			`"aasdesc_submodel_descriptor_supplemental_semantic_id_reference_key"."value"`,
-			`'supplementalsemanticIdExample value'`,
 			`EXISTS`,
 			`external_subject_reference_key`,
 			`'PUBLIC_READABLE'`,
@@ -92,6 +91,7 @@ func TestReadSubmodelDescriptorSupplementalSemanticReferencesAppliesFragmentFilt
 	}()
 
 	mock.ExpectQuery("supplemental reference lookup").
+		WithArgs(sqlmock.AnyArg(), "supplementalsemanticIdExample value").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"owner_id",
 			"ref_id",
@@ -190,9 +190,6 @@ func TestReadRepositorySupplementalSemanticReferencesAppliesFragmentFilter(t *te
 						return fmt.Errorf("expected SQL to contain %q, got: %s", expectedTable, actual)
 					}
 				}
-				if !strings.Contains(actual, "FILTER_VISIBLE") {
-					return fmt.Errorf("expected SQL to contain filter value, got: %s", actual)
-				}
 				if test.name == "submodel" && strings.Contains(actual, "sme_supplemental_semantic_id_reference") {
 					return fmt.Errorf("submodel SQL must not include SME filter aliases: %s", actual)
 				}
@@ -211,6 +208,7 @@ func TestReadRepositorySupplementalSemanticReferencesAppliesFragmentFilter(t *te
 			}()
 
 			mock.ExpectQuery("supplemental reference lookup").
+				WithArgs(sqlmock.AnyArg(), "FILTER_VISIBLE").
 				WillReturnRows(sqlmock.NewRows([]string{
 					"owner_id",
 					"ref_id",

--- a/internal/common/model/grammar/logical_expression_to_sql.go
+++ b/internal/common/model/grammar/logical_expression_to_sql.go
@@ -926,7 +926,7 @@ func buildInlineExistsExpression(resolved []ResolvedFieldPath, predicate exp.Exp
 	}
 
 	d := goqu.Dialect("postgres")
-	ds := d.From(goqu.T(plan.BaseTable).As(plan.BaseAlias)).Select(goqu.V(1))
+	ds := d.From(goqu.T(plan.BaseTable).As(plan.BaseAlias)).Select(goqu.L("1"))
 
 	applied := map[string]struct{}{plan.BaseAlias: {}}
 	visiting := map[string]struct{}{}

--- a/internal/common/postgres_array.go
+++ b/internal/common/postgres_array.go
@@ -1,0 +1,61 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"database/sql/driver"
+	"strconv"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/exp"
+)
+
+type postgresInt64Array []int64
+
+func (values postgresInt64Array) Value() (driver.Value, error) {
+	array := make([]byte, 0, 2+len(values)*4)
+	array = append(array, '{')
+	for index, value := range values {
+		if index > 0 {
+			array = append(array, ',')
+		}
+		array = strconv.AppendInt(array, value, 10)
+	}
+	array = append(array, '}')
+	return string(array), nil
+}
+
+// PostgreSQLBigIntArrayContains builds a stable SQL membership expression for
+// a PostgreSQL bigint array parameter.
+func PostgreSQLBigIntArrayContains(column exp.Expression, values []int64) exp.Expression {
+	return goqu.L("? = ANY(?::bigint[])", column, postgresInt64Array(values))
+}
+
+// PostgreSQLBigIntArrayPosition returns the one-based position of value in a
+// PostgreSQL bigint array parameter.
+func PostgreSQLBigIntArrayPosition(values []int64, value exp.Expression) exp.LiteralExpression {
+	return goqu.L("array_position(?::bigint[], ?)", postgresInt64Array(values), value)
+}

--- a/internal/common/postgres_array.go
+++ b/internal/common/postgres_array.go
@@ -71,19 +71,22 @@ func (values postgresTextArray) Value() (driver.Value, error) {
 }
 
 // PostgreSQLBigIntArrayContains builds a stable SQL membership expression for
-// a PostgreSQL bigint array parameter.
+// a PostgreSQL bigint array parameter. The enclosing Goqu dataset must use
+// Prepared(true) when rendered so values remain bind parameters.
 func PostgreSQLBigIntArrayContains(column exp.Expression, values []int64) exp.Expression {
 	return goqu.L("? = ANY(?::bigint[])", column, postgresInt64Array(values))
 }
 
 // PostgreSQLTextArrayContains builds a stable SQL membership expression for
-// a PostgreSQL text array parameter.
+// a PostgreSQL text array parameter. The enclosing Goqu dataset must use
+// Prepared(true) when rendered so values remain bind parameters.
 func PostgreSQLTextArrayContains(column exp.Expression, values []string) exp.Expression {
 	return goqu.L("? = ANY(?::text[])", column, postgresTextArray(values))
 }
 
 // PostgreSQLBigIntArrayPosition returns the one-based position of value in a
-// PostgreSQL bigint array parameter.
+// PostgreSQL bigint array parameter. The enclosing Goqu dataset must use
+// Prepared(true) when rendered so values remain bind parameters.
 func PostgreSQLBigIntArrayPosition(values []int64, value exp.Expression) exp.LiteralExpression {
 	return goqu.L("array_position(?::bigint[], ?)", postgresInt64Array(values), value)
 }

--- a/internal/common/postgres_array.go
+++ b/internal/common/postgres_array.go
@@ -35,6 +35,8 @@ import (
 
 type postgresInt64Array []int64
 
+type postgresTextArray []string
+
 func (values postgresInt64Array) Value() (driver.Value, error) {
 	array := make([]byte, 0, 2+len(values)*4)
 	array = append(array, '{')
@@ -48,10 +50,36 @@ func (values postgresInt64Array) Value() (driver.Value, error) {
 	return string(array), nil
 }
 
+func (values postgresTextArray) Value() (driver.Value, error) {
+	array := make([]byte, 0, 2+len(values)*8)
+	array = append(array, '{')
+	for index, value := range values {
+		if index > 0 {
+			array = append(array, ',')
+		}
+		array = append(array, '"')
+		for _, character := range []byte(value) {
+			if character == '\\' || character == '"' {
+				array = append(array, '\\')
+			}
+			array = append(array, character)
+		}
+		array = append(array, '"')
+	}
+	array = append(array, '}')
+	return string(array), nil
+}
+
 // PostgreSQLBigIntArrayContains builds a stable SQL membership expression for
 // a PostgreSQL bigint array parameter.
 func PostgreSQLBigIntArrayContains(column exp.Expression, values []int64) exp.Expression {
 	return goqu.L("? = ANY(?::bigint[])", column, postgresInt64Array(values))
+}
+
+// PostgreSQLTextArrayContains builds a stable SQL membership expression for
+// a PostgreSQL text array parameter.
+func PostgreSQLTextArrayContains(column exp.Expression, values []string) exp.Expression {
+	return goqu.L("? = ANY(?::text[])", column, postgresTextArray(values))
 }
 
 // PostgreSQLBigIntArrayPosition returns the one-based position of value in a

--- a/internal/common/postgres_array_test.go
+++ b/internal/common/postgres_array_test.go
@@ -55,3 +55,27 @@ func TestPostgreSQLBigIntArrayExpressionsReuseSQLShape(t *testing.T) {
 	require.Contains(t, oneValueQuery, "ANY($")
 	require.Contains(t, oneValueQuery, "array_position($")
 }
+
+func TestPostgreSQLTextArrayContainsReusesSQLShape(t *testing.T) {
+	t.Parallel()
+
+	build := func(values []string) (string, []any) {
+		query, args, err := goqu.Dialect("postgres").
+			From("resource").
+			Select(goqu.I("id")).
+			Where(PostgreSQLTextArrayContains(goqu.I("value"), values)).
+			Prepared(true).
+			ToSQL()
+		require.NoError(t, err)
+		return query, args
+	}
+
+	oneValueQuery, oneValueArgs := build([]string{"one"})
+	manyValuesQuery, manyValuesArgs := build([]string{"one", `two"quoted`, `three\escaped`})
+
+	require.Equal(t, oneValueQuery, manyValuesQuery)
+	require.Equal(t, `SELECT "id" FROM "resource" WHERE "value" = ANY($1::text[])`, oneValueQuery)
+	require.Len(t, oneValueArgs, 1)
+	require.Len(t, manyValuesArgs, 1)
+	require.Equal(t, `{"one","two\"quoted","three\\escaped"}`, manyValuesArgs[0])
+}

--- a/internal/common/postgres_array_test.go
+++ b/internal/common/postgres_array_test.go
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgreSQLBigIntArrayExpressionsReuseSQLShape(t *testing.T) {
+	t.Parallel()
+
+	build := func(values []int64) (string, []any) {
+		query, args, err := goqu.Dialect("postgres").
+			From("resource").
+			Select(goqu.I("id"), PostgreSQLBigIntArrayPosition(values, goqu.I("id"))).
+			Where(PostgreSQLBigIntArrayContains(goqu.I("id"), values)).
+			Prepared(true).
+			ToSQL()
+		require.NoError(t, err)
+		return query, args
+	}
+
+	oneValueQuery, oneValueArgs := build([]int64{1})
+	manyValuesQuery, manyValuesArgs := build([]int64{1, 2, 3})
+
+	require.Equal(t, oneValueQuery, manyValuesQuery)
+	require.Len(t, oneValueArgs, 2)
+	require.Len(t, manyValuesArgs, 2)
+	require.Contains(t, oneValueQuery, "ANY($")
+	require.Contains(t, oneValueQuery, "array_position($")
+}

--- a/internal/common/postgres_literal.go
+++ b/internal/common/postgres_literal.go
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"strings"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/doug-martin/goqu/v9/exp"
+)
+
+// PostgreSQLTextLiteral builds an explicitly typed PostgreSQL text literal.
+// The value is escaped before it is embedded in the Goqu literal expression.
+func PostgreSQLTextLiteral(value string) exp.LiteralExpression {
+	escapedValue := strings.ReplaceAll(value, "'", "''")
+	return goqu.L("'" + escapedValue + "'::text")
+}

--- a/internal/common/postgres_literal_test.go
+++ b/internal/common/postgres_literal_test.go
@@ -1,0 +1,46 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgreSQLTextLiteralDoesNotCreateBindArgument(t *testing.T) {
+	t.Parallel()
+
+	query, args, err := goqu.Dialect("postgres").
+		Select(PostgreSQLTextLiteral("owner's value")).
+		Prepared(true).
+		ToSQL()
+
+	require.NoError(t, err)
+	require.Equal(t, "SELECT 'owner''s value'::text", query)
+	require.Empty(t, args)
+}

--- a/internal/common/security/filter_helpers.go
+++ b/internal/common/security/filter_helpers.go
@@ -385,9 +385,9 @@ func buildFragmentMaskFlagProjection(
 		return nil, err
 	}
 	if !hasMask {
-		return goqu.V(true).As(alias), nil
+		return goqu.L("TRUE").As(alias), nil
 	}
-	return goqu.Case().When(maskCondition, true).Else(false).As(alias), nil
+	return goqu.Case().When(maskCondition, goqu.L("TRUE")).Else(goqu.L("FALSE")).As(alias), nil
 }
 
 func buildFragmentMaskCondition(

--- a/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
+++ b/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
@@ -255,10 +255,12 @@ func (b *ConceptDescriptionBackend) deleteConceptDescriptionInTx(ctx context.Con
 }
 
 func conceptDescriptionExistsInTx(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
-	query, args, err := goqu.From("concept_description").
-		Select(goqu.V(1)).
+	dialect := goqu.Dialect("postgres")
+	query, args, err := dialect.From("concept_description").
+		Select(goqu.L("1")).
 		Where(goqu.Ex{"id": id}).
 		Limit(1).
+		Prepared(true).
 		ToSQL()
 	if err != nil {
 		return false, common.NewInternalServerError("CDREPO-CDEXIST-BUILDSQL " + err.Error())
@@ -298,7 +300,8 @@ func (b *ConceptDescriptionBackend) checkConceptDescriptionVisibilityInTx(ctx co
 		return false, false, common.NewInternalServerError("CDREPO-ABACCHKCD-BADCOLLECTOR " + collectorErr.Error())
 	}
 
-	query := goqu.From("concept_description").
+	dialect := goqu.Dialect("postgres")
+	query := dialect.From("concept_description").
 		Select(goqu.C("id")).
 		Where(goqu.C("id").Eq(id)).
 		Limit(1)
@@ -308,7 +311,7 @@ func (b *ConceptDescriptionBackend) checkConceptDescriptionVisibilityInTx(ctx co
 		return false, false, common.NewInternalServerError("CDREPO-ABACCHKCD-ADDFORMULA " + addFormulaErr.Error())
 	}
 
-	sqlQuery, args, toSQLErr := query.ToSQL()
+	sqlQuery, args, toSQLErr := query.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return false, false, common.NewInternalServerError("CDREPO-ABACCHKCD-BUILDSQL " + toSQLErr.Error())
 	}
@@ -417,7 +420,8 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptions(ctx context.Context, 
 		return nil, "", common.NewInternalServerError("CDREPO-GCDS-BUILDMASKS " + selectErr.Error())
 	}
 
-	query := goqu.From("concept_description").
+	dialect := goqu.Dialect("postgres")
+	query := dialect.From("concept_description").
 		Select(selectExpressions...).
 		Order(goqu.I("id").Asc()).
 		Limit(peekLimit)
@@ -457,9 +461,9 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptions(ctx context.Context, 
 
 	if cursor != nil && strings.TrimSpace(*cursor) != "" {
 		trimmedCursor := strings.TrimSpace(*cursor)
-		cursorExists := goqu.
+		cursorExists := dialect.
 			From(goqu.T("concept_description").As("cursor_cd")).
-			Select(goqu.V(1)).
+			Select(goqu.L("1")).
 			Where(goqu.I("cursor_cd.id").Eq(trimmedCursor))
 		query = query.
 			Where(goqu.Func("EXISTS", cursorExists)).
@@ -478,7 +482,7 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptions(ctx context.Context, 
 		}
 	}
 
-	sqlQuery, args, err := query.ToSQL()
+	sqlQuery, args, err := query.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, "", fmt.Errorf("CDREPO-GCDS-BUILDSQL failed to build SQL query: %w", err)
 	}
@@ -542,7 +546,8 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptionByID(ctx context.Contex
 		return nil, common.NewInternalServerError("CDREPO-GCDBYID-BUILDMASKS " + selectErr.Error())
 	}
 
-	query := goqu.From("concept_description").
+	dialect := goqu.Dialect("postgres")
+	query := dialect.From("concept_description").
 		Select(selectExpressions...).
 		Where(goqu.C("id").Eq(id)).
 		Limit(1)
@@ -559,7 +564,7 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptionByID(ctx context.Contex
 		}
 	}
 
-	sqlQuery, args, err := query.ToSQL()
+	sqlQuery, args, err := query.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, common.NewInternalServerError("CDREPO-GCDBYID-BUILDSQL " + err.Error())
 	}

--- a/internal/conceptdescriptionrepository/persistence/concept_description_create_visibility_test.go
+++ b/internal/conceptdescriptionrepository/persistence/concept_description_create_visibility_test.go
@@ -119,6 +119,7 @@ func TestConceptDescriptionRepositoryCreateExistingUnauthorizedConceptDescriptio
 	mock.ExpectQuery(`SELECT 1 FROM "concept_description"`).
 		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
 	mock.ExpectQuery(`SELECT "id" FROM "concept_description".*\$2`).
+		WithArgs(conceptDescription.ID(), false, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectRollback()
 

--- a/internal/conceptdescriptionrepository/persistence/concept_description_create_visibility_test.go
+++ b/internal/conceptdescriptionrepository/persistence/concept_description_create_visibility_test.go
@@ -64,8 +64,8 @@ func TestGetConceptDescriptionsValidatesCursorInPageQuery(t *testing.T) {
 	matcher := sqlmock.QueryMatcherFunc(func(_ string, actualSQL string) error {
 		for _, expected := range []string{
 			`SELECT 1 FROM "concept_description" AS "cursor_cd"`,
-			`"cursor_cd"."id" = 'urn:cd:cursor'`,
-			`"id" >= 'urn:cd:cursor'`,
+			`"cursor_cd"."id" = $1`,
+			`"id" >= $2`,
 		} {
 			if !strings.Contains(actualSQL, expected) {
 				return fmt.Errorf("expected SQL to contain %q, got: %s", expected, actualSQL)
@@ -81,6 +81,7 @@ func TestGetConceptDescriptionsValidatesCursorInPageQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	mock.ExpectQuery("cursor query").
+		WithArgs("urn:cd:cursor", "urn:cd:cursor", sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "id_short", "data"}))
 
 	cursor := "urn:cd:cursor"
@@ -117,7 +118,7 @@ func TestConceptDescriptionRepositoryCreateExistingUnauthorizedConceptDescriptio
 		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
 	mock.ExpectQuery(`SELECT 1 FROM "concept_description"`).
 		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
-	mock.ExpectQuery(`SELECT "id" FROM "concept_description".*FALSE`).
+	mock.ExpectQuery(`SELECT "id" FROM "concept_description".*\$2`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectRollback()
 

--- a/internal/digitaltwinregistry/scalability_tests/README.md
+++ b/internal/digitaltwinregistry/scalability_tests/README.md
@@ -1,6 +1,6 @@
 # DTR scalability tests
 
-This suite starts a local Keycloak and local Keycloak PostgreSQL database, runs the BaSyx configuration service from `eclipsebasyx/basyxconfigurationservice-go:SNAPSHOT`, and builds the DTR from the current repository code. The configuration service and DTR both use the external PostgreSQL database configured in `.env`.
+This suite starts a local Keycloak and local Keycloak PostgreSQL database and builds both the BaSyx configuration service and DTR from the current repository code. The configuration service and DTR both use the external PostgreSQL database configured in `.env`, so the schema and service binaries always come from the same revision.
 
 The default workload is read-only after configuration-service schema initialization. It obtains specific asset-link values through `GET /lookup/shells/{aasIdentifier}` and the global asset ID through `GET /shell-descriptors/{aasIdentifier}`; neither is hard-coded.
 
@@ -144,4 +144,4 @@ All descriptors use IDs beginning with `urn:basyx:dtr-scalability:async-bulk:`. 
 - `GET /bulk/status/{handleId}`
 - `GET /bulk/result/{handleId}`
 
-The local Keycloak database is destroyed when the test ends. The external database is never dropped or reset; use a database account that is permitted to run the BaSyx schema configuration service and, when enabled, the async bulk mutations.
+The local Keycloak database is destroyed when the test ends. The external database is never dropped or reset, but the configuration service can apply schema migrations. Use a dedicated scalability database with an appropriate backup and an account that is permitted to run the BaSyx schema configuration service and, when enabled, the async bulk mutations.

--- a/internal/digitaltwinregistry/scalability_tests/docker_compose/docker_compose.yml
+++ b/internal/digitaltwinregistry/scalability_tests/docker_compose/docker_compose.yml
@@ -58,8 +58,9 @@ services:
       - keycloak
 
   basyx-configuration:
-    image: eclipsebasyx/basyxconfigurationservice-go:SNAPSHOT
-    pull_policy: always
+    build:
+      context: ../../../..
+      dockerfile: ./cmd/basyxconfigurationservice/Dockerfile
     environment: *postgres-environment
     extra_hosts:
       - host.docker.internal:host-gateway

--- a/internal/discoveryservice/persistence/PostgreSQLDiscoveryDatabase.go
+++ b/internal/discoveryservice/persistence/PostgreSQLDiscoveryDatabase.go
@@ -271,7 +271,7 @@ func (p *PostgreSQLDiscoveryDatabase) SearchAASIDsByAssetLinks(
 	if cursor != "" {
 		cursorExists := d.
 			From(goqu.T("aas_identifier").As("cursor_ai")).
-			Select(goqu.V(1)).
+			Select(goqu.L("1")).
 			Where(goqu.I("cursor_ai.aasid").Eq(cursor))
 		ds = ds.
 			Where(goqu.Func("EXISTS", cursorExists)).
@@ -288,7 +288,7 @@ func (p *PostgreSQLDiscoveryDatabase) SearchAASIDsByAssetLinks(
 			}
 
 			existsSub := d.From(sai).
-				Select(goqu.V(1)).
+				Select(goqu.L("1")).
 				Where(goqu.And(
 					goqu.I("sai.aasref").Eq(ai.Col(common.ColID)),
 					goqu.I("sai.name").Eq(link.Name),
@@ -314,7 +314,7 @@ func (p *PostgreSQLDiscoveryDatabase) SearchAASIDsByAssetLinks(
 		return nil, "", common.NewInternalServerError("Failed to build query filters. See server logs for details.")
 	}
 
-	sqlStr, args, err := ds.ToSQL()
+	sqlStr, args, err := ds.Prepared(true).ToSQL()
 	debugEnabled := common.DebugEnabled(ctx)
 	if debugEnabled {
 		slog.DebugContext(ctx, "discovery database query prepared")

--- a/internal/discoveryservice/persistence/postgresql_discovery_database_test.go
+++ b/internal/discoveryservice/persistence/postgresql_discovery_database_test.go
@@ -95,8 +95,8 @@ func TestSearchAASIDsByAssetLinks_ValidatesCursorInPageQuery(t *testing.T) {
 	matcher := sqlmock.QueryMatcherFunc(func(_ string, actualSQL string) error {
 		for _, expected := range []string{
 			`SELECT 1 FROM "aas_identifier" AS "cursor_ai"`,
-			`"cursor_ai"."aasid" = 'urn:aas:cursor'`,
-			`"aas_identifier"."aasid" >= 'urn:aas:cursor'`,
+			`"cursor_ai"."aasid" = $1`,
+			`"aas_identifier"."aasid" >= $2`,
 		} {
 			if !strings.Contains(actualSQL, expected) {
 				return fmt.Errorf("expected SQL to contain %q, got: %s", expected, actualSQL)
@@ -116,6 +116,7 @@ func TestSearchAASIDsByAssetLinks_ValidatesCursorInPageQuery(t *testing.T) {
 	}
 
 	mock.ExpectQuery("cursor query").
+		WithArgs("urn:aas:cursor", "urn:aas:cursor", 11).
 		WillReturnRows(sqlmock.NewRows([]string{"aasid"}))
 
 	ids, nextCursor, err := backend.SearchAASIDsByAssetLinks(

--- a/internal/submodelrepository/persistence/queries/submodel_database_queries.go
+++ b/internal/submodelrepository/persistence/queries/submodel_database_queries.go
@@ -464,8 +464,8 @@ func buildSubmodelSemanticIDSelectExpression(dialect *goqu.DialectWrapper) exp.A
 					"jsonb_agg",
 					goqu.Func(
 						"jsonb_build_object",
-						goqu.L("?::text", "type"), goqu.I("ordered_key_values.type"),
-						goqu.L("?::text", "value"), goqu.I("ordered_key_values.value"),
+						common.PostgreSQLTextLiteral("type"), goqu.I("ordered_key_values.type"),
+						common.PostgreSQLTextLiteral("value"), goqu.I("ordered_key_values.value"),
 					),
 				),
 				goqu.L("'[]'::jsonb"),
@@ -477,8 +477,8 @@ func buildSubmodelSemanticIDSelectExpression(dialect *goqu.DialectWrapper) exp.A
 		Select(
 			goqu.Func(
 				"jsonb_build_object",
-				goqu.L("?::text", "type"), referenceTypeSelectExpression,
-				goqu.L("?::text", "keys"), aggregatedKeyValuesSelectDS,
+				common.PostgreSQLTextLiteral("type"), referenceTypeSelectExpression,
+				common.PostgreSQLTextLiteral("keys"), aggregatedKeyValuesSelectDS,
 			),
 		).
 		Where(goqu.I("ssr.id").Eq(goqu.I("submodel.id"))).

--- a/internal/submodelrepository/persistence/queries/submodel_database_queries.go
+++ b/internal/submodelrepository/persistence/queries/submodel_database_queries.go
@@ -464,8 +464,8 @@ func buildSubmodelSemanticIDSelectExpression(dialect *goqu.DialectWrapper) exp.A
 					"jsonb_agg",
 					goqu.Func(
 						"jsonb_build_object",
-						goqu.V("type"), goqu.I("ordered_key_values.type"),
-						goqu.V("value"), goqu.I("ordered_key_values.value"),
+						goqu.L("?::text", "type"), goqu.I("ordered_key_values.type"),
+						goqu.L("?::text", "value"), goqu.I("ordered_key_values.value"),
 					),
 				),
 				goqu.L("'[]'::jsonb"),
@@ -477,8 +477,8 @@ func buildSubmodelSemanticIDSelectExpression(dialect *goqu.DialectWrapper) exp.A
 		Select(
 			goqu.Func(
 				"jsonb_build_object",
-				goqu.V("type"), referenceTypeSelectExpression,
-				goqu.V("keys"), aggregatedKeyValuesSelectDS,
+				goqu.L("?::text", "type"), referenceTypeSelectExpression,
+				goqu.L("?::text", "keys"), aggregatedKeyValuesSelectDS,
 			),
 		).
 		Where(goqu.I("ssr.id").Eq(goqu.I("submodel.id"))).

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
@@ -62,17 +62,16 @@ type DBQueryer interface {
 type postgresInt64Array []int64
 
 func (values postgresInt64Array) Value() (driver.Value, error) {
-	var array strings.Builder
-	array.Grow(2 + len(values)*4)
-	array.WriteByte('{')
+	array := make([]byte, 0, 2+len(values)*4)
+	array = append(array, '{')
 	for index, value := range values {
 		if index > 0 {
-			array.WriteByte(',')
+			array = append(array, ',')
 		}
-		array.WriteString(strconv.FormatInt(value, 10))
+		array = strconv.AppendInt(array, value, 10)
 	}
-	array.WriteByte('}')
-	return array.String(), nil
+	array = append(array, '}')
+	return string(array), nil
 }
 
 func postgresInt64ArrayContains(column exp.Expression, values []int64) exp.Expression {

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
@@ -28,6 +28,7 @@ package submodelelements
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"regexp"
@@ -56,6 +57,30 @@ type DBQueryer interface {
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRow(query string, args ...any) *sql.Row
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+type postgresInt64Array []int64
+
+func (values postgresInt64Array) Value() (driver.Value, error) {
+	var array strings.Builder
+	array.Grow(2 + len(values)*4)
+	array.WriteByte('{')
+	for index, value := range values {
+		if index > 0 {
+			array.WriteByte(',')
+		}
+		array.WriteString(strconv.FormatInt(value, 10))
+	}
+	array.WriteByte('}')
+	return array.String(), nil
+}
+
+func postgresInt64ArrayContains(column exp.Expression, values []int64) exp.Expression {
+	return goqu.L("? = ANY(?::bigint[])", column, postgresInt64Array(values))
+}
+
+func postgresInt64ArrayPosition(values []int64, value exp.Expression) exp.LiteralExpression {
+	return goqu.L("array_position(?::bigint[], ?)", postgresInt64Array(values), value)
 }
 
 // GetSubmodelElementByIDShortOrPath loads a submodel element by path and applies optional ABAC formula filters from ctx.
@@ -714,7 +739,7 @@ func getRootElementPage(ctx context.Context, db DBQueryer, submodelDatabaseID in
 		query = query.Limit(uint(*limit + 1))
 	}
 
-	sqlQuery, args, toSQLErr := query.ToSQL()
+	sqlQuery, args, toSQLErr := query.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return nil, "", common.NewInternalServerError("SMREPO-GETROOTPATHS-BUILDQ " + toSQLErr.Error())
 	}
@@ -1118,7 +1143,7 @@ func addSMEPathAncestorVisibilityQuery(
 	ancestors := targetQuery.UnionAll(ancestorQuery)
 	visibleRoot := dialect.
 		From(goqu.T(ancestorCTE)).
-		Select(goqu.V(1)).
+		Select(goqu.L("1")).
 		Where(goqu.I(ancestorCTE + ".parent_sme_id").IsNull())
 	return query.
 		WithRecursive(ancestorCTE+"(id,parent_sme_id)", ancestors).
@@ -1133,7 +1158,7 @@ func buildSMEPathAuthorizationQuery(
 	dialect := goqu.Dialect("postgres")
 	query := dialect.
 		From(goqu.T("submodel_element").As("sme")).
-		Select(goqu.V(1)).
+		Select(goqu.L("1")).
 		Where(
 			goqu.I("sme.submodel_id").Eq(submodelDatabaseID),
 			goqu.I("sme.idshort_path").Eq(targetPath),
@@ -1193,7 +1218,7 @@ func sortedFragments(items map[grammar.FragmentStringPattern]struct{}) []grammar
 
 func buildSharedMaskVisibilityExpr(dataAlias string, runtime *auth.SharedFragmentMaskRuntime, fragments []grammar.FragmentStringPattern) (exp.Expression, error) {
 	if len(fragments) == 0 {
-		return goqu.V(true), nil
+		return goqu.L("TRUE"), nil
 	}
 
 	seenAliases := make(map[string]struct{}, len(fragments))
@@ -1211,7 +1236,7 @@ func buildSharedMaskVisibilityExpr(dataAlias string, runtime *auth.SharedFragmen
 	}
 
 	if len(conditions) == 0 {
-		return goqu.V(true), nil
+		return goqu.L("TRUE"), nil
 	}
 	if len(conditions) == 1 {
 		return conditions[0], nil
@@ -1337,12 +1362,12 @@ func readSubmodelElementRowsByPath(ctx context.Context, db DBQueryer, submodelDa
 			goqu.I(dataAlias+".raw_supplemental_semantic_ids_referred_payload"),
 			goqu.I(dataAlias+".raw_qualifiers_payload"),
 			goqu.Case().When(semanticVisibleExpr, goqu.I(dataAlias+".raw_semantic_payload")).Else(nil),
-			goqu.Case().When(semanticVisibleExpr, true).Else(false),
-			goqu.Case().When(valueVisibleExpr, true).Else(false),
+			goqu.Case().When(semanticVisibleExpr, goqu.L("TRUE")).Else(goqu.L("FALSE")),
+			goqu.Case().When(valueVisibleExpr, goqu.L("TRUE")).Else(goqu.L("FALSE")),
 		).
 		Order(goqu.I(dataAlias+".c_idshort_path").Asc(), goqu.I(dataAlias+".c_position").Asc())
 
-	sqlQuery, args, toSQLErr := query.ToSQL()
+	sqlQuery, args, toSQLErr := query.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMEBYPATH-BUILDQ " + toSQLErr.Error())
 	}
@@ -1378,21 +1403,17 @@ func readSubmodelElementRowsByRootIDs(ctx context.Context, db DBQueryer, submode
 	if valueVisibleErr != nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMES-BATCHREAD-VALUEMASK " + valueVisibleErr.Error())
 	}
-	rootOrderExpr := goqu.Case().
-		Value(goqu.L("COALESCE(sme.root_sme_id, sme.id)"))
-	for index, rootID := range rootIDs {
-		rootOrderExpr = rootOrderExpr.When(rootID, index)
-	}
-	rootOrderExpr = rootOrderExpr.Else(len(rootIDs))
+	rootIDExpression := goqu.L("COALESCE(?, ?)", goqu.I("sme.root_sme_id"), goqu.I("sme.id"))
+	rootOrderExpr := postgresInt64ArrayPosition(rootIDs, rootIDExpression)
 
-	var rootFilter exp.Expression = goqu.I("sme.id").In(rootIDs)
+	rootFilter := postgresInt64ArrayContains(goqu.I("sme.id"), rootIDs)
 	if includeChildren {
-		rootFilter = goqu.COALESCE(goqu.I("sme.root_sme_id"), goqu.I("sme.id")).In(rootIDs)
+		rootFilter = postgresInt64ArrayContains(rootIDExpression, rootIDs)
 	} else if !includeChildren && isGetSubmodelElements {
 		// For GET /submodel-elements with level=core, return root elements and their direct children.
 		rootFilter = goqu.Or(
-			goqu.I("sme.id").In(rootIDs),
-			goqu.I("sme.parent_sme_id").In(rootIDs),
+			postgresInt64ArrayContains(goqu.I("sme.id"), rootIDs),
+			postgresInt64ArrayContains(goqu.I("sme.parent_sme_id"), rootIDs),
 		)
 	}
 
@@ -1459,8 +1480,8 @@ func readSubmodelElementRowsByRootIDs(ctx context.Context, db DBQueryer, submode
 			goqu.I(dataAlias+".raw_supplemental_semantic_ids_referred_payload"),
 			goqu.I(dataAlias+".raw_qualifiers_payload"),
 			goqu.Case().When(semanticVisibleExpr, goqu.I(dataAlias+".raw_semantic_payload")).Else(nil),
-			goqu.Case().When(semanticVisibleExpr, true).Else(false),
-			goqu.Case().When(valueVisibleExpr, true).Else(false),
+			goqu.Case().When(semanticVisibleExpr, goqu.L("TRUE")).Else(goqu.L("FALSE")),
+			goqu.Case().When(valueVisibleExpr, goqu.L("TRUE")).Else(goqu.L("FALSE")),
 		).
 		Order(
 			goqu.I(dataAlias+".sort_root_order").Asc(),
@@ -1469,7 +1490,7 @@ func readSubmodelElementRowsByRootIDs(ctx context.Context, db DBQueryer, submode
 			goqu.I(dataAlias+".sort_id").Asc(),
 		)
 
-	sqlQuery, args, toSQLErr := query.ToSQL()
+	sqlQuery, args, toSQLErr := query.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMES-BATCHREAD-BUILDQ " + toSQLErr.Error())
 	}
@@ -1910,7 +1931,8 @@ func getReferencesFromKeyTables(db DBQueryer, referenceTable string, referenceKe
 	typeQuery, typeArgs, typeToSQLErr := dialect.
 		From(goqu.T(referenceTable)).
 		Select(goqu.I("id"), goqu.I("type")).
-		Where(goqu.I("id").In(referenceIDs)).
+		Where(postgresInt64ArrayContains(goqu.I("id"), referenceIDs)).
+		Prepared(true).
 		ToSQL()
 	if typeToSQLErr != nil {
 		return nil, common.NewInternalServerError(errorCodePrefix + "-READTYPES-BUILDQ " + typeToSQLErr.Error())
@@ -1943,8 +1965,9 @@ func getReferencesFromKeyTables(db DBQueryer, referenceTable string, referenceKe
 	keysQuery, keyArgs, keysToSQLErr := dialect.
 		From(goqu.T(referenceKeyTable)).
 		Select(goqu.I("reference_id"), goqu.I("type"), goqu.I("value")).
-		Where(goqu.I("reference_id").In(referenceIDs)).
+		Where(postgresInt64ArrayContains(goqu.I("reference_id"), referenceIDs)).
 		Order(goqu.I("reference_id").Asc(), goqu.I("position").Asc()).
+		Prepared(true).
 		ToSQL()
 	if keysToSQLErr != nil {
 		return nil, common.NewInternalServerError(errorCodePrefix + "-READKEYS-BUILDQ " + keysToSQLErr.Error())

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
@@ -28,7 +28,6 @@ package submodelelements
 import (
 	"context"
 	"database/sql"
-	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"regexp"
@@ -57,29 +56,6 @@ type DBQueryer interface {
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRow(query string, args ...any) *sql.Row
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
-}
-
-type postgresInt64Array []int64
-
-func (values postgresInt64Array) Value() (driver.Value, error) {
-	array := make([]byte, 0, 2+len(values)*4)
-	array = append(array, '{')
-	for index, value := range values {
-		if index > 0 {
-			array = append(array, ',')
-		}
-		array = strconv.AppendInt(array, value, 10)
-	}
-	array = append(array, '}')
-	return string(array), nil
-}
-
-func postgresInt64ArrayContains(column exp.Expression, values []int64) exp.Expression {
-	return goqu.L("? = ANY(?::bigint[])", column, postgresInt64Array(values))
-}
-
-func postgresInt64ArrayPosition(values []int64, value exp.Expression) exp.LiteralExpression {
-	return goqu.L("array_position(?::bigint[], ?)", postgresInt64Array(values), value)
 }
 
 // GetSubmodelElementByIDShortOrPath loads a submodel element by path and applies optional ABAC formula filters from ctx.
@@ -200,7 +176,7 @@ func GetSubmodelElementPathsBySubmodelID(ctx context.Context, db DBQueryer, subm
 
 	query = query.Order(goqu.I("sme.idshort_path").Asc(), goqu.I("sme.id").Asc())
 
-	sqlQuery, args, toSQLErr := query.ToSQL()
+	sqlQuery, args, toSQLErr := query.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMEPATHS-BUILDQ " + toSQLErr.Error())
 	}
@@ -301,7 +277,7 @@ func GetSubmodelElementPathsPageBySubmodelID(ctx context.Context, db DBQueryer, 
 		//nolint:gosec // pageLimit is validated to be >= 0
 		Limit(uint(pageLimit) + 1)
 
-	sqlQuery, args, toSQLErr := query.ToSQL()
+	sqlQuery, args, toSQLErr := query.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return nil, "", common.NewInternalServerError("SMREPO-GETSMEPATHSPAGE-BUILDQ " + toSQLErr.Error())
 	}
@@ -564,18 +540,7 @@ func GetSubmodelElementReferencesBySubmodelID(ctx context.Context, db DBQueryer,
 		rootIDs = append(rootIDs, rootElement.id)
 	}
 
-	dialect := goqu.Dialect("postgres")
-	modelTypesQuery, modelTypesArgs, modelTypesSQLErr := dialect.
-		From(goqu.T("submodel_element").As("sme")).
-		Select(
-			goqu.I("sme.id"),
-			goqu.I("sme.model_type"),
-		).
-		Where(
-			goqu.I("sme.submodel_id").Eq(submodelDatabaseID),
-			goqu.I("sme.id").In(rootIDs),
-		).
-		ToSQL()
+	modelTypesQuery, modelTypesArgs, modelTypesSQLErr := buildSubmodelElementModelTypesQuery(submodelDatabaseID, rootIDs)
 	if modelTypesSQLErr != nil {
 		return nil, "", common.NewInternalServerError("SMREPO-GETSMEREFS-BUILDMODELTYPESQ " + modelTypesSQLErr.Error())
 	}
@@ -616,6 +581,21 @@ func GetSubmodelElementReferencesBySubmodelID(ctx context.Context, db DBQueryer,
 	}
 
 	return references, nextCursor, nil
+}
+
+func buildSubmodelElementModelTypesQuery(submodelDatabaseID int, rootIDs []int64) (string, []any, error) {
+	return goqu.Dialect("postgres").
+		From(goqu.T("submodel_element").As("sme")).
+		Select(
+			goqu.I("sme.id"),
+			goqu.I("sme.model_type"),
+		).
+		Where(
+			goqu.I("sme.submodel_id").Eq(submodelDatabaseID),
+			common.PostgreSQLBigIntArrayContains(goqu.I("sme.id"), rootIDs),
+		).
+		Prepared(true).
+		ToSQL()
 }
 
 func buildSubmodelElementReference(submodelID string, modelType types.ModelType, idShortPath string) (types.IReference, error) {
@@ -826,7 +806,7 @@ func submodelElementCursorExists(ctx context.Context, db DBQueryer, query *goqu.
 	if hasCursorID {
 		cursorQuery = cursorQuery.Where(goqu.I("sme.id").Eq(cursorID))
 	}
-	sqlQuery, args, buildErr := cursorQuery.Limit(1).ToSQL()
+	sqlQuery, args, buildErr := cursorQuery.Limit(1).Prepared(true).ToSQL()
 	if buildErr != nil {
 		return false, common.NewInternalServerError("SMREPO-CHECKSMECURSOR-BUILDQ " + buildErr.Error())
 	}
@@ -1403,16 +1383,16 @@ func readSubmodelElementRowsByRootIDs(ctx context.Context, db DBQueryer, submode
 		return nil, common.NewInternalServerError("SMREPO-GETSMES-BATCHREAD-VALUEMASK " + valueVisibleErr.Error())
 	}
 	rootIDExpression := goqu.L("COALESCE(?, ?)", goqu.I("sme.root_sme_id"), goqu.I("sme.id"))
-	rootOrderExpr := postgresInt64ArrayPosition(rootIDs, rootIDExpression)
+	rootOrderExpr := common.PostgreSQLBigIntArrayPosition(rootIDs, rootIDExpression)
 
-	rootFilter := postgresInt64ArrayContains(goqu.I("sme.id"), rootIDs)
+	rootFilter := common.PostgreSQLBigIntArrayContains(goqu.I("sme.id"), rootIDs)
 	if includeChildren {
-		rootFilter = postgresInt64ArrayContains(rootIDExpression, rootIDs)
+		rootFilter = common.PostgreSQLBigIntArrayContains(rootIDExpression, rootIDs)
 	} else if !includeChildren && isGetSubmodelElements {
 		// For GET /submodel-elements with level=core, return root elements and their direct children.
 		rootFilter = goqu.Or(
-			postgresInt64ArrayContains(goqu.I("sme.id"), rootIDs),
-			postgresInt64ArrayContains(goqu.I("sme.parent_sme_id"), rootIDs),
+			common.PostgreSQLBigIntArrayContains(goqu.I("sme.id"), rootIDs),
+			common.PostgreSQLBigIntArrayContains(goqu.I("sme.parent_sme_id"), rootIDs),
 		)
 	}
 
@@ -1930,7 +1910,7 @@ func getReferencesFromKeyTables(db DBQueryer, referenceTable string, referenceKe
 	typeQuery, typeArgs, typeToSQLErr := dialect.
 		From(goqu.T(referenceTable)).
 		Select(goqu.I("id"), goqu.I("type")).
-		Where(postgresInt64ArrayContains(goqu.I("id"), referenceIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(goqu.I("id"), referenceIDs)).
 		Prepared(true).
 		ToSQL()
 	if typeToSQLErr != nil {
@@ -1964,7 +1944,7 @@ func getReferencesFromKeyTables(db DBQueryer, referenceTable string, referenceKe
 	keysQuery, keyArgs, keysToSQLErr := dialect.
 		From(goqu.T(referenceKeyTable)).
 		Select(goqu.I("reference_id"), goqu.I("type"), goqu.I("value")).
-		Where(postgresInt64ArrayContains(goqu.I("reference_id"), referenceIDs)).
+		Where(common.PostgreSQLBigIntArrayContains(goqu.I("reference_id"), referenceIDs)).
 		Order(goqu.I("reference_id").Asc(), goqu.I("position").Asc()).
 		Prepared(true).
 		ToSQL()

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read.go
@@ -382,7 +382,7 @@ func GetSubmodelElementPathsByPath(ctx context.Context, db DBQueryer, submodelID
 
 	query = query.Order(goqu.I("sme.idshort_path").Asc(), goqu.I("sme.id").Asc())
 
-	sqlQuery, args, toSQLErr := query.ToSQL()
+	sqlQuery, args, toSQLErr := query.Prepared(true).ToSQL()
 	if toSQLErr != nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMEPATHSBYPATH-BUILDQ " + toSQLErr.Error())
 	}

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
@@ -101,6 +101,17 @@ func TestSubmodelElementPathReadReusesSQLShapeForDifferentPaths(t *testing.T) {
 	require.NotContains(t, secondQuery, "TechnicalData.Sections[12].MaximumRotationSpeed")
 }
 
+func TestSubmodelElementPathListReusesSQLShapeForDifferentPaths(t *testing.T) {
+	t.Parallel()
+
+	firstQuery := captureSubmodelElementPathListQuery(t, "Motor.Nameplate.ManufacturerName")
+	secondQuery := captureSubmodelElementPathListQuery(t, "TechnicalData.Sections[12].MaximumRotationSpeed")
+
+	require.Equal(t, firstQuery, secondQuery)
+	require.NotContains(t, firstQuery, "Motor.Nameplate.ManufacturerName")
+	require.NotContains(t, secondQuery, "TechnicalData.Sections[12].MaximumRotationSpeed")
+}
+
 func TestSubmodelElementBatchReadReusesSQLShapeForDifferentRootCounts(t *testing.T) {
 	t.Parallel()
 
@@ -145,6 +156,32 @@ func captureSubmodelElementPathReadQuery(t *testing.T, idShortPath string) strin
 		require.Empty(t, rows)
 		return err
 	})
+}
+
+func captureSubmodelElementPathListQuery(t *testing.T, idShortPath string) string {
+	t.Helper()
+
+	queries := make([]string, 0, 2)
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherFunc(func(_ string, actualQuery string) error {
+		queries = append(queries, actualQuery)
+		return nil
+	})))
+	require.NoError(t, err)
+
+	mock.ExpectQuery("submodel lookup").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+	mock.ExpectQuery("submodel element path list").
+		WillReturnRows(sqlmock.NewRows([]string{"idshort_path"}).AddRow(idShortPath))
+
+	paths, err := GetSubmodelElementPathsByPath(contextWithABACDisabled(t), db, "urn:example:submodel", idShortPath, "deep")
+	require.NoError(t, err)
+	require.Equal(t, []string{idShortPath}, paths)
+	mock.ExpectClose()
+	require.NoError(t, db.Close())
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.Len(t, queries, 2)
+
+	return queries[1]
 }
 
 func captureSubmodelElementBatchReadQuery(t *testing.T, rootIDs []int64) string {

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
@@ -27,6 +27,7 @@ package submodelelements
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -87,6 +88,68 @@ func TestEscapeSQLLikePatternEscapesWildcardCharacters(t *testing.T) {
 	require.Equal(t, "A!%B", escapeSQLLikePattern("A%B"))
 	require.Equal(t, "A!!B", escapeSQLLikePattern("A!B"))
 	require.Equal(t, "A!!B!_C!%", escapeSQLLikePattern("A!B_C%"))
+}
+
+func TestSubmodelElementPathReadReusesSQLShapeForDifferentPaths(t *testing.T) {
+	t.Parallel()
+
+	firstQuery := captureSubmodelElementPathReadQuery(t, "Motor.Nameplate.ManufacturerName")
+	secondQuery := captureSubmodelElementPathReadQuery(t, "TechnicalData.Sections[12].MaximumRotationSpeed")
+
+	require.Equal(t, firstQuery, secondQuery)
+	require.NotContains(t, firstQuery, "Motor.Nameplate.ManufacturerName")
+	require.NotContains(t, secondQuery, "TechnicalData.Sections[12].MaximumRotationSpeed")
+}
+
+func TestSubmodelElementBatchReadReusesSQLShapeForDifferentRootCounts(t *testing.T) {
+	t.Parallel()
+
+	oneRootQuery := captureSubmodelElementBatchReadQuery(t, []int64{11})
+	manyRootsQuery := captureSubmodelElementBatchReadQuery(t, []int64{11, 22, 33, 44})
+
+	require.Equal(t, oneRootQuery, manyRootsQuery)
+	require.Contains(t, oneRootQuery, "ANY($")
+	require.Contains(t, oneRootQuery, "array_position($")
+}
+
+func captureSubmodelElementPathReadQuery(t *testing.T, idShortPath string) string {
+	t.Helper()
+
+	return captureSubmodelElementReadQuery(t, func(db *sql.DB) error {
+		rows, err := readSubmodelElementRowsByPath(contextWithABACDisabled(t), db, 42, idShortPath, true, true)
+		require.Empty(t, rows)
+		return err
+	})
+}
+
+func captureSubmodelElementBatchReadQuery(t *testing.T, rootIDs []int64) string {
+	t.Helper()
+
+	return captureSubmodelElementReadQuery(t, func(db *sql.DB) error {
+		rows, err := readSubmodelElementRowsByRootIDs(contextWithABACDisabled(t), db, 42, rootIDs, true, true, true)
+		require.Empty(t, rows)
+		return err
+	})
+}
+
+func captureSubmodelElementReadQuery(t *testing.T, read func(db *sql.DB) error) string {
+	t.Helper()
+
+	var capturedQuery string
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherFunc(func(_ string, actualQuery string) error {
+		capturedQuery = actualQuery
+		return nil
+	})))
+	require.NoError(t, err)
+
+	mock.ExpectQuery("capture query").WillReturnRows(sqlmock.NewRows([]string{"unused"}))
+	require.NoError(t, read(db))
+	mock.ExpectClose()
+	require.NoError(t, db.Close())
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.NotEmpty(t, capturedQuery)
+
+	return capturedQuery
 }
 
 func TestAddSMERowFilterQueriesCorrelatesStructuralConditionToCurrentElement(t *testing.T) {

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_read_test.go
@@ -112,6 +112,31 @@ func TestSubmodelElementBatchReadReusesSQLShapeForDifferentRootCounts(t *testing
 	require.Contains(t, oneRootQuery, "array_position($")
 }
 
+func TestSubmodelElementReferenceModelTypesReuseSQLShapeForDifferentRootCounts(t *testing.T) {
+	t.Parallel()
+
+	oneRootQuery, oneRootArgs, err := buildSubmodelElementModelTypesQuery(42, []int64{11})
+	require.NoError(t, err)
+	manyRootsQuery, manyRootsArgs, err := buildSubmodelElementModelTypesQuery(42, []int64{11, 22, 33, 44})
+	require.NoError(t, err)
+
+	require.Equal(t, oneRootQuery, manyRootsQuery)
+	require.Len(t, oneRootArgs, 2)
+	require.Len(t, manyRootsArgs, 2)
+	require.Contains(t, oneRootQuery, "ANY($")
+}
+
+func TestSubmodelElementCursorCheckReusesSQLShapeForDifferentCursors(t *testing.T) {
+	t.Parallel()
+
+	firstQuery := captureSubmodelElementCursorQuery(t, "Motor|11")
+	secondQuery := captureSubmodelElementCursorQuery(t, "TechnicalData|44")
+
+	require.Equal(t, firstQuery, secondQuery)
+	require.NotContains(t, firstQuery, "Motor")
+	require.NotContains(t, secondQuery, "TechnicalData")
+}
+
 func captureSubmodelElementPathReadQuery(t *testing.T, idShortPath string) string {
 	t.Helper()
 
@@ -150,6 +175,18 @@ func captureSubmodelElementReadQuery(t *testing.T, read func(db *sql.DB) error) 
 	require.NotEmpty(t, capturedQuery)
 
 	return capturedQuery
+}
+
+func captureSubmodelElementCursorQuery(t *testing.T, cursor string) string {
+	t.Helper()
+
+	return captureSubmodelElementReadQuery(t, func(db *sql.DB) error {
+		query := goqu.Dialect("postgres").
+			From(goqu.T("submodel_element").As("sme")).
+			Select(goqu.I("sme.id"))
+		_, err := submodelElementCursorExists(contextWithABACDisabled(t), db, query, cursor)
+		return err
+	})
 }
 
 func TestAddSMERowFilterQueriesCorrelatesStructuralConditionToCurrentElement(t *testing.T) {

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression.go
@@ -30,21 +30,18 @@ import (
 	"github.com/FriedJannik/aas-go-sdk/types"
 	"github.com/doug-martin/goqu/v9"
 	"github.com/doug-martin/goqu/v9/exp"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
 
 func temporalColumnAsText(column exp.IdentifierExpression) exp.LiteralExpression {
 	return goqu.L(`trim(both '"' from to_json(?)::text)`, column)
 }
 
-func postgresText(value string) exp.LiteralExpression {
-	return goqu.L("?::text", value)
-}
-
 func operationValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue bool) exp.Expression {
 	var payload exp.Expression = goqu.Func("jsonb_build_object",
-		postgresText("input_variables"), goqu.I("oe.input_variables"),
-		postgresText("output_variables"), goqu.I("oe.output_variables"),
-		postgresText("inoutput_variables"), goqu.I("oe.inoutput_variables"),
+		common.PostgreSQLTextLiteral("input_variables"), goqu.I("oe.input_variables"),
+		common.PostgreSQLTextLiteral("output_variables"), goqu.I("oe.output_variables"),
+		common.PostgreSQLTextLiteral("inoutput_variables"), goqu.I("oe.inoutput_variables"),
 	)
 	if !includeBlobValue {
 		payload = withoutEmbeddedBlobValues(dialect, payload)
@@ -107,13 +104,13 @@ func withoutEmbeddedBlobValues(dialect goqu.DialectWrapper, payload exp.Expressi
 		From("operation_json_nodes").
 		Select(
 			goqu.ROW_NUMBER().Over(goqu.W().OrderBy(goqu.I("operation_json_nodes.path").Asc())),
-			goqu.L("? || ARRAY[?]", goqu.I("operation_json_nodes.path"), goqu.V("value")),
+			goqu.L("? || ARRAY[?]", goqu.I("operation_json_nodes.path"), common.PostgreSQLTextLiteral("value")),
 		).
 		Where(goqu.L(
 			"? ->> ? = ?",
 			goqu.I("operation_json_nodes.node"),
-			goqu.V("modelType"),
-			goqu.V("Blob"),
+			common.PostgreSQLTextLiteral("modelType"),
+			common.PostgreSQLTextLiteral("Blob"),
 		))
 	strippedPayload := dialect.
 		Select(
@@ -145,10 +142,10 @@ func withoutEmbeddedBlobValues(dialect goqu.DialectWrapper, payload exp.Expressi
 
 func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue bool) exp.CaseExpression {
 	blobPayload := []interface{}{
-		postgresText("content_type"), goqu.I("be.content_type"),
+		common.PostgreSQLTextLiteral("content_type"), goqu.I("be.content_type"),
 	}
 	if includeBlobValue {
-		blobPayload = append(blobPayload, postgresText("value"), goqu.I("be.value"))
+		blobPayload = append(blobPayload, common.PostgreSQLTextLiteral("value"), goqu.I("be.value"))
 	}
 
 	return goqu.Case().
@@ -156,8 +153,8 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeAnnotatedRelationshipElement),
 			dialect.From(goqu.T("annotated_relationship_element").As("are")).
 				Select(goqu.Func("jsonb_build_object",
-					postgresText("first"), goqu.I("are.first"),
-					postgresText("second"), goqu.I("are.second"),
+					common.PostgreSQLTextLiteral("first"), goqu.I("are.first"),
+					common.PostgreSQLTextLiteral("second"), goqu.I("are.second"),
 				)).
 				Where(goqu.I("are.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -166,14 +163,14 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeBasicEventElement),
 			dialect.From(goqu.T("basic_event_element").As("bee")).
 				Select(goqu.Func("jsonb_build_object",
-					postgresText("direction"), goqu.I("bee.direction"),
-					postgresText("state"), goqu.I("bee.state"),
-					postgresText("message_topic"), goqu.I("bee.message_topic"),
-					postgresText("last_update"), goqu.I("bee.last_update"),
-					postgresText("min_interval"), goqu.I("bee.min_interval"),
-					postgresText("max_interval"), goqu.I("bee.max_interval"),
-					postgresText("observed"), goqu.I("bee.observed"),
-					postgresText("message_broker"), goqu.I("bee.message_broker"),
+					common.PostgreSQLTextLiteral("direction"), goqu.I("bee.direction"),
+					common.PostgreSQLTextLiteral("state"), goqu.I("bee.state"),
+					common.PostgreSQLTextLiteral("message_topic"), goqu.I("bee.message_topic"),
+					common.PostgreSQLTextLiteral("last_update"), goqu.I("bee.last_update"),
+					common.PostgreSQLTextLiteral("min_interval"), goqu.I("bee.min_interval"),
+					common.PostgreSQLTextLiteral("max_interval"), goqu.I("bee.max_interval"),
+					common.PostgreSQLTextLiteral("observed"), goqu.I("bee.observed"),
+					common.PostgreSQLTextLiteral("message_broker"), goqu.I("bee.message_broker"),
 				)).
 				Where(goqu.I("bee.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -189,9 +186,9 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeEntity),
 			dialect.From(goqu.T("entity_element").As("ee")).
 				Select(goqu.Func("jsonb_build_object",
-					postgresText("entity_type"), goqu.I("ee.entity_type"),
-					postgresText("global_asset_id"), goqu.I("ee.global_asset_id"),
-					postgresText("specific_asset_ids"), goqu.I("ee.specific_asset_ids"),
+					common.PostgreSQLTextLiteral("entity_type"), goqu.I("ee.entity_type"),
+					common.PostgreSQLTextLiteral("global_asset_id"), goqu.I("ee.global_asset_id"),
+					common.PostgreSQLTextLiteral("specific_asset_ids"), goqu.I("ee.specific_asset_ids"),
 				)).
 				Where(goqu.I("ee.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -200,8 +197,8 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeFile),
 			dialect.From(goqu.T("file_element").As("fe")).
 				Select(goqu.Func("jsonb_build_object",
-					postgresText("value"), goqu.I("fe.value"),
-					postgresText("content_type"), goqu.I("fe.content_type"),
+					common.PostgreSQLTextLiteral("value"), goqu.I("fe.value"),
+					common.PostgreSQLTextLiteral("content_type"), goqu.I("fe.content_type"),
 				)).
 				Where(goqu.I("fe.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -210,10 +207,10 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeSubmodelElementList),
 			dialect.From(goqu.T("submodel_element_list").As("sel")).
 				Select(goqu.Func("jsonb_build_object",
-					postgresText("order_relevant"), goqu.I("sel.order_relevant"),
-					postgresText("type_value_list_element"), goqu.I("sel.type_value_list_element"),
-					postgresText("value_type_list_element"), goqu.I("sel.value_type_list_element"),
-					postgresText("semantic_id_list_element"), goqu.I("sel.semantic_id_list_element"),
+					common.PostgreSQLTextLiteral("order_relevant"), goqu.I("sel.order_relevant"),
+					common.PostgreSQLTextLiteral("type_value_list_element"), goqu.I("sel.type_value_list_element"),
+					common.PostgreSQLTextLiteral("value_type_list_element"), goqu.I("sel.value_type_list_element"),
+					common.PostgreSQLTextLiteral("semantic_id_list_element"), goqu.I("sel.semantic_id_list_element"),
 				)).
 				Where(goqu.I("sel.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -221,20 +218,20 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 		When(
 			goqu.I("sme.model_type").Eq(types.ModelTypeMultiLanguageProperty),
 			goqu.Func("jsonb_build_object",
-				postgresText("value_id"), goqu.COALESCE(
+				common.PostgreSQLTextLiteral("value_id"), goqu.COALESCE(
 					dialect.From(goqu.T("multilanguage_property_payload").As("mlpp")).
 						Select(goqu.I("mlpp.value_id_payload")).
 						Where(goqu.I("mlpp.submodel_element_id").Eq(goqu.I("sme.id"))).
 						Limit(1),
 					goqu.L("'[]'::jsonb"),
 				),
-				postgresText("value_id_referred"), goqu.L("'[]'::jsonb"),
-				postgresText("value"),
+				common.PostgreSQLTextLiteral("value_id_referred"), goqu.L("'[]'::jsonb"),
+				common.PostgreSQLTextLiteral("value"),
 				dialect.From(goqu.T("multilanguage_property_value").As("mlpv")).
 					Select(goqu.Func("jsonb_agg", goqu.Func("jsonb_build_object",
-						postgresText("language"), goqu.I("mlpv.language"),
-						postgresText("text"), goqu.I("mlpv.text"),
-						postgresText("id"), goqu.I("mlpv.id"),
+						common.PostgreSQLTextLiteral("language"), goqu.I("mlpv.language"),
+						common.PostgreSQLTextLiteral("text"), goqu.I("mlpv.text"),
+						common.PostgreSQLTextLiteral("id"), goqu.I("mlpv.id"),
 					))).
 					Where(goqu.I("mlpv.submodel_element_id").Eq(goqu.I("sme.id"))),
 			),
@@ -247,7 +244,7 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeProperty),
 			dialect.From(goqu.T("property_element").As("pe")).
 				Select(goqu.Func("jsonb_build_object",
-					postgresText("value"), goqu.COALESCE(
+					common.PostgreSQLTextLiteral("value"), goqu.COALESCE(
 						goqu.I("pe.value_text"),
 						goqu.L("?::text", goqu.I("pe.value_num")),
 						goqu.L("?::text", goqu.I("pe.value_bool")),
@@ -255,15 +252,15 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 						temporalColumnAsText(goqu.I("pe.value_date")),
 						temporalColumnAsText(goqu.I("pe.value_datetime")),
 					),
-					postgresText("value_type"), goqu.I("pe.value_type"),
-					postgresText("value_id"), goqu.COALESCE(
+					common.PostgreSQLTextLiteral("value_type"), goqu.I("pe.value_type"),
+					common.PostgreSQLTextLiteral("value_id"), goqu.COALESCE(
 						dialect.From(goqu.T("property_element_payload").As("pep")).
 							Select(goqu.I("pep.value_id_payload")).
 							Where(goqu.I("pep.property_element_id").Eq(goqu.I("sme.id"))).
 							Limit(1),
 						goqu.L("'[]'::jsonb"),
 					),
-					postgresText("value_id_referred"), goqu.L("'[]'::jsonb"),
+					common.PostgreSQLTextLiteral("value_id_referred"), goqu.L("'[]'::jsonb"),
 				)).
 				Where(goqu.I("pe.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -272,15 +269,15 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeRange),
 			dialect.From(goqu.T("range_element").As("re")).
 				Select(goqu.Func("jsonb_build_object",
-					postgresText("value_type"), goqu.I("re.value_type"),
-					postgresText("min"), goqu.COALESCE(
+					common.PostgreSQLTextLiteral("value_type"), goqu.I("re.value_type"),
+					common.PostgreSQLTextLiteral("min"), goqu.COALESCE(
 						goqu.I("re.min_text"),
 						goqu.L("?::text", goqu.I("re.min_num")),
 						temporalColumnAsText(goqu.I("re.min_time")),
 						temporalColumnAsText(goqu.I("re.min_date")),
 						temporalColumnAsText(goqu.I("re.min_datetime")),
 					),
-					postgresText("max"), goqu.COALESCE(
+					common.PostgreSQLTextLiteral("max"), goqu.COALESCE(
 						goqu.I("re.max_text"),
 						goqu.L("?::text", goqu.I("re.max_num")),
 						temporalColumnAsText(goqu.I("re.max_time")),
@@ -295,7 +292,7 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeReferenceElement),
 			dialect.From(goqu.T("reference_element").As("refe")).
 				Select(goqu.Func("jsonb_build_object",
-					postgresText("value"), goqu.I("refe.value"),
+					common.PostgreSQLTextLiteral("value"), goqu.I("refe.value"),
 				)).
 				Where(goqu.I("refe.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -304,8 +301,8 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeRelationshipElement),
 			dialect.From(goqu.T("relationship_element").As("rle")).
 				Select(goqu.Func("jsonb_build_object",
-					postgresText("first"), goqu.I("rle.first"),
-					postgresText("second"), goqu.I("rle.second"),
+					common.PostgreSQLTextLiteral("first"), goqu.I("rle.first"),
+					common.PostgreSQLTextLiteral("second"), goqu.I("rle.second"),
 				)).
 				Where(goqu.I("rle.id").Eq(goqu.I("sme.id"))).
 				Limit(1),

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression.go
@@ -36,11 +36,15 @@ func temporalColumnAsText(column exp.IdentifierExpression) exp.LiteralExpression
 	return goqu.L(`trim(both '"' from to_json(?)::text)`, column)
 }
 
+func postgresText(value string) exp.LiteralExpression {
+	return goqu.L("?::text", value)
+}
+
 func operationValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue bool) exp.Expression {
 	var payload exp.Expression = goqu.Func("jsonb_build_object",
-		goqu.V("input_variables"), goqu.I("oe.input_variables"),
-		goqu.V("output_variables"), goqu.I("oe.output_variables"),
-		goqu.V("inoutput_variables"), goqu.I("oe.inoutput_variables"),
+		postgresText("input_variables"), goqu.I("oe.input_variables"),
+		postgresText("output_variables"), goqu.I("oe.output_variables"),
+		postgresText("inoutput_variables"), goqu.I("oe.inoutput_variables"),
 	)
 	if !includeBlobValue {
 		payload = withoutEmbeddedBlobValues(dialect, payload)
@@ -141,10 +145,10 @@ func withoutEmbeddedBlobValues(dialect goqu.DialectWrapper, payload exp.Expressi
 
 func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue bool) exp.CaseExpression {
 	blobPayload := []interface{}{
-		goqu.V("content_type"), goqu.I("be.content_type"),
+		postgresText("content_type"), goqu.I("be.content_type"),
 	}
 	if includeBlobValue {
-		blobPayload = append(blobPayload, goqu.V("value"), goqu.I("be.value"))
+		blobPayload = append(blobPayload, postgresText("value"), goqu.I("be.value"))
 	}
 
 	return goqu.Case().
@@ -152,8 +156,8 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeAnnotatedRelationshipElement),
 			dialect.From(goqu.T("annotated_relationship_element").As("are")).
 				Select(goqu.Func("jsonb_build_object",
-					goqu.V("first"), goqu.I("are.first"),
-					goqu.V("second"), goqu.I("are.second"),
+					postgresText("first"), goqu.I("are.first"),
+					postgresText("second"), goqu.I("are.second"),
 				)).
 				Where(goqu.I("are.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -162,14 +166,14 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeBasicEventElement),
 			dialect.From(goqu.T("basic_event_element").As("bee")).
 				Select(goqu.Func("jsonb_build_object",
-					goqu.V("direction"), goqu.I("bee.direction"),
-					goqu.V("state"), goqu.I("bee.state"),
-					goqu.V("message_topic"), goqu.I("bee.message_topic"),
-					goqu.V("last_update"), goqu.I("bee.last_update"),
-					goqu.V("min_interval"), goqu.I("bee.min_interval"),
-					goqu.V("max_interval"), goqu.I("bee.max_interval"),
-					goqu.V("observed"), goqu.I("bee.observed"),
-					goqu.V("message_broker"), goqu.I("bee.message_broker"),
+					postgresText("direction"), goqu.I("bee.direction"),
+					postgresText("state"), goqu.I("bee.state"),
+					postgresText("message_topic"), goqu.I("bee.message_topic"),
+					postgresText("last_update"), goqu.I("bee.last_update"),
+					postgresText("min_interval"), goqu.I("bee.min_interval"),
+					postgresText("max_interval"), goqu.I("bee.max_interval"),
+					postgresText("observed"), goqu.I("bee.observed"),
+					postgresText("message_broker"), goqu.I("bee.message_broker"),
 				)).
 				Where(goqu.I("bee.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -185,9 +189,9 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeEntity),
 			dialect.From(goqu.T("entity_element").As("ee")).
 				Select(goqu.Func("jsonb_build_object",
-					goqu.V("entity_type"), goqu.I("ee.entity_type"),
-					goqu.V("global_asset_id"), goqu.I("ee.global_asset_id"),
-					goqu.V("specific_asset_ids"), goqu.I("ee.specific_asset_ids"),
+					postgresText("entity_type"), goqu.I("ee.entity_type"),
+					postgresText("global_asset_id"), goqu.I("ee.global_asset_id"),
+					postgresText("specific_asset_ids"), goqu.I("ee.specific_asset_ids"),
 				)).
 				Where(goqu.I("ee.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -196,8 +200,8 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeFile),
 			dialect.From(goqu.T("file_element").As("fe")).
 				Select(goqu.Func("jsonb_build_object",
-					goqu.V("value"), goqu.I("fe.value"),
-					goqu.V("content_type"), goqu.I("fe.content_type"),
+					postgresText("value"), goqu.I("fe.value"),
+					postgresText("content_type"), goqu.I("fe.content_type"),
 				)).
 				Where(goqu.I("fe.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -206,10 +210,10 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeSubmodelElementList),
 			dialect.From(goqu.T("submodel_element_list").As("sel")).
 				Select(goqu.Func("jsonb_build_object",
-					goqu.V("order_relevant"), goqu.I("sel.order_relevant"),
-					goqu.V("type_value_list_element"), goqu.I("sel.type_value_list_element"),
-					goqu.V("value_type_list_element"), goqu.I("sel.value_type_list_element"),
-					goqu.V("semantic_id_list_element"), goqu.I("sel.semantic_id_list_element"),
+					postgresText("order_relevant"), goqu.I("sel.order_relevant"),
+					postgresText("type_value_list_element"), goqu.I("sel.type_value_list_element"),
+					postgresText("value_type_list_element"), goqu.I("sel.value_type_list_element"),
+					postgresText("semantic_id_list_element"), goqu.I("sel.semantic_id_list_element"),
 				)).
 				Where(goqu.I("sel.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -217,20 +221,20 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 		When(
 			goqu.I("sme.model_type").Eq(types.ModelTypeMultiLanguageProperty),
 			goqu.Func("jsonb_build_object",
-				goqu.V("value_id"), goqu.COALESCE(
+				postgresText("value_id"), goqu.COALESCE(
 					dialect.From(goqu.T("multilanguage_property_payload").As("mlpp")).
 						Select(goqu.I("mlpp.value_id_payload")).
 						Where(goqu.I("mlpp.submodel_element_id").Eq(goqu.I("sme.id"))).
 						Limit(1),
 					goqu.L("'[]'::jsonb"),
 				),
-				goqu.V("value_id_referred"), goqu.L("'[]'::jsonb"),
-				goqu.V("value"),
+				postgresText("value_id_referred"), goqu.L("'[]'::jsonb"),
+				postgresText("value"),
 				dialect.From(goqu.T("multilanguage_property_value").As("mlpv")).
 					Select(goqu.Func("jsonb_agg", goqu.Func("jsonb_build_object",
-						goqu.V("language"), goqu.I("mlpv.language"),
-						goqu.V("text"), goqu.I("mlpv.text"),
-						goqu.V("id"), goqu.I("mlpv.id"),
+						postgresText("language"), goqu.I("mlpv.language"),
+						postgresText("text"), goqu.I("mlpv.text"),
+						postgresText("id"), goqu.I("mlpv.id"),
 					))).
 					Where(goqu.I("mlpv.submodel_element_id").Eq(goqu.I("sme.id"))),
 			),
@@ -243,7 +247,7 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeProperty),
 			dialect.From(goqu.T("property_element").As("pe")).
 				Select(goqu.Func("jsonb_build_object",
-					goqu.V("value"), goqu.COALESCE(
+					postgresText("value"), goqu.COALESCE(
 						goqu.I("pe.value_text"),
 						goqu.L("?::text", goqu.I("pe.value_num")),
 						goqu.L("?::text", goqu.I("pe.value_bool")),
@@ -251,15 +255,15 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 						temporalColumnAsText(goqu.I("pe.value_date")),
 						temporalColumnAsText(goqu.I("pe.value_datetime")),
 					),
-					goqu.V("value_type"), goqu.I("pe.value_type"),
-					goqu.V("value_id"), goqu.COALESCE(
+					postgresText("value_type"), goqu.I("pe.value_type"),
+					postgresText("value_id"), goqu.COALESCE(
 						dialect.From(goqu.T("property_element_payload").As("pep")).
 							Select(goqu.I("pep.value_id_payload")).
 							Where(goqu.I("pep.property_element_id").Eq(goqu.I("sme.id"))).
 							Limit(1),
 						goqu.L("'[]'::jsonb"),
 					),
-					goqu.V("value_id_referred"), goqu.L("'[]'::jsonb"),
+					postgresText("value_id_referred"), goqu.L("'[]'::jsonb"),
 				)).
 				Where(goqu.I("pe.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -268,15 +272,15 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeRange),
 			dialect.From(goqu.T("range_element").As("re")).
 				Select(goqu.Func("jsonb_build_object",
-					goqu.V("value_type"), goqu.I("re.value_type"),
-					goqu.V("min"), goqu.COALESCE(
+					postgresText("value_type"), goqu.I("re.value_type"),
+					postgresText("min"), goqu.COALESCE(
 						goqu.I("re.min_text"),
 						goqu.L("?::text", goqu.I("re.min_num")),
 						temporalColumnAsText(goqu.I("re.min_time")),
 						temporalColumnAsText(goqu.I("re.min_date")),
 						temporalColumnAsText(goqu.I("re.min_datetime")),
 					),
-					goqu.V("max"), goqu.COALESCE(
+					postgresText("max"), goqu.COALESCE(
 						goqu.I("re.max_text"),
 						goqu.L("?::text", goqu.I("re.max_num")),
 						temporalColumnAsText(goqu.I("re.max_time")),
@@ -291,7 +295,7 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeReferenceElement),
 			dialect.From(goqu.T("reference_element").As("refe")).
 				Select(goqu.Func("jsonb_build_object",
-					goqu.V("value"), goqu.I("refe.value"),
+					postgresText("value"), goqu.I("refe.value"),
 				)).
 				Where(goqu.I("refe.id").Eq(goqu.I("sme.id"))).
 				Limit(1),
@@ -300,8 +304,8 @@ func getSMEValueExpressionForRead(dialect goqu.DialectWrapper, includeBlobValue 
 			goqu.I("sme.model_type").Eq(types.ModelTypeRelationshipElement),
 			dialect.From(goqu.T("relationship_element").As("rle")).
 				Select(goqu.Func("jsonb_build_object",
-					goqu.V("first"), goqu.I("rle.first"),
-					goqu.V("second"), goqu.I("rle.second"),
+					postgresText("first"), goqu.I("rle.first"),
+					postgresText("second"), goqu.I("rle.second"),
 				)).
 				Where(goqu.I("rle.id").Eq(goqu.I("sme.id"))).
 				Limit(1),

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_value_expression_test.go
@@ -63,7 +63,7 @@ func TestGetSMEValueExpressionForReadSanitizesOperationVariableBlobs(t *testing.
 	require.NoError(t, err)
 	require.Contains(t, withoutBlobValueSQL, "WITH RECURSIVE operation_json_nodes")
 	require.Contains(t, withoutBlobValueSQL, `"current"."payload" #- "target"."path"`)
-	require.Contains(t, withoutBlobValueSQL, `"operation_json_nodes"."node" ->> 'modelType' = 'Blob'`)
+	require.Contains(t, withoutBlobValueSQL, `"operation_json_nodes"."node" ->> 'modelType'::text = 'Blob'::text`)
 
 	withBlobValueSQL, _, err := dialect.
 		Select(getSMEValueExpressionForRead(dialect, true)).
@@ -71,4 +71,18 @@ func TestGetSMEValueExpressionForReadSanitizesOperationVariableBlobs(t *testing.
 	require.NoError(t, err)
 	require.NotContains(t, withBlobValueSQL, "WITH RECURSIVE operation_json_nodes")
 	require.NotContains(t, withBlobValueSQL, `"current"."payload" #- "target"."path"`)
+}
+
+func TestGetSMEValueExpressionDoesNotBindStaticJSONKeys(t *testing.T) {
+	t.Parallel()
+
+	dialect := goqu.Dialect("postgres")
+	_, args, err := dialect.
+		Select(getSMEValueExpressionForRead(dialect, true)).
+		Prepared(true).
+		ToSQL()
+	require.NoError(t, err)
+	require.NotContains(t, args, "content_type")
+	require.NotContains(t, args, "value")
+	require.NotContains(t, args, "modelType")
 }

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -1215,10 +1215,10 @@ func TestGetSubmodelElementPathPageAcceptsCompositeCursor(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM "submodel"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
 
-	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*"sme"\."submodel_id" = 42.*"sme"\."idshort_path" = 'A'.*"sme"\."id" = 10`).
+	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*"sme"\."submodel_id" = \$1.*"sme"\."idshort_path" = \$2.*"sme"\."id" = \$3`).
 		WillReturnRows(sqlmock.NewRows([]string{"idshort_path", "id"}).AddRow("A", int64(10)))
 
-	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*"sme"\."idshort_path" > 'A'.*"sme"\."idshort_path" = 'A'.*"sme"\."id" > 10`).
+	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*"sme"\."idshort_path" > \$2.*"sme"\."idshort_path" = \$3.*"sme"\."id" > \$4`).
 		WillReturnRows(sqlmock.NewRows([]string{"idshort_path", "id"}).
 			AddRow("A", int64(20)).
 			AddRow("B", int64(30)))

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -371,7 +371,7 @@ func TestGetSubmodelElementsCoreReturnsOnlyRootElements(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*parent_sme_id.*IS NULL`).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "idshort_path"}).AddRow(10, "RootCollection"))
 
-	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*"sme"\."id" IN`).
+	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*"sme"\."id" = ANY`).
 		WillReturnRows(sqlmock.NewRows(submodelElementReadColumns()).
 			AddRow(
 				10,
@@ -428,7 +428,7 @@ func TestGetSubmodelElementsDeepReturnsRootWithChildren(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*parent_sme_id.*IS NULL`).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "idshort_path"}).AddRow(10, "RootCollection"))
 
-	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*COALESCE\("sme"\."root_sme_id", "sme"\."id"\) IN`).
+	mock.ExpectQuery(`SELECT .*FROM "submodel_element" AS "sme".*COALESCE\("sme"\."root_sme_id", "sme"\."id"\) = ANY`).
 		WillReturnRows(sqlmock.NewRows(submodelElementReadColumns()).
 			AddRow(
 				10,

--- a/internal/submodelrepository/persistence/submodel_read_database.go
+++ b/internal/submodelrepository/persistence/submodel_read_database.go
@@ -166,7 +166,7 @@ func (s *SubmodelDatabase) getSubmodelMetadataByIDInTransaction(ctx context.Cont
 		}
 	}
 
-	query, args, err := selectDS.ToSQL()
+	query, args, err := selectDS.Prepared(true).ToSQL()
 	if err != nil {
 		return nil, common.NewInternalServerError("SMREPO-GETSMBYIDTX-BUILDSQL " + err.Error())
 	}

--- a/internal/submodelrepository/persistence/utils/submodel_utils.go
+++ b/internal/submodelrepository/persistence/utils/submodel_utils.go
@@ -70,9 +70,10 @@ func GetSubmodelDatabaseIDForUpdate(tx *sql.Tx, submodelID string) (int, error) 
 
 func getSubmodelDatabaseID(db SubmodelIDQueryer, submodelID string, forUpdate bool) (int, error) {
 	var databaseID int
-	query := goqu.Select("id").
+	query := goqu.Dialect("postgres").Select("id").
 		From("submodel").
-		Where(goqu.I("submodel_identifier").Eq(submodelID))
+		Where(goqu.I("submodel_identifier").Eq(submodelID)).
+		Prepared(true)
 	if forUpdate {
 		query = query.ForUpdate(goqu.Wait)
 	}


### PR DESCRIPTION
## What changed

- use prepared PostgreSQL statements for recurring read queries in the Submodel Repository, AAS Repository, registries, Discovery, Concept Description Repository, Company Lookup and AASX File Server
- pass variable numeric and text ID sets as PostgreSQL array parameters so batch size no longer changes the SQL shape
- keep static JSON keys as typed SQL literals while request values remain bound parameters
- cover Submodel element reconstruction, AAS batch assembly and shared descriptor child reads without changing their response mapping or security filters
- build the configuration service from the same revision in the DTR scalability setup instead of pulling a mutable `SNAPSHOT`
- add regression tests for stable query shapes across different paths and batch sizes

## Why

The realistic million-record tests showed a large difference between diverse reads and repeatedly reading the same target. Request-specific identifiers, paths and variable-length `IN` lists caused pgx and PostgreSQL to see many different SQL statements, which limited prepared statement and plan reuse.

The original Submodel experiment reached about 6,039 RPS for one repeated full Submodel target instead of 3,317 RPS across diverse targets. Path reads reached about 10,635 RPS instead of 6,951 RPS. Keeping the SQL shape stable allows PostgreSQL to reuse plans across different resources and applies the same improvement to the other PostgreSQL-backed read services.

There are no API, configuration or schema changes. AAS Environment and DTR inherit the optimized repository, registry, discovery and company descriptor paths.

## Verification

- `go test -v ./internal/submodelrepository/integration_tests`
- AAS Repository, AAS Registry, Submodel Registry, Discovery, Concept Description, AASX, Company Lookup, DTR and AAS Environment integration suites
- corresponding Submodel/AAS/registry/Discovery/Concept Description/DTR/AAS Environment security suites
- repository-wide `go test ./...` passed every package except the DTR scalability suite startup
- `go vet ./...`
- `golangci-lint run ./...`
- `docker compose ... config --quiet` for the DTR scalability setup

The isolated DTR scalability run is currently blocked by the existing external benchmark database being at schema `v1.1.12` while this branch expects `v1.1.11`. The mutable `SNAPSHOT` configuration image caused that mismatch before the Compose fix. The test now builds the matching configuration service locally, but the external database needs to be restored or reseeded before this branch can run against it safely.
