### PR TITLE
Require subject attributes in ABAC rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,28 @@
 
 All notable user-visible changes are documented here.
 
+## Terminology
+
+The `Type` column uses the following values:
+
+| Type | Usage |
+| --- | --- |
+| Major | Requires users to update an API integration, configuration, policy, or deployment. |
+| Minor | Adds, extends, or hardens behavior without requiring migration. |
+| Bugfix | Corrects behavior that did not work as intended. |
+
+Security consequences are documented separately in the `Security impact`
+column and do not determine the change type.
+
 ## Unreleased (after v1.0.9)
 
 These changes affect upgrades from `v1.0.9` to the next release.
 
 | Type | Change | Pull request | Security impact |
 | --- | --- | --- | --- |
-| Bugfix | ABAC rules containing only `UTCNOW`, `LOCALNOW`, or `CLIENTNOW` now require a `CLAIM`, or `GLOBAL=ANONYMOUS` for intentionally public access. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: existing time-only rules no longer grant access. |
+| Major | ABAC rules containing only `UTCNOW`, `LOCALNOW`, or `CLIENTNOW` now require a `CLAIM`, or `GLOBAL=ANONYMOUS` for intentionally public access. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: existing time-only rules no longer grant access. |
 | Bugfix | `CLIENTNOW` is no longer generated or overwritten by the server and must come from the verified access token. Use `UTCNOW` or `LOCALNOW` when server time is intended. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: rules requiring `CLIENTNOW` no longer match without the token claim. |
 | Bugfix | `UTCNOW` and `LOCALNOW` now use the trusted server clock instead of same-named JWT claims. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | JWT values can no longer control server-time authorization decisions. |
-| Bugfix | Every declared `CLAIM` is mandatory, including when combined with `GLOBAL=ANONYMOUS`; unsupported attributes fail closed. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: missing claims and unsupported attributes deny access. |
+| Minor | Every declared `CLAIM` is mandatory, including when combined with `GLOBAL=ANONYMOUS`; unsupported attributes fail closed. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: missing claims and unsupported attributes deny access. |
 | Minor | Anonymous time-based rules can grant access when `GLOBAL=ANONYMOUS` is explicitly configured. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | Potentially broader, but only for policies that explicitly allow anonymous access. |
 | Minor | `EvalInput.Globals` allows trusted or deterministic time values to be supplied separately from token claims. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | None; developer-facing evaluation and test support. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable user-visible changes are documented here.
+
+## Unreleased (after v1.0.9)
+
+These changes affect upgrades from `v1.0.9` to the next release.
+
+| Type | Change | Pull request | Security impact |
+| --- | --- | --- | --- |
+| Bugfix | ABAC rules containing only `UTCNOW`, `LOCALNOW`, or `CLIENTNOW` now require a `CLAIM`, or `GLOBAL=ANONYMOUS` for intentionally public access. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: existing time-only rules no longer grant access. |
+| Bugfix | `CLIENTNOW` is no longer generated or overwritten by the server and must come from the verified access token. Use `UTCNOW` or `LOCALNOW` when server time is intended. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: rules requiring `CLIENTNOW` no longer match without the token claim. |
+| Bugfix | `UTCNOW` and `LOCALNOW` now use the trusted server clock instead of same-named JWT claims. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | JWT values can no longer control server-time authorization decisions. |
+| Bugfix | Every declared `CLAIM` is mandatory, including when combined with `GLOBAL=ANONYMOUS`; unsupported attributes fail closed. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: missing claims and unsupported attributes deny access. |
+| Minor | Anonymous time-based rules can grant access when `GLOBAL=ANONYMOUS` is explicitly configured. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | Potentially broader, but only for policies that explicitly allow anonymous access. |
+| Minor | `EvalInput.Globals` allows trusted or deterministic time values to be supplied separately from token claims. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | None; developer-facing evaluation and test support. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The `Type` column uses the following values:
 
 | Type | Usage |
 | --- | --- |
-| Major | Requires users to update an API integration, configuration, policy, or deployment. |
-| Minor | Adds, extends, or hardens behavior without requiring migration. |
+| High impact | Requires users to update an API integration, configuration, policy, or deployment. |
+| Low impact | Adds, extends, or hardens behavior without requiring migration. |
 | Bugfix | Corrects behavior that did not work as intended. |
 
 Security consequences are documented separately in the `Security impact`
@@ -21,9 +21,8 @@ These changes affect upgrades from `v1.0.9` to the next release.
 
 | Type | Change | Pull request | Security impact |
 | --- | --- | --- | --- |
-| Major | ABAC rules containing only `UTCNOW`, `LOCALNOW`, or `CLIENTNOW` now require a `CLAIM`, or `GLOBAL=ANONYMOUS` for intentionally public access. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: existing time-only rules no longer grant access. |
+| Bugfix | ABAC rules containing only `UTCNOW`, `LOCALNOW`, or `CLIENTNOW` now require a `CLAIM`, or `GLOBAL=ANONYMOUS` for intentionally public access. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: existing time-only rules no longer grant access. |
 | Bugfix | `CLIENTNOW` is no longer generated or overwritten by the server and must come from the verified access token. Use `UTCNOW` or `LOCALNOW` when server time is intended. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: rules requiring `CLIENTNOW` no longer match without the token claim. |
 | Bugfix | `UTCNOW` and `LOCALNOW` now use the trusted server clock instead of same-named JWT claims. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | JWT values can no longer control server-time authorization decisions. |
-| Minor | Every declared `CLAIM` is mandatory, including when combined with `GLOBAL=ANONYMOUS`; unsupported attributes fail closed. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: missing claims and unsupported attributes deny access. |
-| Minor | Anonymous time-based rules can grant access when `GLOBAL=ANONYMOUS` is explicitly configured. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | Potentially broader, but only for policies that explicitly allow anonymous access. |
-| Minor | `EvalInput.Globals` allows trusted or deterministic time values to be supplied separately from token claims. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | None; developer-facing evaluation and test support. |
+| Low impact | Every declared `CLAIM` is mandatory, including when combined with `GLOBAL=ANONYMOUS`; unsupported attributes fail closed. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | More restrictive: missing claims and unsupported attributes deny access. |
+| Low impact | Anonymous time-based rules can grant access when `GLOBAL=ANONYMOUS` is explicitly configured. | [#573](https://github.com/eclipse-basyx/basyx-go-components/pull/573) | Potentially broader, but only for policies that explicitly allow anonymous access. |

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@
 
 Welcome to the BaSyx Go project! This guide is designed to help new developers onboard quickly, understand the architecture, and contribute effectively.
 
+See the [changelog](CHANGELOG.md) for release changes and upgrade considerations.
+
 > [!NOTE]
 > We also provide a wiki at https://wiki.basyx.org with a extensive user and developer documentation.
 
 ## Table of Contents
 
 - [BaSyx Go Components](#basyx-go-components)
+  - [Changelog](CHANGELOG.md)
   - [Table of Contents](#table-of-contents)
   - [1. Project Overview](#1-project-overview)
   - [2. Architecture Overview](#2-architecture-overview)

--- a/docu/security/README.md
+++ b/docu/security/README.md
@@ -380,7 +380,9 @@ Attribute satisfaction follows these rules:
 
 - An attribute list must contain at least one subject attribute: `CLAIM` or `GLOBAL=ANONYMOUS`.
 - Every declared `CLAIM` must be present. `GLOBAL=ANONYMOUS` does not compensate for a missing claim.
-- `GLOBAL=UTCNOW`, `GLOBAL=LOCALNOW`, and `GLOBAL=CLIENTNOW` are optional at this gate and are resolved during formula evaluation.
+- Date-time globals are optional at this gate and are resolved during formula evaluation.
+- `GLOBAL=UTCNOW` and `GLOBAL=LOCALNOW` come from the server's trusted clock and are available to authenticated and anonymous requests.
+- `GLOBAL=CLIENTNOW` comes from the verified access-token claim with the same name. It is unavailable when that claim or access token is absent.
 - A list containing only date-time globals does not satisfy the attribute gate.
 
 Validation invariants enforced by the current implementation:

--- a/docu/security/README.md
+++ b/docu/security/README.md
@@ -376,6 +376,13 @@ Access rules define:
 - DEFFORMULAS: reusable boolean expressions.
 - rules: ordered rules that combine ACLs, objects, and formulas.
 
+Attribute satisfaction follows these rules:
+
+- An attribute list must contain at least one subject attribute: `CLAIM` or `GLOBAL=ANONYMOUS`.
+- Every declared `CLAIM` must be present. `GLOBAL=ANONYMOUS` does not compensate for a missing claim.
+- `GLOBAL=UTCNOW`, `GLOBAL=LOCALNOW`, and `GLOBAL=CLIENTNOW` are optional at this gate and are resolved during formula evaluation.
+- A list containing only date-time globals does not satisfy the attribute gate.
+
 Validation invariants enforced by the current implementation:
 - Rule-level one-of:
   - exactly one of `ACL` or `USEACL`

--- a/internal/common/security/abac_engine.go
+++ b/internal/common/security/abac_engine.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/builder"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
@@ -203,6 +204,10 @@ func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.
 	if !mapped {
 		return AuthorizationEvaluation{Reason: DecisionNoMatch}
 	}
+	globals := globalAttributesForEvaluation(in.Globals, in.Claims, time.Now())
+	resolver := func(attr grammar.AttributeValue) any {
+		return resolveAttributeValue(attr, in.Claims, globals)
+	}
 
 	var ruleExprs []QueryFilter
 	allFragments := make(map[grammar.FragmentStringPattern]struct{})
@@ -253,9 +258,6 @@ func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.
 			return AuthorizationEvaluation{Reason: DecisionNoMatch}
 		}
 
-		resolver := func(attr grammar.AttributeValue) any {
-			return resolveAttributeValue(attr, in.Claims)
-		}
 		adapted, decision := combinedLE.SimplifyForBackendFilterWithOptions(resolver, opts)
 		if decision == grammar.SimplifyFalse {
 			continue
@@ -300,9 +302,6 @@ func (m *AccessModel) AuthorizeWithFilterWithOptions(in EvalInput, opts grammar.
 		combined.Or = append(combined.Or, *qfr.Formula)
 	}
 
-	resolver := func(attr grammar.AttributeValue) any {
-		return resolveAttributeValue(attr, in.Claims)
-	}
 	simplified, decision := combined.SimplifyForBackendFilterWithOptions(resolver, opts)
 	combinedByRight := make(map[grammar.RightsEnum]grammar.LogicalExpression, len(relevantRights))
 	for _, right := range relevantRights {

--- a/internal/common/security/abac_engine_attributes.go
+++ b/internal/common/security/abac_engine_attributes.go
@@ -30,42 +30,35 @@ import (
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 )
 
-// attributesSatisfiedAll returns true only if ALL required attributes are satisfied.
-// Rules supported:
-//   - GLOBAL=ANONYMOUS         → satisfied unconditionally
-//   - CLAIM=<claimKey>         → user must have that claim key (presence check)
-//
-// If items is empty, it returns true. Unknown kinds fail closed (return false).
+// attributesSatisfiedAll returns true when all required claims are present and
+// the attributes identify either a claim-based or anonymous subject. Date-time
+// globals do not restrict access at this stage and are resolved when evaluating
+// formulas. Unknown attributes fail closed.
 func attributesSatisfiedAll(items []grammar.AttributeItem, claims Claims) bool {
-	// with no attributes deny access per default
 	if len(items) == 0 {
 		return false
 	}
 
+	hasSubjectAttribute := false
 	for _, it := range items {
 		switch it.Kind {
 		case grammar.ATTRGLOBAL:
-			// Currently only ANONYMOUS is supported per your comment.
-			if it.Value == "ANONYMOUS" {
-				// satisfied → continue checking the rest
-				continue
+			switch it.Value {
+			case "ANONYMOUS":
+				hasSubjectAttribute = true
+			case "UTCNOW", "LOCALNOW", "CLIENTNOW":
+			default:
+				return false
 			}
-			// Unsupported GLOBAL value → ignore
-			continue
-
 		case grammar.ATTRCLAIM:
-			// Presence-only check: user must have this claim key
-
+			hasSubjectAttribute = true
 			if _, ok := claims[it.Value]; !ok {
 				return false
 			}
-
 		default:
-			// Unknown attribute type → fail closed
 			return false
 		}
 	}
 
-	// All attributes satisfied
-	return true
+	return hasSubjectAttribute
 }

--- a/internal/common/security/abac_engine_attributes_test.go
+++ b/internal/common/security/abac_engine_attributes_test.go
@@ -1,0 +1,135 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+)
+
+func TestAttributesSatisfiedAll(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		items  []grammar.AttributeItem
+		claims Claims
+		want   bool
+	}{
+		{
+			name: "empty attributes deny access",
+			want: false,
+		},
+		{
+			name: "all claims are present",
+			items: []grammar.AttributeItem{
+				{Kind: grammar.ATTRCLAIM, Value: "role"},
+				{Kind: grammar.ATTRCLAIM, Value: "clearance"},
+			},
+			claims: Claims{"role": "reader", "clearance": 3},
+			want:   true,
+		},
+		{
+			name: "one claim is missing",
+			items: []grammar.AttributeItem{
+				{Kind: grammar.ATTRCLAIM, Value: "role"},
+				{Kind: grammar.ATTRCLAIM, Value: "clearance"},
+			},
+			claims: Claims{"role": "reader"},
+			want:   false,
+		},
+		{
+			name: "anonymous permits access without claims",
+			items: []grammar.AttributeItem{
+				{Kind: grammar.ATTRGLOBAL, Value: "ANONYMOUS"},
+			},
+			want: true,
+		},
+		{
+			name: "anonymous does not replace missing claims",
+			items: []grammar.AttributeItem{
+				{Kind: grammar.ATTRCLAIM, Value: "role"},
+				{Kind: grammar.ATTRGLOBAL, Value: "ANONYMOUS"},
+			},
+			want: false,
+		},
+		{
+			name: "anonymous remains optional when all claims are present",
+			items: []grammar.AttributeItem{
+				{Kind: grammar.ATTRCLAIM, Value: "role"},
+				{Kind: grammar.ATTRGLOBAL, Value: "ANONYMOUS"},
+			},
+			claims: Claims{"role": "reader"},
+			want:   true,
+		},
+		{
+			name: "date-time globals are optional",
+			items: []grammar.AttributeItem{
+				{Kind: grammar.ATTRGLOBAL, Value: "UTCNOW"},
+				{Kind: grammar.ATTRGLOBAL, Value: "LOCALNOW"},
+				{Kind: grammar.ATTRGLOBAL, Value: "CLIENTNOW"},
+				{Kind: grammar.ATTRCLAIM, Value: "role"},
+			},
+			claims: Claims{"role": "reader"},
+			want:   true,
+		},
+		{
+			name: "date-time-only attributes deny access",
+			items: []grammar.AttributeItem{
+				{Kind: grammar.ATTRGLOBAL, Value: "UTCNOW"},
+				{Kind: grammar.ATTRGLOBAL, Value: "LOCALNOW"},
+				{Kind: grammar.ATTRGLOBAL, Value: "CLIENTNOW"},
+			},
+			want: false,
+		},
+		{
+			name: "date-time globals do not replace missing claims",
+			items: []grammar.AttributeItem{
+				{Kind: grammar.ATTRGLOBAL, Value: "UTCNOW"},
+				{Kind: grammar.ATTRCLAIM, Value: "role"},
+			},
+			want: false,
+		},
+		{
+			name: "unknown attribute kind fails closed",
+			items: []grammar.AttributeItem{
+				{Kind: grammar.ATTRTYPE("UNKNOWN"), Value: "value"},
+				{Kind: grammar.ATTRGLOBAL, Value: "ANONYMOUS"},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := attributesSatisfiedAll(test.items, test.claims); got != test.want {
+				t.Fatalf("attributesSatisfiedAll() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/common/security/attribute_resolver.go
+++ b/internal/common/security/attribute_resolver.go
@@ -30,25 +30,37 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 	jsoniter "github.com/json-iterator/go"
 )
 
-func resolveGlobalToken(name string, claims Claims) (any, bool) {
-	switch strings.ToUpper(name) {
-	case "UTCNOW":
-		if val, ok := claims["UTCNOW"]; ok {
-			return normalizeClaimScalar(val), true
-		}
-		return "", false
-	case "LOCALNOW":
-		if val, ok := claims["LOCALNOW"]; ok {
-			return normalizeClaimScalar(val), true
-		}
-		return "", false
-	case "CLIENTNOW":
-		if val, ok := claims["CLIENTNOW"]; ok {
+func globalAttributesForEvaluation(configured GlobalAttributes, claims Claims, currentTime time.Time) GlobalAttributes {
+	globals := make(GlobalAttributes, len(configured)+3)
+	for name, value := range configured {
+		globals[name] = value
+	}
+
+	if _, exists := globals["UTCNOW"]; !exists {
+		globals["UTCNOW"] = currentTime.UTC().Format(time.RFC3339)
+	}
+	if _, exists := globals["LOCALNOW"]; !exists {
+		globals["LOCALNOW"] = currentTime.In(time.Local).Format(time.RFC3339)
+	}
+	delete(globals, "CLIENTNOW")
+	if clientNow, exists := claims["CLIENTNOW"]; exists {
+		globals["CLIENTNOW"] = normalizeClaimScalar(clientNow)
+	}
+
+	return globals
+}
+
+func resolveGlobalToken(name string, globals GlobalAttributes) (any, bool) {
+	normalizedName := strings.ToUpper(name)
+	switch normalizedName {
+	case "UTCNOW", "LOCALNOW", "CLIENTNOW":
+		if val, ok := globals[normalizedName]; ok {
 			return normalizeClaimScalar(val), true
 		}
 		return "", false
@@ -61,7 +73,7 @@ func resolveGlobalToken(name string, claims Claims) (any, bool) {
 
 // resolveAttributeValue resolves a grammar.AttributeValue to a concrete literal using claims/globals.
 // It also normalizes common claim container shapes (e.g., single-element arrays from Keycloak).
-func resolveAttributeValue(attr grammar.AttributeValue, claims Claims) any {
+func resolveAttributeValue(attr grammar.AttributeValue, claims Claims, globals GlobalAttributes) any {
 	m, ok := asStringMap(attr)
 	if !ok {
 		return nil
@@ -78,7 +90,7 @@ func resolveAttributeValue(attr grammar.AttributeValue, claims Claims) any {
 		return fmt.Sprint(normalized)
 	}
 	if g := m["GLOBAL"]; g != "" {
-		if val, ok := resolveGlobalToken(g, claims); ok {
+		if val, ok := resolveGlobalToken(g, globals); ok {
 			return val
 		}
 	}

--- a/internal/common/security/attribute_resolver_test.go
+++ b/internal/common/security/attribute_resolver_test.go
@@ -25,13 +25,16 @@
 
 package auth
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestResolveAttributeValue_MissingClaimReturnsNil(t *testing.T) {
 	attr := map[string]any{"CLAIM": "clear"}
 	claims := Claims{"role": "editor"}
 
-	got := resolveAttributeValue(attr, claims)
+	got := resolveAttributeValue(attr, claims, nil)
 	if got != nil {
 		t.Fatalf("expected nil for missing claim, got %#v", got)
 	}
@@ -41,8 +44,60 @@ func TestResolveAttributeValue_ClaimArrayUnwrapsFirstElement(t *testing.T) {
 	attr := map[string]any{"CLAIM": "role"}
 	claims := Claims{"role": []any{"editor"}}
 
-	got := resolveAttributeValue(attr, claims)
+	got := resolveAttributeValue(attr, claims, nil)
 	if got != "editor" {
 		t.Fatalf("expected editor, got %#v", got)
+	}
+}
+
+func TestGlobalAttributesForEvaluationProvidesServerTimeWithoutClaims(t *testing.T) {
+	currentTime := time.Date(2026, time.August, 5, 12, 30, 0, 0, time.FixedZone("UTC+2", 2*60*60))
+
+	globals := globalAttributesForEvaluation(nil, nil, currentTime)
+
+	if got := globals["UTCNOW"]; got != "2026-08-05T10:30:00Z" {
+		t.Fatalf("UTCNOW = %#v, want 2026-08-05T10:30:00Z", got)
+	}
+	if got := globals["LOCALNOW"]; got != currentTime.In(time.Local).Format(time.RFC3339) {
+		t.Fatalf("LOCALNOW = %#v, want server local time", got)
+	}
+	if _, exists := globals["CLIENTNOW"]; exists {
+		t.Fatal("CLIENTNOW must not be generated for anonymous requests")
+	}
+}
+
+func TestGlobalAttributesForEvaluationUsesAuthenticatedClientTime(t *testing.T) {
+	clientNow := "2026-08-05T12:30:00+02:00"
+	claims := Claims{"CLIENTNOW": clientNow}
+	configured := GlobalAttributes{"CLIENTNOW": "untrusted"}
+
+	globals := globalAttributesForEvaluation(configured, claims, time.Time{})
+
+	if got := globals["CLIENTNOW"]; got != clientNow {
+		t.Fatalf("CLIENTNOW = %#v, want %s", got, clientNow)
+	}
+}
+
+func TestGlobalAttributesForEvaluationRejectsUnauthenticatedClientTime(t *testing.T) {
+	configured := GlobalAttributes{"CLIENTNOW": "2026-08-05T12:30:00+02:00"}
+
+	globals := globalAttributesForEvaluation(configured, nil, time.Time{})
+
+	if _, exists := globals["CLIENTNOW"]; exists {
+		t.Fatal("CLIENTNOW must not be accepted without an authenticated claim")
+	}
+}
+
+func TestResolveAttributeValueKeepsGlobalsSeparateFromClaims(t *testing.T) {
+	globals := GlobalAttributes{"UTCNOW": "2026-08-05T10:30:00Z"}
+
+	globalValue := resolveAttributeValue(map[string]any{"GLOBAL": "UTCNOW"}, nil, globals)
+	if globalValue != "2026-08-05T10:30:00Z" {
+		t.Fatalf("GLOBAL UTCNOW = %#v, want 2026-08-05T10:30:00Z", globalValue)
+	}
+
+	claimValue := resolveAttributeValue(map[string]any{"CLAIM": "UTCNOW"}, nil, globals)
+	if claimValue != nil {
+		t.Fatalf("CLAIM UTCNOW = %#v, want nil", claimValue)
 	}
 }

--- a/internal/common/security/authorize_test.go
+++ b/internal/common/security/authorize_test.go
@@ -154,6 +154,48 @@ func TestSecurityMiddleware_RejectsAnonymousGetWhenACLRequiresSubClaim(t *testin
 	}
 }
 
+func TestAuthorizeWithFilter_AllowsAnonymousServerTimeFormula(t *testing.T) {
+	t.Parallel()
+
+	router := api.NewRouter()
+	router.Get("/description", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	model, err := ParseAccessModel([]byte(`{
+		"AllAccessPermissionRules": {
+			"rules": [{
+				"ACL": {
+					"ACCESS": "ALLOW",
+					"RIGHTS": ["READ"],
+					"ATTRIBUTES": [
+						{"GLOBAL": "ANONYMOUS"},
+						{"GLOBAL": "UTCNOW"}
+					]
+				},
+				"OBJECTS": [{"ROUTE": "/description"}],
+				"FORMULA": {
+					"$gt": [
+						{"$attribute": {"GLOBAL": "UTCNOW"}},
+						{"$dateTimeVal": "2000-01-01T00:00:00Z"}
+					]
+				}
+			}]
+		}
+	}`), router, "")
+	if err != nil {
+		t.Fatalf("ParseAccessModel() error = %v", err)
+	}
+
+	allowed, reason, _ := model.AuthorizeWithFilter(EvalInput{
+		Method: http.MethodGet,
+		Path:   "/description",
+		Claims: Claims{},
+	})
+	if !allowed || reason != DecisionAllow {
+		t.Fatalf("anonymous time-based rule denied access: allowed=%t reason=%s", allowed, reason)
+	}
+}
+
 func TestVerifyEndpointRequiresAuthWhenABACEnabled(t *testing.T) {
 	router := api.NewRouter()
 	model := &AccessModel{

--- a/internal/common/security/input_eval.go
+++ b/internal/common/security/input_eval.go
@@ -33,7 +33,12 @@ type EvalInput struct {
 	Path      string
 	RoutePath string
 	Claims    Claims
+	Globals   GlobalAttributes
 }
 
 // Claims represents token claims extracted from a verified token.
 type Claims map[string]any
+
+// GlobalAttributes represents trusted environmental values used during ABAC
+// formula evaluation.
+type GlobalAttributes map[string]any

--- a/internal/common/security/oidc.go
+++ b/internal/common/security/oidc.go
@@ -35,7 +35,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
@@ -231,12 +230,6 @@ func (o *OIDC) Middleware(next http.Handler) http.Handler {
 			respondOIDCStatus(w, http.StatusForbidden)
 			return
 		}
-
-		// add time claims sourced from the current request context
-		currTime := time.Now()
-		c["CLIENTNOW"] = currTime.Format(time.RFC3339)
-		c["LOCALNOW"] = currTime.In(time.Local).Format(time.RFC3339)
-		c["UTCNOW"] = currTime.UTC().Format(time.RFC3339)
 
 		r = r.WithContext(context.WithValue(r.Context(), ClaimsKey, c))
 		next.ServeHTTP(w, r)

--- a/internal/common/security/oidc_test.go
+++ b/internal/common/security/oidc_test.go
@@ -193,6 +193,15 @@ func TestOIDCMiddleware_AppliesClaimMappingsAndTokenTypeIndicators(t *testing.T)
 		if got := claims["basyx.scopes"]; !reflect.DeepEqual(got, wantScopes) {
 			t.Fatalf("basyx.scopes = %#v, want %#v", got, wantScopes)
 		}
+		if got := claims["CLIENTNOW"]; got != "2026-08-05T12:30:00+02:00" {
+			t.Fatalf("CLIENTNOW = %#v, want token-provided value", got)
+		}
+		if _, exists := claims["UTCNOW"]; exists {
+			t.Fatal("UTCNOW must not be stored as a JWT claim")
+		}
+		if _, exists := claims["LOCALNOW"]; exists {
+			t.Fatal("LOCALNOW must not be stored as a JWT claim")
+		}
 
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -201,6 +210,7 @@ func TestOIDCMiddleware_AppliesClaimMappingsAndTokenTypeIndicators(t *testing.T)
 		"aud":          "basyx-api",
 		"scp":          "access_as_user profile",
 		"idtyp":        "app",
+		"CLIENTNOW":    "2026-08-05T12:30:00+02:00",
 		"roles":        []any{"viewer", "admin"},
 		"realm_access": map[string]any{"roles": []any{"admin", "editor"}},
 	})

--- a/internal/common/security/unit_tests/abac_engine/eval/get_shellDescriptors_time_match.json
+++ b/internal/common/security/unit_tests/abac_engine/eval/get_shellDescriptors_time_match.json
@@ -3,8 +3,10 @@
   "path": "/shell-descriptors",
   "claims": {
     "role": "viewer",
-    "UTCNOW": "2025-01-01T00:00:00Z",
-    "LOCALNOW": "2025-01-01T01:00:00+01:00",
     "CLIENTNOW": "2025-01-01T00:00:00Z"
+  },
+  "globals": {
+    "UTCNOW": "2025-01-01T00:00:00Z",
+    "LOCALNOW": "2025-01-01T01:00:00+01:00"
   }
 }

--- a/internal/common/security/unit_tests/abac_engine/eval/get_shellDescriptors_time_mismatch.json
+++ b/internal/common/security/unit_tests/abac_engine/eval/get_shellDescriptors_time_mismatch.json
@@ -3,8 +3,10 @@
   "path": "/shell-descriptors",
   "claims": {
     "role": "viewer",
-    "UTCNOW": "2025-01-01T00:00:00Z",
-    "LOCALNOW": "2025-01-01T01:00:00+01:00",
     "CLIENTNOW": "2024-12-31T23:00:00Z"
+  },
+  "globals": {
+    "UTCNOW": "2025-01-01T00:00:00Z",
+    "LOCALNOW": "2025-01-01T01:00:00+01:00"
   }
 }


### PR DESCRIPTION
closes #574

## Description of Changes

Clarifies and tightens ABAC attribute evaluation. This makes access only more strict and safer to use.

Before:

- An attribute list containing only date-time globals was accepted.
- The interaction between claims, `ANONYMOUS`, and date-time globals was not clearly documented or directly unit-tested.

After:

- Every declared claim must exist, even when `ANONYMOUS` is also present.
- `ANONYMOUS` is valid alone or together with satisfied claims.
- Date-time globals remain optional but cannot grant access by themselves.

This makes access rules safer and easier to understand by requiring an explicit subject. Existing rules that contain only date-time globals must add either a `CLAIM` or `ANONYMOUS`.

## Testing

- `go test ./internal/common/security/...`
