### PR TITLE
improve performance for post and delete in aas and sm repository

### DIFF
--- a/cmd/basyxconfigurationservice/main.go
+++ b/cmd/basyxconfigurationservice/main.go
@@ -95,7 +95,8 @@ func main() {
 	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_10.sql"), "v1.1.10"))
 	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_11.sql"), "v1.1.11"))
 	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_12.sql"), "v1.1.12"))
-	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_13.sql"), common.CURRENT_DATABASE_VERSION))
+	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_13.sql"), "v1.1.13"))
+	schemInit.Register(sequences.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_14.sql"), common.CURRENT_DATABASE_VERSION))
 
 	if err = schemInit.Execute(); err != nil {
 		slog.Error("configuration failed", "error.code", "BASYXCFG-MAIN-EXECUTE", "error", err)

--- a/database/patches/1_1_14.sql
+++ b/database/patches/1_1_14.sql
@@ -1,0 +1,46 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+-- Adds indexes for reverse AAS-to-Submodel lookups and supplemental semantic
+-- reference cascade deletes.
+
+CREATE INDEX IF NOT EXISTS ix_aas_submodel_reference_key_value_reference_id
+  ON aas_submodel_reference_key(value, reference_id);
+
+CREATE INDEX IF NOT EXISTS ix_sme_supp_sem_ref_payload_reference_id
+  ON submodel_element_supplemental_semantic_id_reference_payload(reference_id);
+
+CREATE INDEX IF NOT EXISTS ix_submodel_supp_sem_ref_payload_reference_id
+  ON submodel_supplemental_semantic_id_reference_payload(reference_id);
+
+UPDATE basyxsystem
+SET schema_version = 'v1.1.14',
+    state = 'clean'
+WHERE identifier = (
+  SELECT identifier
+  FROM basyxsystem
+  ORDER BY identifier ASC
+  LIMIT 1
+);

--- a/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
+++ b/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
@@ -460,6 +460,9 @@ func (p *PostgreSQLAASRegistryDatabase) DeleteAssetAdministrationShellDescriptor
 	aasIdentifier string,
 ) error {
 	return common.ExecuteInTransaction(p.writerDB, "AASREG-DELAASDESC-STARTTX", "AASREG-DELAASDESC-COMMIT", func(tx *sql.Tx) error {
+		if !history.MutationRecordingEnabled() && descriptors.CanSkipDeleteReadback(ctx) {
+			return descriptors.DeleteAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasIdentifier)
+		}
 		previousSnapshot, err := loadDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, aasIdentifier)
 		if err != nil {
 			return err
@@ -556,6 +559,9 @@ func (p *PostgreSQLAASRegistryDatabase) DeleteAssetAdministrationShellDescriptor
 ) error {
 	if tx == nil {
 		return common.NewInternalServerError("AASREG-DELAASDESC-NILTX transaction must not be nil")
+	}
+	if !history.MutationRecordingEnabled() && descriptors.CanSkipDeleteReadback(ctx) {
+		return descriptors.DeleteAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasIdentifier)
 	}
 
 	previousSnapshot, err := loadDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, aasIdentifier)

--- a/internal/aasrepository/persistence/aas_asset_information_thumbnail_test.go
+++ b/internal/aasrepository/persistence/aas_asset_information_thumbnail_test.go
@@ -27,10 +27,13 @@ package persistence
 
 import (
 	"database/sql"
+	"errors"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,11 +55,96 @@ func TestCreateAssetAdministrationShellPersistsDefaultThumbnail(t *testing.T) {
 		[]types.IKey{types.NewKey(types.KeyTypesSubmodel, "https://example.com/ids/sm/1")},
 	)})
 
-	mock.ExpectExec(`(?s)INSERT INTO "aas".*INSERT INTO "aas_payload".*INSERT INTO "asset_information".*INSERT INTO "thumbnail_file_element".*INSERT INTO "specific_asset_id".*INSERT INTO "specific_asset_id_payload".*INSERT INTO "aas_submodel_reference".*INSERT INTO "aas_submodel_reference_key".*INSERT INTO "aas_submodel_reference_payload"`).
+	mock.ExpectQuery(`INSERT INTO "aas".*RETURNING "id"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(17))
+	mock.ExpectExec(`(?s)INSERT INTO "aas_payload".*INSERT INTO "asset_information".*INSERT INTO "thumbnail_file_element".*INSERT INTO "specific_asset_id".*INSERT INTO "specific_asset_id_payload".*INSERT INTO "aas_submodel_reference".*INSERT INTO "aas_submodel_reference_key".*INSERT INTO "aas_submodel_reference_payload"`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	repository := &AssetAdministrationShellDatabase{}
 	require.NoError(t, repository.createAssetAdministrationShellInTransaction(t.Context(), tx, aas))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateAssetAdministrationShellLargeDuplicateStopsAfterRootInsert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tx := beginMockTransaction(t, db, mock)
+	aas := types.NewAssetAdministrationShell(
+		"https://example.com/ids/aas/duplicate",
+		types.NewAssetInformation(types.AssetKindInstance),
+	)
+	references := make([]types.IReference, 1000)
+	for index := range references {
+		references[index] = types.NewReference(
+			types.ReferenceTypesModelReference,
+			[]types.IKey{types.NewKey(types.KeyTypesSubmodel, "https://example.com/ids/sm/duplicate")},
+		)
+	}
+	aas.SetSubmodels(references)
+
+	duplicateErr := &pgconn.PgError{Code: "23505", ConstraintName: "aas_aas_id_key"}
+	mock.ExpectQuery(`INSERT INTO "aas".*RETURNING "id"`).WillReturnError(duplicateErr)
+	mock.ExpectRollback()
+
+	repository := &AssetAdministrationShellDatabase{}
+	err = repository.createAssetAdministrationShellInTransaction(t.Context(), tx, aas)
+	require.Error(t, err)
+	require.True(t, common.IsErrConflict(err), "expected conflict error, got %v", err)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateAssetAdministrationShellRejectsKeylessReferenceBeforeInsert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tx := beginMockTransaction(t, db, mock)
+	aas := types.NewAssetAdministrationShell(
+		"https://example.com/ids/aas/keyless-reference",
+		types.NewAssetInformation(types.AssetKindInstance),
+	)
+	aas.SetSubmodels([]types.IReference{
+		types.NewReference(types.ReferenceTypesModelReference, []types.IKey{}),
+	})
+	mock.ExpectRollback()
+
+	repository := &AssetAdministrationShellDatabase{}
+	err = repository.createAssetAdministrationShellInTransaction(t.Context(), tx, aas)
+	require.Error(t, err)
+	require.True(t, common.IsErrBadRequest(err), "expected bad-request error, got %v", err)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateAssetAdministrationShellDependentConflictRemainsInternal(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tx := beginMockTransaction(t, db, mock)
+	aas := types.NewAssetAdministrationShell(
+		"https://example.com/ids/aas/dependent-conflict",
+		types.NewAssetInformation(types.AssetKindInstance),
+	)
+
+	mock.ExpectQuery(`INSERT INTO "aas".*RETURNING "id"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(17))
+	dependentErr := &pgconn.PgError{Code: "23505"}
+	mock.ExpectExec(`(?s)INSERT INTO "aas_payload".*INSERT INTO "asset_information"`).
+		WillReturnError(dependentErr)
+	mock.ExpectRollback()
+
+	repository := &AssetAdministrationShellDatabase{}
+	err = repository.createAssetAdministrationShellInTransaction(t.Context(), tx, aas)
+	require.Error(t, err)
+	require.True(t, common.IsInternalServerError(err), "expected internal-server error, got %v", err)
+	require.False(t, common.IsErrConflict(err), "dependent conflict must not be mapped as an AAS identifier conflict")
+	var postgresErr *pgconn.PgError
+	require.True(t, errors.As(err, &postgresErr), "expected PostgreSQL cause, got %v", err)
+	require.NoError(t, tx.Rollback())
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/aasrepository/persistence/aas_asset_information_thumbnail_test.go
+++ b/internal/aasrepository/persistence/aas_asset_information_thumbnail_test.go
@@ -27,12 +27,10 @@ package persistence
 
 import (
 	"database/sql"
-	"strings"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/FriedJannik/aas-go-sdk/types"
-	"github.com/doug-martin/goqu/v9"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,62 +44,20 @@ func TestCreateAssetAdministrationShellPersistsDefaultThumbnail(t *testing.T) {
 		"https://example.com/ids/aas/default-thumbnail-create",
 		assetInformationWithDefaultThumbnail("https://example.com/thumb-create.png", "image/png"),
 	)
+	aas.AssetInformation().SetSpecificAssetIDs([]types.ISpecificAssetID{
+		types.NewSpecificAssetID("serialNumber", "123"),
+	})
+	aas.SetSubmodels([]types.IReference{types.NewReference(
+		types.ReferenceTypesModelReference,
+		[]types.IKey{types.NewKey(types.KeyTypesSubmodel, "https://example.com/ids/sm/1")},
+	)})
 
-	mock.ExpectQuery(`INSERT INTO "aas".*RETURNING "id"`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
-	mock.ExpectExec(`INSERT INTO "aas_payload"`).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(`INSERT INTO "asset_information"`).
-		WillReturnResult(sqlmock.NewResult(0, 1))
-	expectInternalThumbnailCleanup(mock)
-	mock.ExpectExec(`INSERT INTO "thumbnail_file_element"`).
+	mock.ExpectExec(`(?s)INSERT INTO "aas".*INSERT INTO "aas_payload".*INSERT INTO "asset_information".*INSERT INTO "thumbnail_file_element".*INSERT INTO "specific_asset_id".*INSERT INTO "specific_asset_id_payload".*INSERT INTO "aas_submodel_reference".*INSERT INTO "aas_submodel_reference_key".*INSERT INTO "aas_submodel_reference_payload"`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	repository := &AssetAdministrationShellDatabase{}
-	require.NoError(t, repository.createAssetAdministrationShellInTransaction(tx, aas))
+	require.NoError(t, repository.createAssetAdministrationShellInTransaction(t.Context(), tx, aas))
 	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func expectInternalThumbnailCleanup(mock sqlmock.Sqlmock) {
-	mock.ExpectExec(`DELETE FROM "thumbnail_binary_reference"`).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectQuery(`SELECT "file_oid" FROM "thumbnail_file_data"`).
-		WillReturnError(sql.ErrNoRows)
-	mock.ExpectExec(`DELETE FROM "thumbnail_file_data"`).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-}
-
-func TestBuildUpsertDefaultThumbnailQueryPreservesExistingContentTypeWhenUnset(t *testing.T) {
-	dialect := goquDialect()
-	thumbnail := types.NewResource("https://example.com/thumb.png")
-
-	upsertSQL, _, err := buildUpsertDefaultThumbnailQuery(
-		&dialect,
-		int64(42),
-		thumbnail,
-		thumbnail.Path(),
-	)
-
-	require.NoError(t, err)
-	require.Contains(t, upsertSQL, `COALESCE("excluded"."content_type", "thumbnail_file_element"."content_type")`)
-	require.Contains(t, upsertSQL, `"file_name"=NULL`)
-	require.NotContains(t, strings.ToLower(upsertSQL), `"content_type"=null`)
-}
-
-func TestBuildUpsertDefaultThumbnailQueryClearsFileNameForExternalURL(t *testing.T) {
-	dialect := goquDialect()
-	assetInformation := assetInformationWithDefaultThumbnail("https://example.com/thumb-update.png", "image/png")
-	thumbnail := assetInformation.DefaultThumbnail()
-
-	upsertSQL, _, err := buildUpsertDefaultThumbnailQuery(
-		&dialect,
-		int64(42),
-		thumbnail,
-		thumbnail.Path(),
-	)
-
-	require.NoError(t, err)
-	require.Contains(t, upsertSQL, `"file_name"=NULL`)
 }
 
 func assetInformationWithDefaultThumbnail(path string, contentType string) types.IAssetInformation {
@@ -119,8 +75,4 @@ func beginMockTransaction(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.T
 	tx, err := db.Begin()
 	require.NoError(t, err)
 	return tx
-}
-
-func goquDialect() goqu.DialectWrapper {
-	return goqu.Dialect("postgres")
 }

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -409,6 +409,9 @@ func (s *AssetAdministrationShellDatabase) checkAASVisibilityInTx(ctx context.Co
 }
 
 func (s *AssetAdministrationShellDatabase) ensureVisibleAASCreateDoesNotExist(ctx context.Context, tx *sql.Tx, aasIdentifier string) error {
+	if createprecheck.CanSkipExistenceCheck(ctx) {
+		return nil
+	}
 	return createprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) {
@@ -468,7 +471,7 @@ func (s *AssetAdministrationShellDatabase) CreateAssetAdministrationShellInTrans
 		return err
 	}
 
-	if err := s.createAssetAdministrationShellInTransaction(tx, aas); err != nil {
+	if err := s.createAssetAdministrationShellInTransaction(ctx, tx, aas); err != nil {
 		return err
 	}
 
@@ -493,97 +496,113 @@ func (s *AssetAdministrationShellDatabase) CreateAssetAdministrationShellInTrans
 }
 
 // createAssetAdministrationShellInTransaction creates an AAS and all dependent records within an existing transaction.
-func (s *AssetAdministrationShellDatabase) createAssetAdministrationShellInTransaction(tx *sql.Tx, aas types.IAssetAdministrationShell) error {
+func (s *AssetAdministrationShellDatabase) createAssetAdministrationShellInTransaction(ctx context.Context, tx *sql.Tx, aas types.IAssetAdministrationShell) error {
 	dialect := goqu.Dialect("postgres")
-
-	ids, args, err := buildAssetAdministrationShellQuery(&dialect, aas)
-	if err != nil {
+	batch := &common.PostgreSQLBatch{}
+	if err := batch.AppendDataset(dialect.Insert("aas").Rows(goqu.Record{
+		"aas_id":   aas.ID(),
+		"category": aas.Category(),
+		"id_short": aas.IDShort(),
+	})); err != nil {
 		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDINSERTSQL " + err.Error())
 	}
-
-	var aasDBID int64
-	if err := tx.QueryRow(ids, args...).Scan(&aasDBID); err != nil {
-		if mappedErr := mapCreateAASInsertError(err); mappedErr != nil {
-			return mappedErr
-		}
-		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECINSERTSQL " + err.Error())
-	}
-
+	aasDBID := common.PostgreSQLCurrentSequenceValue("aas", "id")
 	jsonizedPayload, err := jsonizeAssetAdministrationShellPayload(aas)
 	if err != nil {
 		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-JSON " + err.Error())
 	}
-
-	ids, args, err = buildAssetAdministrationShellPayloadQuery(
-		&dialect,
-		aasDBID,
-		jsonizedPayload.description,
-		jsonizedPayload.displayName,
-		jsonizedPayload.administrativeInformation,
-		jsonizedPayload.embeddedDataSpecification,
-		jsonizedPayload.extensions,
-		jsonizedPayload.derivedFrom,
-	)
-	if err != nil {
+	if err = batch.AppendDataset(dialect.Insert("aas_payload").Rows(goqu.Record{
+		"aas_id":                              aasDBID,
+		"administrative_information_payload":  jsonizedPayload.administrativeInformation,
+		"derived_from_payload":                jsonizedPayload.derivedFrom,
+		"description_payload":                 jsonizedPayload.description,
+		"displayname_payload":                 jsonizedPayload.displayName,
+		"embedded_data_specification_payload": jsonizedPayload.embeddedDataSpecification,
+		"extensions_payload":                  jsonizedPayload.extensions,
+	})); err != nil {
 		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDPAYLOADSQL " + err.Error())
 	}
-
-	if _, err := tx.Exec(ids, args...); err != nil {
-		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECPAYLOADSQL " + err.Error())
-	}
-
-	// asset information
-	ids, args, err = buildAssetInformationQuery(
-		&dialect,
-		aasDBID,
-		aas.AssetInformation(),
-	)
-	if err != nil {
+	assetInformation := aas.AssetInformation()
+	if err = batch.AppendDataset(dialect.Insert("asset_information").Rows(goqu.Record{
+		"asset_information_id": aasDBID,
+		"asset_kind":           assetInformation.AssetKind(),
+		"asset_type":           assetInformation.AssetType(),
+		"global_asset_id":      assetInformation.GlobalAssetID(),
+	})); err != nil {
 		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDASSETINFORMATIONSQL " + err.Error())
 	}
-
-	if _, err := tx.Exec(ids, args...); err != nil {
-		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECASSETINFORMATIONSQL " + err.Error())
-	}
-
-	if err := upsertDefaultThumbnailForAssetInformation(tx, &dialect, aasDBID, aas.AssetInformation(), "AASREPO-NEWAAS-CREATE", false); err != nil {
+	if err = appendAASCreateThumbnail(batch, dialect, aasDBID, assetInformation); err != nil {
 		return err
 	}
-
-	// specific asset ids
-	err = common.CreateSpecificAssetIDForAssetInformation(tx, aasDBID, aas.AssetInformation().SpecificAssetIDs())
-	if err != nil {
+	if err = batch.AppendAssetInformationSpecificAssetIDs(aasDBID, assetInformation.SpecificAssetIDs()); err != nil {
 		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-CREATESPECIFICASSETIDS " + err.Error())
 	}
+	if err = appendAASCreateSubmodelReferences(batch, dialect, aasDBID, aas.Submodels()); err != nil {
+		return err
+	}
+	if err = common.ExecutePostgreSQLBatchInTransaction(ctx, tx, batch.Statements()); err != nil {
+		if mappedErr := mapCreateAASInsertError(err); mappedErr != nil {
+			return mappedErr
+		}
+		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECBATCH " + err.Error())
+	}
+	return nil
+}
 
-	// submodel references
-	for position, submodelRef := range aas.Submodels() {
-		ids, args, err = buildAssetAdministrationShellSubmodelReferenceQuery(&dialect, aasDBID, position, submodelRef)
-		if err != nil {
+func appendAASCreateThumbnail(batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, aasDBID any, assetInformation types.IAssetInformation) error {
+	thumbnail, thumbnailPath := defaultThumbnailWithPath(assetInformation)
+	if thumbnail == nil {
+		return nil
+	}
+	if err := batch.AppendDataset(dialect.Insert("thumbnail_file_element").Rows(goqu.Record{
+		"content_type": thumbnail.ContentType(),
+		"file_name":    nil,
+		"id":           aasDBID,
+		"value":        thumbnailPath,
+	})); err != nil {
+		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDTHUMBNAILSQL " + err.Error())
+	}
+	return nil
+}
+
+func appendAASCreateSubmodelReferences(batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, aasDBID any, references []types.IReference) error {
+	for position, reference := range references {
+		if err := batch.AppendDataset(dialect.Insert("aas_submodel_reference").Rows(goqu.Record{
+			"aas_id":   aasDBID,
+			"position": position,
+			"type":     int(reference.Type()),
+		})); err != nil {
 			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDSUBMODELREFSQL " + err.Error())
 		}
-
-		var aasSubmodelReferenceDBID int64
-		if err := tx.QueryRow(ids, args...).Scan(&aasSubmodelReferenceDBID); err != nil {
-			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECSUBMODELREFSQL " + err.Error())
+		referenceID := common.PostgreSQLCurrentSequenceValue("aas_submodel_reference", "id")
+		keyRows := make([]goqu.Record, 0, len(reference.Keys()))
+		for keyPosition, key := range reference.Keys() {
+			keyRows = append(keyRows, goqu.Record{
+				"position":     keyPosition,
+				"reference_id": referenceID,
+				"type":         int(key.Type()),
+				"value":        key.Value(),
+			})
 		}
-
-		ids, args, err = buildAssetAdministrationShellSubmodelReferenceKeysQuery(&dialect, aasSubmodelReferenceDBID, submodelRef)
-		if err != nil {
+		if len(keyRows) == 0 {
+			return common.NewErrBadRequest("AASREPO-NEWAAS-CREATE-SUBMODELREFNOKEYS reference must contain at least one key")
+		}
+		if err := batch.AppendDataset(dialect.Insert("aas_submodel_reference_key").Rows(keyRows)); err != nil {
 			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDSUBMODELREFKEYSSQL " + err.Error())
 		}
-
-		if _, err := tx.Exec(ids, args...); err != nil {
-			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECSUBMODELREFKEYSSQL " + err.Error())
-		}
-
-		ids, args, err = buildAssetAdministrationShellSubmodelReferencePayloadQuery(&dialect, aasSubmodelReferenceDBID, submodelRef)
+		jsonable, err := jsonization.ToJsonable(reference)
 		if err != nil {
-			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDSUBMODELREFPAYLOADSSQL " + err.Error())
+			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDSUBMODELREFPAYLOAD " + err.Error())
 		}
-
-		if _, err := tx.Exec(ids, args...); err != nil {
-			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECSUBMODELREFPAYLOADSSQL " + err.Error())
+		payload, err := json.Marshal(jsonable)
+		if err != nil {
+			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-MARSHALSUBMODELREFPAYLOAD " + err.Error())
+		}
+		if err = batch.AppendDataset(dialect.Insert("aas_submodel_reference_payload").Rows(goqu.Record{
+			"parent_reference_payload": goqu.L("?::jsonb", string(payload)),
+			"reference_id":             referenceID,
+		})); err != nil {
+			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDSUBMODELREFPAYLOADSSQL " + err.Error())
 		}
 	}
 	return nil
@@ -1156,7 +1175,7 @@ func (s *AssetAdministrationShellDatabase) putAssetAdministrationShellByIDInTran
 			return PutAssetAdministrationShellResult{}, reconciliationErr
 		}
 	} else {
-		if err := s.createAssetAdministrationShellInTransaction(tx, aas); err != nil {
+		if err := s.createAssetAdministrationShellInTransaction(ctx, tx, aas); err != nil {
 			return PutAssetAdministrationShellResult{}, err
 		}
 	}
@@ -1278,30 +1297,29 @@ func (s *AssetAdministrationShellDatabase) DeleteAssetAdministrationShellByIDInT
 		return err
 	}
 
-	if err = cleanupThumbnailLargeObjectsByAASDBID(tx, &dialect, aasDBID, "AASREPO-DELAAS"); err != nil {
+	if err = cleanupAndDeleteAASByDatabaseID(ctx, tx, &dialect, aasDBID); err != nil {
 		return err
 	}
 
-	sqlQuery, args, buildErr := buildDeleteAssetAdministrationShellByDBIDQuery(&dialect, aasDBID)
-	if buildErr != nil {
-		return common.NewInternalServerError("AASREPO-DELAAS-BUILDSQL " + buildErr.Error())
-	}
-
-	result, execErr := tx.Exec(sqlQuery, args...)
-	if execErr != nil {
-		return common.NewInternalServerError("AASREPO-DELAAS-EXECSQL " + execErr.Error())
-	}
-
-	rowsAffected, rowsErr := result.RowsAffected()
-	if rowsErr != nil {
-		return common.NewInternalServerError("AASREPO-DELAAS-GETROWCOUNT " + rowsErr.Error())
-	}
-
-	if rowsAffected == 0 {
-		return common.NewErrNotFound("AASREPO-DELAAS-AASNOTFOUND Asset Administration Shell with ID '" + aasIdentifier + "' not found")
-	}
-
 	return history.AppendVersionTx(ctx, tx, history.TableAAS, aasIdentifier, history.ChangeDeleted, previousSnapshot, map[string]any{"id": aasIdentifier}, true)
+}
+
+func cleanupAndDeleteAASByDatabaseID(ctx context.Context, tx *sql.Tx, dialect *goqu.DialectWrapper, aasDBID int64) error {
+	cleanupQuery, cleanupArgs, err := buildCleanupThumbnailLargeObjectsByAASDBIDQuery(dialect, aasDBID)
+	if err != nil {
+		return common.NewInternalServerError("AASREPO-DELAAS-BUILDUNLINKLO " + err.Error())
+	}
+	deleteQuery, deleteArgs, err := buildDeleteAssetAdministrationShellByDBIDQuery(dialect, aasDBID)
+	if err != nil {
+		return common.NewInternalServerError("AASREPO-DELAAS-BUILDSQL " + err.Error())
+	}
+	batch := &common.PostgreSQLBatch{}
+	batch.AppendStatement(cleanupQuery, cleanupArgs...)
+	batch.AppendStatement(deleteQuery, deleteArgs...)
+	if err = common.ExecutePostgreSQLBatchInTransaction(ctx, tx, batch.Statements()); err != nil {
+		return common.NewInternalServerError("AASREPO-DELAAS-EXECBATCH " + err.Error())
+	}
+	return nil
 }
 
 func getAssetAdministrationShellDBIDForDelete(tx *sql.Tx, aasIdentifier string) (int64, error) {
@@ -1313,19 +1331,6 @@ func getAssetAdministrationShellDBIDForDelete(tx *sql.Tx, aasIdentifier string) 
 		return 0, common.NewInternalServerError("AASREPO-DELAAS-EXECSELECT " + scanErr.Error())
 	}
 	return aasDBID, nil
-}
-
-func cleanupThumbnailLargeObjectsByAASDBID(tx *sql.Tx, dialect *goqu.DialectWrapper, aasDBID int64, errorPrefix string) error {
-	query, args, buildErr := buildCleanupThumbnailLargeObjectsByAASDBIDQuery(dialect, aasDBID)
-	if buildErr != nil {
-		return common.NewInternalServerError(errorPrefix + "-BUILDUNLINKLO " + buildErr.Error())
-	}
-
-	var unlinkedCount int64
-	if scanErr := tx.QueryRow(query, args...).Scan(&unlinkedCount); scanErr != nil {
-		return common.NewInternalServerError(errorPrefix + "-UNLINKLO " + scanErr.Error())
-	}
-	return nil
 }
 
 // GetAssetAdministrationShellReferences returns paginated model references while preserving ABAC filters from ctx.
@@ -1556,85 +1561,6 @@ func (s *AssetAdministrationShellDatabase) loadAssetInformationForReconciliation
 	return buildAssetInformationFromCoreRow(row, specificAssetIDs), nil
 }
 
-func upsertDefaultThumbnailForAssetInformation(
-	tx *sql.Tx,
-	dialect *goqu.DialectWrapper,
-	aasDBID int64,
-	assetInformation types.IAssetInformation,
-	errorPrefix string,
-	replaceExisting bool,
-) error {
-	thumbnail, thumbnailPath := defaultThumbnailWithPath(assetInformation)
-	if replaceExisting || thumbnail != nil {
-		if err := clearInternalThumbnailStorageTx(tx, aasDBID, errorPrefix); err != nil {
-			return err
-		}
-	}
-	if thumbnail == nil {
-		if !replaceExisting {
-			return nil
-		}
-		deleteSQL, deleteArgs, buildErr := dialect.Delete("thumbnail_file_element").
-			Where(goqu.C("id").Eq(aasDBID)).ToSQL()
-		if buildErr != nil {
-			return common.NewInternalServerError(errorPrefix + "-BUILDDELETETHUMBNAILSQL " + buildErr.Error())
-		}
-		if _, execErr := tx.Exec(deleteSQL, deleteArgs...); execErr != nil {
-			return common.NewInternalServerError(errorPrefix + "-EXECDELETETHUMBNAILSQL " + execErr.Error())
-		}
-		return nil
-	}
-
-	upsertSQL, upsertArgs, buildErr := buildUpsertDefaultThumbnailQuery(dialect, aasDBID, thumbnail, thumbnailPath)
-	if buildErr != nil {
-		return common.NewInternalServerError(errorPrefix + "-BUILDTHUMBNAILSQL " + buildErr.Error())
-	}
-
-	if _, execErr := tx.Exec(upsertSQL, upsertArgs...); execErr != nil {
-		return common.NewInternalServerError(errorPrefix + "-EXECTHUMBNAILSQL " + execErr.Error())
-	}
-
-	return nil
-}
-
-func clearInternalThumbnailStorageTx(tx *sql.Tx, aasDBID int64, errorPrefix string) error {
-	deleteReferenceSQL, deleteReferenceArgs, err := goqu.Delete(binarycontent.TableThumbnailReference).
-		Where(goqu.C("thumbnail_element_id").Eq(aasDBID)).ToSQL()
-	if err != nil {
-		return common.NewInternalServerError(errorPrefix + "-BUILDDELETETHUMBREF " + err.Error())
-	}
-	if _, err = tx.Exec(deleteReferenceSQL, deleteReferenceArgs...); err != nil {
-		return common.NewInternalServerError(errorPrefix + "-EXECDELETETHUMBREF " + err.Error())
-	}
-
-	selectLegacySQL, selectLegacyArgs, err := goqu.From("thumbnail_file_data").Select("file_oid").
-		Where(goqu.C("id").Eq(aasDBID)).ToSQL()
-	if err != nil {
-		return common.NewInternalServerError(errorPrefix + "-BUILDGETTHUMBLO " + err.Error())
-	}
-	var oid sql.NullInt64
-	if err = tx.QueryRow(selectLegacySQL, selectLegacyArgs...).Scan(&oid); err != nil && err != sql.ErrNoRows {
-		return common.NewInternalServerError(errorPrefix + "-EXECGETTHUMBLO " + err.Error())
-	}
-	if oid.Valid {
-		unlinkSQL, unlinkArgs, buildErr := goqu.Select(goqu.Func("lo_unlink", oid.Int64)).ToSQL()
-		if buildErr != nil {
-			return common.NewInternalServerError(errorPrefix + "-BUILDUNLINKTHUMBLO " + buildErr.Error())
-		}
-		if _, err = tx.Exec(unlinkSQL, unlinkArgs...); err != nil {
-			return common.NewInternalServerError(errorPrefix + "-EXECUNLINKTHUMBLO " + err.Error())
-		}
-	}
-	deleteLegacySQL, deleteLegacyArgs, err := goqu.Delete("thumbnail_file_data").Where(goqu.C("id").Eq(aasDBID)).ToSQL()
-	if err != nil {
-		return common.NewInternalServerError(errorPrefix + "-BUILDDELETETHUMBLO " + err.Error())
-	}
-	if _, err = tx.Exec(deleteLegacySQL, deleteLegacyArgs...); err != nil {
-		return common.NewInternalServerError(errorPrefix + "-EXECDELETETHUMBLO " + err.Error())
-	}
-	return nil
-}
-
 func defaultThumbnailWithPath(assetInformation types.IAssetInformation) (types.IResource, string) {
 	if assetInformation == nil || assetInformation.DefaultThumbnail() == nil {
 		return nil, ""
@@ -1651,29 +1577,6 @@ func defaultThumbnailWithPath(assetInformation types.IAssetInformation) (types.I
 	}
 
 	return thumbnail, thumbnailPath
-}
-
-func buildUpsertDefaultThumbnailQuery(
-	dialect *goqu.DialectWrapper,
-	aasDBID int64,
-	thumbnail types.IResource,
-	thumbnailPath string,
-) (string, []any, error) {
-	record := goqu.Record{
-		"id":           aasDBID,
-		"content_type": thumbnail.ContentType(),
-		"file_name":    nil,
-		"value":        thumbnailPath,
-	}
-
-	return dialect.Insert("thumbnail_file_element").
-		Rows(record).
-		OnConflict(goqu.DoUpdate("id", goqu.Record{
-			"content_type": goqu.COALESCE(goqu.I("excluded.content_type"), goqu.I("thumbnail_file_element.content_type")),
-			"file_name":    nil,
-			"value":        thumbnailPath,
-		})).
-		ToSQL()
 }
 
 func (s *AssetAdministrationShellDatabase) ensureAASVisibleAfterAssetInformationUpdate(

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -32,6 +32,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -53,6 +54,7 @@ import (
 	commonmodel "github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
 	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // AssetAdministrationShellDatabase is the implementation of the AssetAdministrationShellRepositoryDatabase interface using PostgreSQL as the underlying database.
@@ -498,15 +500,15 @@ func (s *AssetAdministrationShellDatabase) CreateAssetAdministrationShellInTrans
 // createAssetAdministrationShellInTransaction creates an AAS and all dependent records within an existing transaction.
 func (s *AssetAdministrationShellDatabase) createAssetAdministrationShellInTransaction(ctx context.Context, tx *sql.Tx, aas types.IAssetAdministrationShell) error {
 	dialect := goqu.Dialect("postgres")
-	batch := &common.PostgreSQLBatch{}
-	if err := batch.AppendDataset(dialect.Insert("aas").Rows(goqu.Record{
-		"aas_id":   aas.ID(),
-		"category": aas.Category(),
-		"id_short": aas.IDShort(),
-	})); err != nil {
-		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDINSERTSQL " + err.Error())
+	if err := validateAASCreateSubmodelReferences(aas.Submodels()); err != nil {
+		return err
 	}
-	aasDBID := common.PostgreSQLCurrentSequenceValue("aas", "id")
+	aasDBID, err := insertAASCreateRoot(ctx, tx, dialect, aas)
+	if err != nil {
+		return err
+	}
+
+	batch := &common.PostgreSQLBatch{}
 	jsonizedPayload, err := jsonizeAssetAdministrationShellPayload(aas)
 	if err != nil {
 		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-JSON " + err.Error())
@@ -541,10 +543,36 @@ func (s *AssetAdministrationShellDatabase) createAssetAdministrationShellInTrans
 		return err
 	}
 	if err = common.ExecutePostgreSQLBatchInTransaction(ctx, tx, batch.Statements()); err != nil {
+		return fmt.Errorf("%s %w", common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECBATCH"), err)
+	}
+	return nil
+}
+
+func insertAASCreateRoot(ctx context.Context, tx *sql.Tx, dialect goqu.DialectWrapper, aas types.IAssetAdministrationShell) (int64, error) {
+	query, args, err := dialect.Insert("aas").Rows(goqu.Record{
+		"aas_id":   aas.ID(),
+		"category": aas.Category(),
+		"id_short": aas.IDShort(),
+	}).Returning(goqu.C("id")).Prepared(true).ToSQL()
+	if err != nil {
+		return 0, common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDINSERTSQL " + err.Error())
+	}
+
+	var aasDBID int64
+	if err = tx.QueryRowContext(ctx, query, args...).Scan(&aasDBID); err != nil {
 		if mappedErr := mapCreateAASInsertError(err); mappedErr != nil {
-			return mappedErr
+			return 0, mappedErr
 		}
-		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECBATCH " + err.Error())
+		return 0, fmt.Errorf("%s %w", common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECINSERT"), err)
+	}
+	return aasDBID, nil
+}
+
+func validateAASCreateSubmodelReferences(references []types.IReference) error {
+	for _, reference := range references {
+		if reference == nil || len(reference.Keys()) == 0 {
+			return common.NewErrBadRequest("AASREPO-NEWAAS-CREATE-SUBMODELREFNOKEYS reference must contain at least one key")
+		}
 	}
 	return nil
 }
@@ -584,9 +612,6 @@ func appendAASCreateSubmodelReferences(batch *common.PostgreSQLBatch, dialect go
 				"value":        key.Value(),
 			})
 		}
-		if len(keyRows) == 0 {
-			return common.NewErrBadRequest("AASREPO-NEWAAS-CREATE-SUBMODELREFNOKEYS reference must contain at least one key")
-		}
 		if err := batch.AppendDataset(dialect.Insert("aas_submodel_reference_key").Rows(keyRows)); err != nil {
 			return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDSUBMODELREFKEYSSQL " + err.Error())
 		}
@@ -608,13 +633,10 @@ func appendAASCreateSubmodelReferences(batch *common.PostgreSQLBatch, dialect go
 	return nil
 }
 
-// mapCreateAASInsertError maps database uniqueness violations to domain-specific conflict errors.
+// mapCreateAASInsertError maps root AAS uniqueness violations to domain-specific conflict errors.
 func mapCreateAASInsertError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	if common.IsPostgresUniqueViolation(err) {
+	var postgresErr *pgconn.PgError
+	if errors.As(err, &postgresErr) && postgresErr.Code == "23505" && postgresErr.ConstraintName == "aas_aas_id_key" {
 		return common.NewErrConflict("AASREPO-NEWAAS-CONFLICT AAS with given id already exists")
 	}
 

--- a/internal/aasrepository/persistence/aas_database_query_utils.go
+++ b/internal/aasrepository/persistence/aas_database_query_utils.go
@@ -54,35 +54,6 @@ func buildPageLimitPlusOne(limit int32) (uint, error) {
 	return uint(pageLimitPlusOne), nil
 }
 
-func buildAssetAdministrationShellQuery(dialect *goqu.DialectWrapper, aas types.IAssetAdministrationShell) (string, []any, error) {
-	return dialect.Insert("aas").Rows(goqu.Record{
-		"aas_id":   aas.ID(),
-		"id_short": aas.IDShort(),
-		"category": aas.Category(),
-	}).Returning(goqu.I("id")).ToSQL()
-}
-
-func buildAssetAdministrationShellPayloadQuery(dialect *goqu.DialectWrapper, aasDBID int64, descriptionJsonString *string, displayNameJsonString *string, administrativeInformationJsonString *string, edsJsonString *string, extensionJsonString *string, derivedFromJsonString *string) (string, []any, error) {
-	return dialect.Insert("aas_payload").Rows(goqu.Record{
-		"aas_id":                              aasDBID,
-		"description_payload":                 descriptionJsonString,
-		"displayname_payload":                 displayNameJsonString,
-		"administrative_information_payload":  administrativeInformationJsonString,
-		"embedded_data_specification_payload": edsJsonString,
-		"extensions_payload":                  extensionJsonString,
-		"derived_from_payload":                derivedFromJsonString,
-	}).ToSQL()
-}
-
-func buildAssetInformationQuery(dialect *goqu.DialectWrapper, aasDBID int64, asset_information types.IAssetInformation) (string, []any, error) {
-	return dialect.Insert("asset_information").Rows(goqu.Record{
-		"asset_information_id": aasDBID,
-		"asset_kind":           asset_information.AssetKind(),
-		"global_asset_id":      asset_information.GlobalAssetID(),
-		"asset_type":           asset_information.AssetType(),
-	}).ToSQL()
-}
-
 func buildGetAssetInformationReconciliationStateQuery(dialect *goqu.DialectWrapper, aasDBID int64) (string, []any, error) {
 	return dialect.
 		From(goqu.T("asset_information").As("asset_information")).
@@ -331,7 +302,6 @@ func buildDeleteAssetAdministrationShellByDBIDQuery(dialect *goqu.DialectWrapper
 
 func buildCleanupThumbnailLargeObjectsByAASDBIDQuery(dialect *goqu.DialectWrapper, aasDBID int64) (string, []any, error) {
 	unlinkSubquery := dialect.From(goqu.T("thumbnail_file_data").As("tfd")).
-		Prepared(true).
 		Select(goqu.Func("lo_unlink", goqu.I("tfd.file_oid")).As("unlink_result")).
 		Where(
 			goqu.I("tfd.id").Eq(aasDBID),
@@ -339,7 +309,6 @@ func buildCleanupThumbnailLargeObjectsByAASDBIDQuery(dialect *goqu.DialectWrappe
 		)
 
 	return dialect.From(unlinkSubquery.As("unlink_results")).
-		Prepared(true).
 		Select(goqu.COUNT("*")).
 		ToSQL()
 }

--- a/internal/aasrepository/persistence/aas_large_object_cleanup_test.go
+++ b/internal/aasrepository/persistence/aas_large_object_cleanup_test.go
@@ -48,9 +48,7 @@ func TestDeleteAssetAdministrationShellCleansThumbnailLargeObjectBeforeDelete(t 
 
 	mock.ExpectQuery(`SELECT .*FROM "aas".*FOR UPDATE`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
-	mock.ExpectQuery(`SELECT COUNT\(\*\).*lo_unlink.*thumbnail_file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
-	mock.ExpectExec(`DELETE FROM "aas"`).
+	mock.ExpectExec(`(?s)SELECT COUNT\(\*\).*lo_unlink.*thumbnail_file_data.*DELETE FROM "aas"`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectRollback()
 

--- a/internal/common/createprecheck/create.go
+++ b/internal/common/createprecheck/create.go
@@ -92,6 +92,13 @@ func EnsureVisibleDuplicate(
 	return common.NewErrConflict(conflictMessage)
 }
 
+// CanSkipExistenceCheck reports whether create authorization cannot hide an
+// existing resource. Callers may rely on the database uniqueness constraint in
+// this case and avoid a successful-create lookup.
+func CanSkipExistenceCheck(ctx context.Context) bool {
+	return canSkipDuplicateVisibilityRead(ctx)
+}
+
 func canSkipDuplicateVisibilityRead(ctx context.Context) bool {
 	queryFilter := auth.GetQueryFilter(ctx)
 	if queryFilter == nil {

--- a/internal/common/createprecheck/create_test.go
+++ b/internal/common/createprecheck/create_test.go
@@ -143,6 +143,14 @@ func TestEnsureVisibleCreateAllowsMissingDescriptor(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCanSkipExistenceCheckRequiresUnrestrictedCreate(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, CanSkipExistenceCheck(t.Context()))
+	ctx := auth.WithQueryFilter(t.Context(), limitedCreateQueryFilter())
+	require.False(t, CanSkipExistenceCheck(ctx))
+}
+
 func TestEnsureVisibleDuplicateAllowsMissingDescriptor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/common/database.go
+++ b/internal/common/database.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	CURRENT_DATABASE_VERSION = "v1.1.13"
+	CURRENT_DATABASE_VERSION = "v1.1.14"
 	cleanSchemaState         = "clean"
 )
 

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -137,6 +137,25 @@ func CanSkipPostInsertReadback(ctx context.Context) bool {
 	return CanSkipCreateReadback(ctx)
 }
 
+// CanSkipDeleteReadback reports whether deletion needs no descriptor read for
+// authorization. History callers must check mutation recording separately.
+func CanSkipDeleteReadback(ctx context.Context) bool {
+	queryFilter := auth.GetQueryFilter(ctx)
+	if queryFilter == nil {
+		return true
+	}
+	if len(queryFilter.Filters) > 0 {
+		return false
+	}
+	if len(queryFilter.FormulasByRight) > 0 {
+		return auth.HasUnrestrictedFormulaForRight(ctx, grammar.RightsEnumDELETE)
+	}
+	if queryFilter.Formula == nil {
+		return true
+	}
+	return auth.HasUnrestrictedFormulaForRight(ctx, grammar.RightsEnumDELETE)
+}
+
 // InsertAdministrationShellDescriptorTx performs the same insert as
 // InsertAdministrationShellDescriptor but uses the provided transaction. This allows
 // callers to compose multiple writes into a single atomic unit.
@@ -605,28 +624,14 @@ func deleteAssetAdministrationShellDescriptorByIDTx(ctx context.Context, tx *sql
 		Select(common.ColDescriptorID).
 		Where(goqu.C(common.ColAASDescriptorID).Eq(descID))
 
-	childDelStr, childDelArgs, buildChildDelErr := d.
-		Delete(common.TblDescriptor).
-		Where(goqu.C(common.ColID).In(childDescriptorIDs)).
-		ToSQL()
-	if buildChildDelErr != nil {
-		return buildChildDelErr
+	batch := &common.PostgreSQLBatch{}
+	if err := batch.AppendDataset(d.Delete(common.TblDescriptor).Where(goqu.C(common.ColID).In(childDescriptorIDs))); err != nil {
+		return common.NewInternalServerError("AASDESC-DELETE-BUILDCHILDSQL " + err.Error())
 	}
-	if _, execErr := tx.ExecContext(ctx, childDelStr, childDelArgs...); execErr != nil {
-		return execErr
+	if err := batch.AppendDataset(d.Delete(common.TblDescriptor).Where(goqu.C(common.ColID).Eq(descID))); err != nil {
+		return common.NewInternalServerError("AASDESC-DELETE-BUILDPARENTSQL " + err.Error())
 	}
-
-	parentDelStr, parentDelArgs, buildParentDelErr := d.
-		Delete(common.TblDescriptor).
-		Where(goqu.C(common.ColID).Eq(descID)).
-		ToSQL()
-	if buildParentDelErr != nil {
-		return buildParentDelErr
-	}
-	if _, execErr := tx.ExecContext(ctx, parentDelStr, parentDelArgs...); execErr != nil {
-		return execErr
-	}
-	return nil
+	return common.ExecutePostgreSQLBatchInTransaction(ctx, tx, batch.Statements())
 }
 
 // ReplaceAdministrationShellDescriptor atomically replaces the descriptor with

--- a/internal/common/descriptors/SubModelDescriptorHandler.go
+++ b/internal/common/descriptors/SubModelDescriptorHandler.go
@@ -842,22 +842,22 @@ func deleteSubmodelDescriptorByIDTx(
 		).
 		Limit(1)
 
-	sqlStr, args, buildErr := ds.ToSQL()
+	delSQL, delArgs, buildErr := d.Delete(common.TblDescriptor).
+		Where(goqu.C(common.ColID).In(ds)).
+		ToSQL()
 	if buildErr != nil {
-		return common.NewInternalServerError("Failed to build submodel lookup query. See server logs for details.")
+		return common.NewInternalServerError("SMDESC-DELETE-BUILDSQL " + buildErr.Error())
 	}
-	var descID int64
-	if err := tx.QueryRowContext(ctx, sqlStr, args...).Scan(&descID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return common.NewErrNotFound("Submodel Descriptor not found")
-		}
-		return common.NewInternalServerError("Failed to query submodel descriptor id. See server logs for details.")
+	result, err := tx.ExecContext(ctx, delSQL, delArgs...)
+	if err != nil {
+		return common.NewInternalServerError("SMDESC-DELETE-EXECSQL " + err.Error())
 	}
-
-	delSQL, delArgs, delErr := d.Delete(common.TblDescriptor).Where(goqu.C(common.ColID).Eq(descID)).ToSQL()
-	if delErr != nil {
-		return delErr
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return common.NewInternalServerError("SMDESC-DELETE-ROWSAFFECTED " + err.Error())
 	}
-	_, err := tx.Exec(delSQL, delArgs...)
-	return err
+	if deleted == 0 {
+		return common.NewErrNotFound("Submodel Descriptor not found")
+	}
+	return nil
 }

--- a/internal/common/descriptors/create_readback_test.go
+++ b/internal/common/descriptors/create_readback_test.go
@@ -104,3 +104,27 @@ func TestCanSkipCreateReadbackRequiresUnrestrictedCreateFormula(t *testing.T) {
 		})
 	}
 }
+
+func TestCanSkipDeleteReadbackRequiresUnrestrictedDeleteFormula(t *testing.T) {
+	t.Parallel()
+
+	allow := true
+	deny := false
+	restricted := auth.WithQueryFilter(t.Context(), &auth.QueryFilter{
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumDELETE: {Boolean: &deny},
+		},
+	})
+	unrestricted := auth.WithQueryFilter(t.Context(), &auth.QueryFilter{
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumDELETE: {Boolean: &allow},
+		},
+	})
+
+	if CanSkipDeleteReadback(restricted) {
+		t.Fatal("restricted delete must retain descriptor readback")
+	}
+	if !CanSkipDeleteReadback(unrestricted) {
+		t.Fatal("unrestricted delete should skip descriptor readback")
+	}
+}

--- a/internal/common/postgres_batch.go
+++ b/internal/common/postgres_batch.go
@@ -37,6 +37,12 @@ import (
 	"github.com/jackc/pgx/v5/stdlib"
 )
 
+const (
+	postgreSQLBatchMaxStatements = 1000
+	postgreSQLBatchMaxBytes      = 4 * 1024 * 1024
+	postgreSQLBatchSeparator     = ";\n"
+)
+
 // PostgreSQLBatchStatement is one rendered PostgreSQL statement and the values
 // that must be passed when executing it with pgx batch support.
 type PostgreSQLBatchStatement struct {
@@ -143,15 +149,42 @@ func executePostgreSQLBatchInTransaction(
 	if len(statements) == 0 {
 		return NewErrBadRequest("COMMON-PGBATCH-EMPTY no statements supplied")
 	}
-
-	queries := make([]string, 0, len(statements))
 	for _, statement := range statements {
 		if len(statement.Args) != 0 {
 			return NewInternalServerError("COMMON-PGBATCH-PARAMS collected statement contains unresolved parameters")
 		}
-		queries = append(queries, statement.SQL)
 	}
-	query := strings.Join(queries, ";\n")
+
+	for start := 0; start < len(statements); {
+		query, end := collectPostgreSQLBatchQuery(statements, start)
+		if err := executePostgreSQLBatchQuery(ctx, tx, query); err != nil {
+			return err
+		}
+		start = end
+	}
+	return nil
+}
+
+func collectPostgreSQLBatchQuery(statements []PostgreSQLBatchStatement, start int) (string, int) {
+	queries := make([]string, 0, postgreSQLBatchMaxStatements)
+	queryBytes := 0
+	end := start
+	for end < len(statements) && len(queries) < postgreSQLBatchMaxStatements {
+		statementBytes := len(statements[end].SQL)
+		if len(queries) != 0 {
+			statementBytes += len(postgreSQLBatchSeparator)
+		}
+		if len(queries) != 0 && queryBytes+statementBytes > postgreSQLBatchMaxBytes {
+			break
+		}
+		queries = append(queries, statements[end].SQL)
+		queryBytes += statementBytes
+		end++
+	}
+	return strings.Join(queries, postgreSQLBatchSeparator), end
+}
+
+func executePostgreSQLBatchQuery(ctx *context.Context, tx *sql.Tx, query string) error {
 	var err error
 	if ctx == nil {
 		_, err = tx.Exec(query)

--- a/internal/common/postgres_batch.go
+++ b/internal/common/postgres_batch.go
@@ -90,6 +90,11 @@ func (b *PostgreSQLBatch) AppendDataset(dataset sqlDataset) error {
 	return nil
 }
 
+// AppendStatement appends an already rendered SQL statement to the batch.
+func (b *PostgreSQLBatch) AppendStatement(query string, args ...any) {
+	b.statements = append(b.statements, PostgreSQLBatchStatement{SQL: query, Args: args})
+}
+
 // Statements returns the statements collected in append order.
 //
 // Returns:
@@ -115,6 +120,23 @@ func ExecutePostgreSQLBatchInTransaction(
 	tx *sql.Tx,
 	statements []PostgreSQLBatchStatement,
 ) error {
+	return executePostgreSQLBatchInTransaction(&ctx, tx, statements)
+}
+
+// ExecutePostgreSQLBatchInTransactionWithoutContext executes rendered
+// statements for legacy callers whose API does not carry a request context.
+func ExecutePostgreSQLBatchInTransactionWithoutContext(
+	tx *sql.Tx,
+	statements []PostgreSQLBatchStatement,
+) error {
+	return executePostgreSQLBatchInTransaction(nil, tx, statements)
+}
+
+func executePostgreSQLBatchInTransaction(
+	ctx *context.Context,
+	tx *sql.Tx,
+	statements []PostgreSQLBatchStatement,
+) error {
 	if tx == nil {
 		return NewErrBadRequest("COMMON-PGBATCH-NILTX transaction must not be nil")
 	}
@@ -129,7 +151,14 @@ func ExecutePostgreSQLBatchInTransaction(
 		}
 		queries = append(queries, statement.SQL)
 	}
-	if _, err := tx.ExecContext(ctx, strings.Join(queries, ";\n")); err != nil {
+	query := strings.Join(queries, ";\n")
+	var err error
+	if ctx == nil {
+		_, err = tx.Exec(query)
+	} else {
+		_, err = tx.ExecContext(*ctx, query)
+	}
+	if err != nil {
 		return internalServerErrorWithCause("COMMON-PGBATCH-EXEC", err)
 	}
 	return nil

--- a/internal/common/postgres_batch_descriptor.go
+++ b/internal/common/postgres_batch_descriptor.go
@@ -171,11 +171,39 @@ func (b *PostgreSQLBatch) AppendSpecificAssetIDs(
 	aasRef any,
 	specificAssetIDs []types.ISpecificAssetID,
 ) error {
+	return b.appendSpecificAssetIDs(
+		descriptorID,
+		sql.NullInt64{},
+		aasRef,
+		specificAssetIDs,
+	)
+}
+
+// AppendAssetInformationSpecificAssetIDs appends specific asset IDs owned by
+// an AssetInformation row.
+func (b *PostgreSQLBatch) AppendAssetInformationSpecificAssetIDs(
+	assetInformationID any,
+	specificAssetIDs []types.ISpecificAssetID,
+) error {
+	return b.appendSpecificAssetIDs(
+		sql.NullInt64{},
+		assetInformationID,
+		sql.NullInt64{},
+		specificAssetIDs,
+	)
+}
+
+func (b *PostgreSQLBatch) appendSpecificAssetIDs(
+	descriptorID any,
+	assetInformationID any,
+	aasRef any,
+	specificAssetIDs []types.ISpecificAssetID,
+) error {
 	dialect := goqu.Dialect(Dialect)
 	for position, assetID := range specificAssetIDs {
 		if err := b.AppendDataset(dialect.Insert(TblSpecificAssetID).Rows(goqu.Record{
 			ColDescriptorID:       descriptorID,
-			ColAssetInformationID: sql.NullInt64{},
+			ColAssetInformationID: assetInformationID,
 			ColPosition:           position,
 			ColName:               assetID.Name(),
 			ColValue:              assetID.Value(),

--- a/internal/common/postgres_batch_test.go
+++ b/internal/common/postgres_batch_test.go
@@ -28,7 +28,9 @@ package common
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -113,5 +115,76 @@ func TestExecutePostgreSQLBatchInTransactionPreservesPostgresError(t *testing.T)
 	}
 	if err = mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestExecutePostgreSQLBatchInTransactionSplitsByStatementCountInOrder(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New returned error: %v", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx returned error: %v", err)
+	}
+
+	statements := make([]PostgreSQLBatchStatement, 0, postgreSQLBatchMaxStatements+1)
+	firstQueries := make([]string, 0, postgreSQLBatchMaxStatements)
+	for index := 0; index <= postgreSQLBatchMaxStatements; index++ {
+		query := fmt.Sprintf("SELECT %d", index)
+		statements = append(statements, PostgreSQLBatchStatement{SQL: query})
+		if index < postgreSQLBatchMaxStatements {
+			firstQueries = append(firstQueries, query)
+		}
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta(strings.Join(firstQueries, postgreSQLBatchSeparator))).
+		WillReturnResult(sqlmock.NewResult(0, int64(postgreSQLBatchMaxStatements)))
+	mock.ExpectExec(regexp.QuoteMeta(statements[postgreSQLBatchMaxStatements].SQL)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err = ExecutePostgreSQLBatchInTransaction(context.Background(), tx, statements); err != nil {
+		t.Fatalf("ExecutePostgreSQLBatchInTransaction returned error: %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err = tx.Rollback(); err != nil {
+		t.Fatalf("Rollback returned error: %v", err)
+	}
+	if err = mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestExecutePostgreSQLBatchInTransactionSplitsByRenderedBytes(t *testing.T) {
+	t.Parallel()
+
+	firstQuery := strings.Repeat("a", postgreSQLBatchMaxBytes+1)
+	secondQuery := "SELECT 2"
+	statements := []PostgreSQLBatchStatement{
+		{SQL: firstQuery},
+		{SQL: secondQuery},
+	}
+
+	query, end := collectPostgreSQLBatchQuery(statements, 0)
+	if end != 1 {
+		t.Fatalf("first batch ended at %d, want 1", end)
+	}
+	if query != firstQuery {
+		t.Fatal("first batch did not preserve the oversized statement")
+	}
+
+	query, end = collectPostgreSQLBatchQuery(statements, end)
+	if end != len(statements) {
+		t.Fatalf("second batch ended at %d, want %d", end, len(statements))
+	}
+	if query != secondQuery {
+		t.Fatalf("second batch query %q, want %q", query, secondQuery)
 	}
 }

--- a/internal/smregistry/persistence/PostgreSQLSMDatabase.go
+++ b/internal/smregistry/persistence/PostgreSQLSMDatabase.go
@@ -426,6 +426,9 @@ func (p *PostgreSQLSMDatabase) DeleteSubmodelDescriptorByID(
 	submodelID string,
 ) error {
 	return common.ExecuteInTransaction(p.writerDB, "SMREG-DELSMDESC-STARTTX", "SMREG-DELSMDESC-COMMITTX", func(tx *sql.Tx) error {
+		if !history.MutationRecordingEnabled() && descriptors.CanSkipDeleteReadback(ctx) {
+			return descriptors.DeleteSubmodelDescriptorByIDTx(ctx, tx, submodelID)
+		}
 		previousSnapshot, err := loadSubmodelDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, submodelID)
 		if err != nil {
 			return err
@@ -450,6 +453,9 @@ func (p *PostgreSQLSMDatabase) DeleteSubmodelDescriptorByIDInTransaction(
 ) error {
 	if tx == nil {
 		return common.NewInternalServerError("SMREG-DELSMDESC-NILTX transaction must not be nil")
+	}
+	if !history.MutationRecordingEnabled() && descriptors.CanSkipDeleteReadback(ctx) {
+		return descriptors.DeleteSubmodelDescriptorByIDTx(ctx, tx, submodelID)
 	}
 	previousSnapshot, err := loadSubmodelDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, submodelID)
 	if err != nil {

--- a/internal/submodelrepository/persistence/queries/submodel_database_queries.go
+++ b/internal/submodelrepository/persistence/queries/submodel_database_queries.go
@@ -421,7 +421,6 @@ func BuildSubmodelElementPathExistsSQL(submodelDatabaseID int, idShortPath strin
 func BuildCleanupSubmodelLargeObjectsSQL(submodelDatabaseID int64) (string, []any, error) {
 	dialect := goqu.Dialect(common.Dialect)
 	unlinkSubquery := dialect.From(goqu.T("submodel_element").As("sme")).
-		Prepared(true).
 		Join(goqu.T("file_data").As("fd"), goqu.On(goqu.I("fd.id").Eq(goqu.I("sme.id")))).
 		Select(goqu.Func("lo_unlink", goqu.I("fd.file_oid")).As("unlink_result")).
 		Where(
@@ -430,7 +429,6 @@ func BuildCleanupSubmodelLargeObjectsSQL(submodelDatabaseID int64) (string, []an
 		)
 
 	return dialect.From(unlinkSubquery.As("unlink_results")).
-		Prepared(true).
 		Select(goqu.COUNT("*")).
 		ToSQL()
 }

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_batch_insert_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_batch_insert_test.go
@@ -26,10 +26,13 @@
 package submodelelements
 
 import (
+	"errors"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,5 +66,65 @@ func TestInsertSubmodelElementsExecutesGraphAsSingleBatch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []int{101}, ids)
 	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInsertSubmodelElementsRollsBackOwnedTransactionAfterConflict(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	property := types.NewProperty(types.DataTypeDefXSDString)
+	idShort := "temperature"
+	property.SetIDShort(&idShort)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT .*nextval.*generate_series`).
+		WillReturnRows(sqlmock.NewRows([]string{"nextval"}).AddRow(101))
+	mock.ExpectExec(`(?s)INSERT INTO "submodel_element".*INSERT INTO "property_element"`).
+		WillReturnError(&pgconn.PgError{Code: "23505", ConstraintName: "uq_sibling_idshort"})
+	mock.ExpectRollback()
+
+	_, err = InsertSubmodelElementsForSubmodelDatabaseID(
+		db,
+		42,
+		[]types.ISubmodelElement{property},
+		nil,
+		nil,
+	)
+	require.Error(t, err)
+	require.True(t, common.IsErrConflict(err), "expected conflict error, got %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInsertSubmodelElementsDependentConflictRemainsInternal(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	property := types.NewProperty(types.DataTypeDefXSDString)
+	idShort := "temperature"
+	property.SetIDShort(&idShort)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT .*nextval.*generate_series`).
+		WillReturnRows(sqlmock.NewRows([]string{"nextval"}).AddRow(101))
+	postgresErr := &pgconn.PgError{Code: "23505", ConstraintName: "property_element_pkey"}
+	mock.ExpectExec(`(?s)INSERT INTO "submodel_element".*INSERT INTO "property_element"`).
+		WillReturnError(postgresErr)
+	mock.ExpectRollback()
+
+	_, err = InsertSubmodelElementsForSubmodelDatabaseID(
+		db,
+		42,
+		[]types.ISubmodelElement{property},
+		nil,
+		nil,
+	)
+	require.Error(t, err)
+	require.True(t, common.IsInternalServerError(err), "expected internal-server error, got %v", err)
+	require.False(t, common.IsErrConflict(err), "dependent conflict must not be mapped as an SME conflict")
+	var unwrapped *pgconn.PgError
+	require.True(t, errors.As(err, &unwrapped), "expected PostgreSQL cause, got %v", err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_batch_insert_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_batch_insert_test.go
@@ -1,0 +1,67 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package submodelelements
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsertSubmodelElementsExecutesGraphAsSingleBatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	property := types.NewProperty(types.DataTypeDefXSDString)
+	idShort := "temperature"
+	property.SetIDShort(&idShort)
+	mock.ExpectQuery(`SELECT .*nextval.*generate_series`).
+		WillReturnRows(sqlmock.NewRows([]string{"nextval"}).AddRow(101))
+	mock.ExpectExec(`(?s)INSERT INTO "submodel_element".*INSERT INTO "property_element"`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectRollback()
+
+	ids, err := InsertSubmodelElementsForSubmodelDatabaseIDContext(
+		t.Context(),
+		db,
+		42,
+		[]types.ISubmodelElement{property},
+		tx,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int{101}, ids)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
@@ -34,6 +34,7 @@
 package submodelelements
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"strconv"
@@ -630,7 +631,7 @@ func DeleteAllChildren(db *sql.DB, submodelId string, idShortPath string, tx *sq
 //
 //nolint:revive // cognitive-complexity is acceptable for performance-focused persistence orchestration
 func InsertSubmodelElements(db *sql.DB, submodelID string, elements []types.ISubmodelElement, tx *sql.Tx, ctx *BatchInsertContext) ([]int, error) {
-	return insertSubmodelElements(db, elements, tx, ctx, func(localTx *sql.Tx) (int, error) {
+	return insertSubmodelElements(common.ExecutePostgreSQLBatchInTransactionWithoutContext, db, elements, tx, ctx, nil, func(localTx *sql.Tx) (int, error) {
 		submodelDatabaseID, submodelDatabaseIDErr := persistenceutils.GetSubmodelDatabaseID(localTx, submodelID)
 		if submodelDatabaseIDErr != nil {
 			if errors.Is(submodelDatabaseIDErr, sql.ErrNoRows) {
@@ -644,7 +645,7 @@ func InsertSubmodelElements(db *sql.DB, submodelID string, elements []types.ISub
 
 // InsertSubmodelElementsForSubmodelDatabaseID inserts submodel elements when the caller already knows the submodel database ID.
 func InsertSubmodelElementsForSubmodelDatabaseID(db *sql.DB, submodelDatabaseID int, elements []types.ISubmodelElement, tx *sql.Tx, ctx *BatchInsertContext) ([]int, error) {
-	return insertSubmodelElements(db, elements, tx, ctx, func(_ *sql.Tx) (int, error) {
+	return insertSubmodelElements(common.ExecutePostgreSQLBatchInTransactionWithoutContext, db, elements, tx, ctx, nil, func(_ *sql.Tx) (int, error) {
 		if submodelDatabaseID <= 0 {
 			return 0, common.NewInternalServerError("SMREPO-INSSME-SMDATABASEIDINVALID Submodel database ID must be positive")
 		}
@@ -652,7 +653,21 @@ func InsertSubmodelElementsForSubmodelDatabaseID(db *sql.DB, submodelDatabaseID 
 	})
 }
 
-func insertSubmodelElements(db *sql.DB, elements []types.ISubmodelElement, tx *sql.Tx, ctx *BatchInsertContext, resolveSubmodelDatabaseID func(*sql.Tx) (int, error)) ([]int, error) {
+// InsertSubmodelElementsForSubmodelDatabaseIDContext inserts elements using the
+// request context for the batched database write.
+func InsertSubmodelElementsForSubmodelDatabaseIDContext(requestCtx context.Context, db *sql.DB, submodelDatabaseID int, elements []types.ISubmodelElement, tx *sql.Tx, ctx *BatchInsertContext, batch *common.PostgreSQLBatch) ([]int, error) {
+	executeBatch := func(tx *sql.Tx, statements []common.PostgreSQLBatchStatement) error {
+		return common.ExecutePostgreSQLBatchInTransaction(requestCtx, tx, statements)
+	}
+	return insertSubmodelElements(executeBatch, db, elements, tx, ctx, batch, func(_ *sql.Tx) (int, error) {
+		if submodelDatabaseID <= 0 {
+			return 0, common.NewInternalServerError("SMREPO-INSSME-SMDATABASEIDINVALID Submodel database ID must be positive")
+		}
+		return submodelDatabaseID, nil
+	})
+}
+
+func insertSubmodelElements(executeBatch func(*sql.Tx, []common.PostgreSQLBatchStatement) error, db *sql.DB, elements []types.ISubmodelElement, tx *sql.Tx, ctx *BatchInsertContext, batch *common.PostgreSQLBatch, resolveSubmodelDatabaseID func(*sql.Tx) (int, error)) ([]int, error) {
 	// Handle empty elements slice
 	if len(elements) == 0 {
 		return []int{}, nil
@@ -681,6 +696,9 @@ func insertSubmodelElements(db *sql.DB, elements []types.ISubmodelElement, tx *s
 
 	dialect := goqu.Dialect("postgres")
 	jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
+	if batch == nil {
+		batch = &common.PostgreSQLBatch{}
+	}
 
 	submodelDatabaseID, submodelDatabaseIDErr := resolveSubmodelDatabaseID(localTx)
 	if submodelDatabaseIDErr != nil {
@@ -694,40 +712,47 @@ func insertSubmodelElements(db *sql.DB, elements []types.ISubmodelElement, tx *s
 		return nil, err
 	}
 
-	insertBaseErr := insertBaseNodesDepthWise(localTx, dialect, int64(submodelDatabaseID), nodes)
+	insertBaseErr := insertBaseNodesDepthWise(localTx, batch, dialect, int64(submodelDatabaseID), nodes)
 	if insertBaseErr != nil {
 		err = insertBaseErr
 		return nil, err
 	}
 
-	payloadErr := insertPayloadAndSemanticReferences(localTx, dialect, nodes, jsonLib)
+	payloadErr := insertPayloadAndSemanticReferences(batch, dialect, nodes, jsonLib)
 	if payloadErr != nil {
 		err = payloadErr
 		return nil, err
 	}
 
-	typeRowsErr := insertTypeSpecificRows(localTx, dialect, nodes)
+	typeRowsErr := insertTypeSpecificRows(localTx, batch, dialect, nodes)
 	if typeRowsErr != nil {
 		err = typeRowsErr
 		return nil, err
 	}
 
-	mlpErr := insertMultiLanguagePropertyValues(localTx, dialect, nodes)
+	mlpErr := insertMultiLanguagePropertyValues(batch, dialect, nodes)
 	if mlpErr != nil {
 		err = mlpErr
 		return nil, err
 	}
 
-	mlpPayloadErr := insertMultiLanguagePropertyPayloadRows(localTx, dialect, nodes)
+	mlpPayloadErr := insertMultiLanguagePropertyPayloadRows(batch, dialect, nodes)
 	if mlpPayloadErr != nil {
 		err = mlpPayloadErr
 		return nil, err
 	}
 
-	propertyPayloadErr := insertPropertyPayloadRows(localTx, dialect, nodes)
+	propertyPayloadErr := insertPropertyPayloadRows(batch, dialect, nodes)
 	if propertyPayloadErr != nil {
 		err = propertyPayloadErr
 		return nil, err
+	}
+
+	if batchErr := executeBatch(localTx, batch.Statements()); batchErr != nil {
+		if mappedErr := mapConflictInsertError(batchErr); mappedErr != nil {
+			return nil, mappedErr
+		}
+		return nil, common.NewInternalServerError("SMREPO-INSSME-EXECBATCH " + batchErr.Error())
 	}
 
 	// Commit if we own the transaction

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
@@ -37,6 +37,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -683,12 +684,10 @@ func insertSubmodelElements(executeBatch func(*sql.Tx, []common.PostgreSQLBatchS
 	if ownTransaction {
 		localTx, _, err = common.StartTransaction(db)
 		if err != nil {
-			return nil, common.NewInternalServerError("Failed to start transaction for batch insert: " + err.Error())
+			return nil, common.NewInternalServerError("SMREPO-INSSME-STARTTX failed to start insert transaction: " + err.Error())
 		}
 		defer func() {
-			if err != nil {
-				_ = localTx.Rollback()
-			}
+			_ = localTx.Rollback()
 		}()
 	} else {
 		localTx = tx
@@ -750,9 +749,11 @@ func insertSubmodelElements(executeBatch func(*sql.Tx, []common.PostgreSQLBatchS
 
 	if batchErr := executeBatch(localTx, batch.Statements()); batchErr != nil {
 		if mappedErr := mapConflictInsertError(batchErr); mappedErr != nil {
-			return nil, mappedErr
+			err = mappedErr
+		} else {
+			err = fmt.Errorf("%s %w", common.NewInternalServerError("SMREPO-INSSME-EXECBATCH"), batchErr)
 		}
-		return nil, common.NewInternalServerError("SMREPO-INSSME-EXECBATCH " + batchErr.Error())
+		return nil, err
 	}
 
 	// Commit if we own the transaction

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_database_utils.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_database_utils.go
@@ -28,11 +28,13 @@ package submodelelements
 
 import (
 	"database/sql"
+	"errors"
 	"strconv"
 
 	"github.com/FriedJannik/aas-go-sdk/types"
 	"github.com/doug-martin/goqu/v9"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/jackc/pgx/v5/pgconn"
 	jsoniter "github.com/json-iterator/go"
 )
 
@@ -611,15 +613,20 @@ func appendRecordInsertChunked(batch *common.PostgreSQLBatch, dialect goqu.Diale
 }
 
 func mapConflictInsertError(err error) error {
-	if err == nil {
+	if !common.IsPostgresUniqueViolation(err) {
 		return nil
 	}
 
-	if common.IsPostgresUniqueViolation(err) {
+	var postgresErr *pgconn.PgError
+	if errors.As(err, &postgresErr) && isSubmodelElementSiblingConstraint(postgresErr.ConstraintName) {
 		return common.NewErrConflict("SMREPO-INSSME-CONFLICT Duplicate submodel element")
 	}
 
 	return nil
+}
+
+func isSubmodelElementSiblingConstraint(constraintName string) bool {
+	return constraintName == "uq_sibling_idshort" || constraintName == "uq_sibling_pos"
 }
 
 // getChildElements extracts child elements from container-type submodel elements.

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_database_utils.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_database_utils.go
@@ -184,7 +184,7 @@ func buildIDShortPath(parentPath string, isFromList bool, position int, idShort 
 	return parentPath + "." + idShort
 }
 
-func insertBaseNodesDepthWise(tx *sql.Tx, dialect goqu.DialectWrapper, submodelDatabaseID int64, nodes []*flattenedInsertNode) error {
+func insertBaseNodesDepthWise(tx *sql.Tx, batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, submodelDatabaseID int64, nodes []*flattenedInsertNode) error {
 	if len(nodes) == 0 {
 		return nil
 	}
@@ -219,8 +219,8 @@ func insertBaseNodesDepthWise(tx *sql.Tx, dialect goqu.DialectWrapper, submodelD
 		baseRows = append(baseRows, record)
 	}
 
-	insertErr := executeRecordInsertChunked(
-		tx,
+	insertErr := appendRecordInsertChunked(
+		batch,
 		dialect,
 		"submodel_element",
 		[]string{"id", "submodel_id", "parent_sme_id", "position", "id_short", "category", "model_type", "idshort_path", "root_sme_id", "depth"},
@@ -308,7 +308,7 @@ func resolveNodeHierarchyIDs(nodes []*flattenedInsertNode, node *flattenedInsert
 	return parentID, rootID, nil
 }
 
-func insertPayloadAndSemanticReferences(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode, jsonLib jsoniter.API) error {
+func insertPayloadAndSemanticReferences(batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode, jsonLib jsoniter.API) error {
 	payloadRows := make([]goqu.Record, 0, len(nodes))
 	for _, node := range nodes {
 		payloadRecord, hasPayload, payloadBuildErr := buildSubmodelElementPayloadRecord(int64(node.dbID), node.element, jsonLib)
@@ -322,8 +322,8 @@ func insertPayloadAndSemanticReferences(tx *sql.Tx, dialect goqu.DialectWrapper,
 	}
 
 	if len(payloadRows) > 0 {
-		if payloadInsertErr := executeRecordInsertChunked(
-			tx,
+		if payloadInsertErr := appendRecordInsertChunked(
+			batch,
 			dialect,
 			"submodel_element_payload",
 			[]string{"submodel_element_id", "description_payload", "displayname_payload", "embedded_data_specification_payload", "supplemental_semantic_ids_payload", "extensions_payload", "qualifiers_payload"},
@@ -334,16 +334,15 @@ func insertPayloadAndSemanticReferences(tx *sql.Tx, dialect goqu.DialectWrapper,
 		}
 	}
 
-	if err := insertSemanticReferencesBulk(tx, dialect, nodes); err != nil {
+	if err := insertSemanticReferencesBulk(batch, dialect, nodes); err != nil {
 		return err
 	}
-	return insertSupplementalSemanticReferences(tx, nodes)
+	return appendSupplementalSemanticReferences(batch, nodes)
 }
 
-func insertSupplementalSemanticReferences(tx *sql.Tx, nodes []*flattenedInsertNode) error {
+func appendSupplementalSemanticReferences(batch *common.PostgreSQLBatch, nodes []*flattenedInsertNode) error {
 	for _, node := range nodes {
-		if err := common.CreateContextReferences1ToMany(
-			tx,
+		if err := batch.AppendContextReferences(
 			int64(node.dbID),
 			node.element.SupplementalSemanticIDs(),
 			common.TblSubmodelElementSuppSemantic,
@@ -355,7 +354,7 @@ func insertSupplementalSemanticReferences(tx *sql.Tx, nodes []*flattenedInsertNo
 	return nil
 }
 
-func insertSemanticReferencesBulk(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
+func insertSemanticReferencesBulk(batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
 	referenceRows := make([]goqu.Record, 0, len(nodes))
 	payloadRows := make([]goqu.Record, 0, len(nodes))
 	keyRows := make([]goqu.Record, 0)
@@ -398,8 +397,8 @@ func insertSemanticReferencesBulk(tx *sql.Tx, dialect goqu.DialectWrapper, nodes
 		return nil
 	}
 
-	if err := executeRecordInsertChunked(
-		tx,
+	if err := appendRecordInsertChunked(
+		batch,
 		dialect,
 		"submodel_element_semantic_id_reference",
 		[]string{"id", "type"},
@@ -409,8 +408,8 @@ func insertSemanticReferencesBulk(tx *sql.Tx, dialect goqu.DialectWrapper, nodes
 		return err
 	}
 
-	if err := executeRecordInsertChunked(
-		tx,
+	if err := appendRecordInsertChunked(
+		batch,
 		dialect,
 		"submodel_element_semantic_id_reference_payload",
 		[]string{"reference_id", "parent_reference_payload"},
@@ -424,8 +423,8 @@ func insertSemanticReferencesBulk(tx *sql.Tx, dialect goqu.DialectWrapper, nodes
 		return nil
 	}
 
-	return executeRecordInsertChunked(
-		tx,
+	return appendRecordInsertChunked(
+		batch,
 		dialect,
 		"submodel_element_semantic_id_reference_key",
 		[]string{"reference_id", "position", "type", "value"},
@@ -434,7 +433,7 @@ func insertSemanticReferencesBulk(tx *sql.Tx, dialect goqu.DialectWrapper, nodes
 	)
 }
 
-func insertTypeSpecificRows(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
+func insertTypeSpecificRows(tx *sql.Tx, batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
 	typeSpecificRows := make(map[string][]goqu.Record)
 
 	for _, node := range nodes {
@@ -451,7 +450,7 @@ func insertTypeSpecificRows(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []*fl
 		if len(rows) == 0 {
 			continue
 		}
-		if err := executeRecordInsertChunked(tx, dialect, tableName, nil, rows, "SMREPO-INSSME-INSTYPE"); err != nil {
+		if err := appendRecordInsertChunked(batch, dialect, tableName, nil, rows, "SMREPO-INSSME-INSTYPE"); err != nil {
 			return err
 		}
 	}
@@ -459,7 +458,7 @@ func insertTypeSpecificRows(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []*fl
 	return nil
 }
 
-func insertMultiLanguagePropertyValues(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
+func insertMultiLanguagePropertyValues(batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
 	mlpRows := make([]goqu.Record, 0)
 	for _, node := range nodes {
 		if node.element.ModelType() != types.ModelTypeMultiLanguageProperty {
@@ -484,8 +483,8 @@ func insertMultiLanguagePropertyValues(tx *sql.Tx, dialect goqu.DialectWrapper, 
 		return nil
 	}
 
-	return executeRecordInsertChunked(
-		tx,
+	return appendRecordInsertChunked(
+		batch,
 		dialect,
 		"multilanguage_property_value",
 		[]string{"submodel_element_id", "language", "text"},
@@ -494,7 +493,7 @@ func insertMultiLanguagePropertyValues(tx *sql.Tx, dialect goqu.DialectWrapper, 
 	)
 }
 
-func insertMultiLanguagePropertyPayloadRows(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
+func insertMultiLanguagePropertyPayloadRows(batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
 	mlpPayloadRows := make([]goqu.Record, 0)
 	for _, node := range nodes {
 		if node.element.ModelType() != types.ModelTypeMultiLanguageProperty {
@@ -525,8 +524,8 @@ func insertMultiLanguagePropertyPayloadRows(tx *sql.Tx, dialect goqu.DialectWrap
 		return nil
 	}
 
-	return executeRecordInsertChunked(
-		tx,
+	return appendRecordInsertChunked(
+		batch,
 		dialect,
 		"multilanguage_property_payload",
 		[]string{"submodel_element_id", "value_id_payload"},
@@ -535,7 +534,7 @@ func insertMultiLanguagePropertyPayloadRows(tx *sql.Tx, dialect goqu.DialectWrap
 	)
 }
 
-func insertPropertyPayloadRows(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
+func insertPropertyPayloadRows(batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, nodes []*flattenedInsertNode) error {
 	propertyPayloadRows := make([]goqu.Record, 0)
 	for _, node := range nodes {
 		if node.element.ModelType() != types.ModelTypeProperty {
@@ -566,8 +565,8 @@ func insertPropertyPayloadRows(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []
 		return nil
 	}
 
-	return executeRecordInsertChunked(
-		tx,
+	return appendRecordInsertChunked(
+		batch,
 		dialect,
 		"property_element_payload",
 		[]string{"property_element_id", "value_id_payload"},
@@ -576,7 +575,7 @@ func insertPropertyPayloadRows(tx *sql.Tx, dialect goqu.DialectWrapper, nodes []
 	)
 }
 
-func executeRecordInsertChunked(tx *sql.Tx, dialect goqu.DialectWrapper, tableName string, cols []string, rows []goqu.Record, errCode string) error {
+func appendRecordInsertChunked(batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, tableName string, cols []string, rows []goqu.Record, errCode string) error {
 	if len(rows) == 0 {
 		return nil
 	}
@@ -603,15 +602,8 @@ func executeRecordInsertChunked(tx *sql.Tx, dialect goqu.DialectWrapper, tableNa
 		}
 		insert = insert.Rows(chunkRows...)
 
-		sqlQuery, args, buildErr := insert.ToSQL()
-		if buildErr != nil {
+		if buildErr := batch.AppendDataset(insert); buildErr != nil {
 			return common.NewInternalServerError(errCode + "-BUILDQ " + buildErr.Error())
-		}
-		if _, execErr := tx.Exec(sqlQuery, args...); execErr != nil {
-			if mappedErr := mapConflictInsertError(execErr); mappedErr != nil {
-				return mappedErr
-			}
-			return common.NewInternalServerError(errCode + "-EXECQ " + execErr.Error())
 		}
 	}
 

--- a/internal/submodelrepository/persistence/submodel_database_delete_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_delete_sqlmock_test.go
@@ -51,9 +51,7 @@ func TestDeleteSubmodelSuccessCleansLargeObjectsAndDeletesSubmodel(t *testing.T)
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(submodelDatabaseID))
 	expectSubmodelHistoryAppend(mock)
-	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(1)))
-	mock.ExpectExec(`DELETE FROM .*submodel`).
+	mock.ExpectExec(`(?s)SELECT COUNT\(\*\).*file_oid.*FROM .*submodel_element.*file_data.*DELETE FROM .*submodel`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
@@ -97,16 +95,14 @@ func TestDeleteSubmodelDeleteFailsRollsBack(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(submodelDatabaseID))
 	expectSubmodelHistoryAppend(mock)
-	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
-	mock.ExpectExec(`DELETE FROM .*submodel`).
+	mock.ExpectExec(`(?s)SELECT COUNT\(\*\).*file_oid.*FROM .*submodel_element.*file_data.*DELETE FROM .*submodel`).
 		WillReturnError(errors.New("delete failed"))
 	mock.ExpectRollback()
 
 	err = sut.DeleteSubmodel(contextWithABACDisabled(t), submodelID)
 	require.Error(t, err)
 	require.True(t, common.IsInternalServerError(err))
-	require.Contains(t, err.Error(), "SMREPO-DELSM-DELETESM")
+	require.Contains(t, err.Error(), "SMREPO-DELSM-EXECBATCH")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -125,9 +121,7 @@ func TestDeleteSubmodelCommitFailsReturnsInternalError(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(submodelDatabaseID))
 	expectSubmodelHistoryAppend(mock)
-	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(0)))
-	mock.ExpectExec(`DELETE FROM .*submodel`).
+	mock.ExpectExec(`(?s)SELECT COUNT\(\*\).*file_oid.*FROM .*submodel_element.*file_data.*DELETE FROM .*submodel`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
 
@@ -153,13 +147,13 @@ func TestDeleteSubmodelOrphanCleanupFailsRollsBack(t *testing.T) {
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(submodelDatabaseID))
 	expectSubmodelHistoryAppend(mock)
-	mock.ExpectQuery(`SELECT .*file_oid.*FROM .*submodel_element.*file_data`).
+	mock.ExpectExec(`(?s)SELECT COUNT\(\*\).*file_oid.*FROM .*submodel_element.*file_data.*DELETE FROM .*submodel`).
 		WillReturnError(errors.New("unlink failed"))
 	mock.ExpectRollback()
 
 	err = sut.DeleteSubmodel(contextWithABACDisabled(t), submodelID)
 	require.Error(t, err)
 	require.True(t, common.IsInternalServerError(err))
-	require.Contains(t, err.Error(), "SMREPO-DELSM-UNLINKLO")
+	require.Contains(t, err.Error(), "SMREPO-DELSM-EXECBATCH")
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -325,7 +325,7 @@ func TestCreateSubmodelDuplicateIdentifierReturnsConflict(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
-		WillReturnError(&pgconn.PgError{Code: "23505"})
+		WillReturnError(&pgconn.PgError{Code: "23505", ConstraintName: "submodel_submodel_identifier_key"})
 	mock.ExpectRollback()
 
 	err = sut.CreateSubmodel(contextWithABACDisabled(t), submodel)

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -298,8 +298,6 @@ func TestCreateSubmodelInsertFailureRollsBack(t *testing.T) {
 	submodel.SetIDShort(&idShort)
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT "id" FROM "submodel"`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
 		WillReturnError(errors.New("insert failed"))
 	mock.ExpectRollback()
@@ -326,8 +324,6 @@ func TestCreateSubmodelDuplicateIdentifierReturnsConflict(t *testing.T) {
 	submodel.SetIDShort(&idShort)
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(`SELECT "id" FROM "submodel"`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectQuery(`INSERT INTO .*submodel.*RETURNING`).
 		WillReturnError(&pgconn.PgError{Code: "23505"})
 	mock.ExpectRollback()

--- a/internal/submodelrepository/persistence/submodel_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_write_database.go
@@ -98,7 +98,7 @@ func (s *SubmodelDatabase) createSubmodelInTransactionValidated(ctx context.Cont
 		return err
 	}
 
-	err := s.createSubmodelInTransaction(tx, submodel)
+	err := s.createSubmodelInTransaction(ctx, tx, submodel)
 	if err != nil {
 		return err
 	}
@@ -123,6 +123,9 @@ func (s *SubmodelDatabase) createSubmodelInTransactionValidated(ctx context.Cont
 }
 
 func (s *SubmodelDatabase) ensureVisibleSubmodelCreateDoesNotExist(ctx context.Context, tx *sql.Tx, submodelID string) error {
+	if createprecheck.CanSkipExistenceCheck(ctx) {
+		return nil
+	}
 	return createprecheck.EnsureVisibleCreate(
 		ctx,
 		func(context.Context) (bool, error) {
@@ -153,7 +156,7 @@ func (s *SubmodelDatabase) ensureVisibleSubmodelCreateDoesNotExist(ctx context.C
 	)
 }
 
-func (s *SubmodelDatabase) createSubmodelInTransaction(tx *sql.Tx, submodel types.ISubmodel) error {
+func (s *SubmodelDatabase) createSubmodelInTransaction(ctx context.Context, tx *sql.Tx, submodel types.ISubmodel) error {
 	ids, args, err := submodelqueries.BuildInsertSubmodelSQL(submodel)
 	if err != nil {
 		return common.NewInternalServerError("SMREPO-NEWSM-CREATE-INSERTSQL " + err.Error())
@@ -185,13 +188,9 @@ func (s *SubmodelDatabase) createSubmodelInTransaction(tx *sql.Tx, submodel type
 	if err != nil {
 		return common.NewInternalServerError("SMREPO-NEWSM-CREATE-PAYLOADSQL " + err.Error())
 	}
-
-	if _, err := tx.Exec(ids, args...); err != nil {
-		return common.NewInternalServerError("SMREPO-NEWSM-CREATE-EXECPAYLOADSQL " + err.Error())
-	}
-
-	if err := common.CreateContextReferences1ToMany(
-		tx,
+	metadataBatch := &common.PostgreSQLBatch{}
+	metadataBatch.AppendStatement(ids, args...)
+	if err = metadataBatch.AppendContextReferences(
 		submodelDBID,
 		submodel.SupplementalSemanticIDs(),
 		common.TblSubmodelSuppSemantic,
@@ -199,51 +198,56 @@ func (s *SubmodelDatabase) createSubmodelInTransaction(tx *sql.Tx, submodel type
 	); err != nil {
 		return common.NewInternalServerError("SMREPO-NEWSM-CREATE-SUPPSEM " + err.Error())
 	}
-
-	semanticID := submodel.SemanticID()
-	if semanticID != nil {
-		ids, args, err = submodelqueries.BuildInsertSubmodelSemanticIDReferenceSQL(submodelDBID, semanticID)
-		if err != nil {
-			return common.NewInternalServerError("SMREPO-NEWSM-CREATE-SEMIDREFSQL " + err.Error())
-		}
-
-		if _, err := tx.Exec(ids, args...); err != nil {
-			return common.NewInternalServerError("SMREPO-NEWSM-CREATE-EXECSEMIDREFSQL " + err.Error())
-		}
-
-		ids, args, err = submodelqueries.BuildInsertSubmodelSemanticIDReferenceKeysSQL(submodelDBID, semanticID)
-		if err != nil {
-			return common.NewInternalServerError("SMREPO-NEWSM-CREATE-SEMIDKEYSQL " + err.Error())
-		}
-
-		if ids != "" {
-			if _, err := tx.Exec(ids, args...); err != nil {
-				return common.NewInternalServerError("SMREPO-NEWSM-CREATE-EXECSEMIDKEYSQL " + err.Error())
-			}
-		}
-
-		ids, args, err = submodelqueries.BuildInsertSubmodelSemanticIDReferencePayloadSQL(submodelDBID, semanticID)
-		if err != nil {
-			return common.NewInternalServerError("SMREPO-NEWSM-CREATE-SEMIDPAYLOADSQL " + err.Error())
-		}
-
-		if _, err := tx.Exec(ids, args...); err != nil {
-			return common.NewInternalServerError("SMREPO-NEWSM-CREATE-EXECSEMIDPAYLOADSQL " + err.Error())
-		}
+	if err = appendSubmodelSemanticIDCreate(metadataBatch, submodelDBID, submodel.SemanticID()); err != nil {
+		return err
 	}
-
 	if len(submodel.SubmodelElements()) > 0 {
 		submodelDatabaseID, conversionErr := submodelDatabaseIDAsInt(submodelDBID)
 		if conversionErr != nil {
 			return conversionErr
 		}
 
-		_, err = submodelelements.InsertSubmodelElementsForSubmodelDatabaseID(s.db, submodelDatabaseID, submodel.SubmodelElements(), tx, nil)
+		_, err = submodelelements.InsertSubmodelElementsForSubmodelDatabaseIDContext(ctx, s.db, submodelDatabaseID, submodel.SubmodelElements(), tx, nil, metadataBatch)
 		if err != nil {
 			return err
 		}
+		return nil
 	}
 
+	if err = common.ExecutePostgreSQLBatchInTransaction(ctx, tx, metadataBatch.Statements()); err != nil {
+		return common.NewInternalServerError("SMREPO-NEWSM-CREATE-EXECMETADATABATCH " + err.Error())
+	}
+
+	return nil
+}
+
+func appendSubmodelSemanticIDCreate(batch *common.PostgreSQLBatch, submodelDBID int64, semanticID types.IReference) error {
+	if semanticID == nil {
+		return nil
+	}
+	builders := []struct {
+		code  string
+		build func() (string, []any, error)
+	}{
+		{"SMREPO-NEWSM-CREATE-SEMIDREFSQL", func() (string, []any, error) {
+			return submodelqueries.BuildInsertSubmodelSemanticIDReferenceSQL(submodelDBID, semanticID)
+		}},
+		{"SMREPO-NEWSM-CREATE-SEMIDKEYSQL", func() (string, []any, error) {
+			return submodelqueries.BuildInsertSubmodelSemanticIDReferenceKeysSQL(submodelDBID, semanticID)
+		}},
+		{"SMREPO-NEWSM-CREATE-SEMIDPAYLOADSQL", func() (string, []any, error) {
+			return submodelqueries.BuildInsertSubmodelSemanticIDReferencePayloadSQL(submodelDBID, semanticID)
+		}},
+	}
+	for _, builder := range builders {
+		query, args, err := builder.build()
+		if err != nil {
+			return common.NewInternalServerError(builder.code + " " + err.Error())
+		}
+		if query != "" {
+			batch.AppendStatement(query, args...)
+		}
+	}
 	return nil
 }
 
@@ -327,8 +331,8 @@ func (s *SubmodelDatabase) PatchSubmodelInTransaction(ctx context.Context, submo
 	return s.appendCurrentSubmodelHistoryTx(ctx, tx, submodelID, previousSnapshot, history.ChangeUpdated)
 }
 
-func (s *SubmodelDatabase) patchSubmodelInTransactionValidated(_ context.Context, submodelID string, tx *sql.Tx, submodel types.ISubmodel) error {
-	_, err := s.replaceSubmodelInTransaction(tx, submodelID, submodel, true)
+func (s *SubmodelDatabase) patchSubmodelInTransactionValidated(ctx context.Context, submodelID string, tx *sql.Tx, submodel types.ISubmodel) error {
+	_, err := s.replaceSubmodelInTransaction(ctx, tx, submodelID, submodel, true)
 	if err != nil {
 		return err
 	}
@@ -480,7 +484,7 @@ func (s *SubmodelDatabase) createSubmodelForPutTx(ctx context.Context, tx *sql.T
 	if err != nil {
 		return false, err
 	}
-	if err = s.createSubmodelInTransaction(tx, submodel); err != nil {
+	if err = s.createSubmodelInTransaction(ctx, tx, submodel); err != nil {
 		return false, err
 	}
 	recordHistory := history.MutationRecordingEnabled()
@@ -714,12 +718,7 @@ func (s *SubmodelDatabase) deleteSubmodelInTransaction(ctx context.Context, tx *
 		return err
 	}
 
-	err = cleanupSubmodelLargeObjects(tx, int64(submodelDatabaseID))
-	if err != nil {
-		return err
-	}
-
-	err = deleteSubmodelByDatabaseID(tx, int64(submodelDatabaseID))
+	err = cleanupAndDeleteSubmodelByDatabaseID(ctx, tx, int64(submodelDatabaseID))
 	if err != nil {
 		return err
 	}
@@ -727,7 +726,25 @@ func (s *SubmodelDatabase) deleteSubmodelInTransaction(ctx context.Context, tx *
 	return nil
 }
 
-func (s *SubmodelDatabase) replaceSubmodelInTransaction(tx *sql.Tx, submodelID string, submodel types.ISubmodel, requireExisting bool) (bool, error) {
+func cleanupAndDeleteSubmodelByDatabaseID(ctx context.Context, tx *sql.Tx, submodelDatabaseID int64) error {
+	cleanupQuery, cleanupArgs, err := submodelqueries.BuildCleanupSubmodelLargeObjectsSQL(submodelDatabaseID)
+	if err != nil {
+		return common.NewInternalServerError("SMREPO-DELSM-BUILDUNLINKQUERY " + err.Error())
+	}
+	deleteQuery, deleteArgs, err := submodelqueries.BuildDeleteSubmodelByDatabaseIDSQL(submodelDatabaseID)
+	if err != nil {
+		return common.NewInternalServerError("SMREPO-DELSM-BUILDDELETESM " + err.Error())
+	}
+	batch := &common.PostgreSQLBatch{}
+	batch.AppendStatement(cleanupQuery, cleanupArgs...)
+	batch.AppendStatement(deleteQuery, deleteArgs...)
+	if err = common.ExecutePostgreSQLBatchInTransaction(ctx, tx, batch.Statements()); err != nil {
+		return common.NewInternalServerError("SMREPO-DELSM-EXECBATCH " + err.Error())
+	}
+	return nil
+}
+
+func (s *SubmodelDatabase) replaceSubmodelInTransaction(ctx context.Context, tx *sql.Tx, submodelID string, submodel types.ISubmodel, requireExisting bool) (bool, error) {
 	submodelDatabaseID, err := persistenceutils.GetSubmodelDatabaseIDForUpdate(tx, submodelID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -735,7 +752,7 @@ func (s *SubmodelDatabase) replaceSubmodelInTransaction(tx *sql.Tx, submodelID s
 				return false, common.NewErrNotFound("SMREPO-UPDSM-NOTFOUND Submodel with ID '" + submodelID + "' not found")
 			}
 
-			if createErr := s.createSubmodelInTransaction(tx, submodel); createErr != nil {
+			if createErr := s.createSubmodelInTransaction(ctx, tx, submodel); createErr != nil {
 				return false, createErr
 			}
 			return false, nil
@@ -758,7 +775,7 @@ func (s *SubmodelDatabase) replaceSubmodelInTransaction(tx *sql.Tx, submodelID s
 		return false, err
 	}
 
-	err = s.createSubmodelInTransaction(tx, submodel)
+	err = s.createSubmodelInTransaction(ctx, tx, submodel)
 	if err != nil {
 		return false, err
 	}

--- a/internal/submodelrepository/persistence/submodel_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_write_database.go
@@ -44,6 +44,7 @@ import (
 	submodelqueries "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence/queries"
 	submodelelements "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence/submodelElements"
 	persistenceutils "github.com/eclipse-basyx/basyx-go-components/internal/submodelrepository/persistence/utils"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // CreateSubmodel creates a new submodel and performs an ABAC re-check before commit when ABAC is enabled.
@@ -1011,11 +1012,8 @@ func (s *SubmodelDatabase) patchSubmodelMetadataInTransaction(tx *sql.Tx, submod
 }
 
 func mapCreateSubmodelInsertError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	if common.IsPostgresUniqueViolation(err) {
+	var postgresErr *pgconn.PgError
+	if errors.As(err, &postgresErr) && postgresErr.Code == "23505" && postgresErr.ConstraintName == "submodel_submodel_identifier_key" {
 		return common.NewErrConflict("SMREPO-NEWSM-CREATE-CONFLICT submodel identifier already exists")
 	}
 


### PR DESCRIPTION
## Description of Changes

This PR improves PostgreSQL persistence performance for POST and DELETE operations across the AAS Repository, Submodel Repository, AAS Registry, and Submodel Registry.

Key changes:

- Batch dependent inserts for AASs, Submodels, and Submodel Elements to reduce database round trips.
- Batch large-object cleanup and resource deletion statements.
- Skip unnecessary existence and delete-readback queries when ABAC and history settings allow it.
- Preserve authorization and history readbacks when required.
- Split large PostgreSQL batches at 1,000 statements or 4 MiB.
- Map uniqueness violations only for the relevant constraints, preventing unrelated database conflicts from being reported incorrectly.
- Add database schema patch `v1.1.14` with indexes for reverse AAS-to-Submodel lookups and supplemental semantic reference cascade deletes.
- Add and update tests covering batch execution, batch splitting, rollback behavior, conflict handling, authorization-dependent readbacks, and AAS/Submodel persistence.

## Related Issue

N/A

## BaSyx Configuration for Testing

No special BaSyx configuration is required. The configuration service must apply database schema patch `v1.1.14`.

## AAS Files Used for Testing

No additional AAS files are required.

## Additional Information

The optimization retains existing ABAC and history behavior. Readbacks are skipped only when authorization is unrestricted for the relevant operation and mutation history does not require the previous resource state.