### PR TITLE
Fix access to draft releases in release guard

### DIFF
--- a/.changes/unreleased/fixed-637-draft-release-guard.yaml
+++ b/.changes/unreleased/fixed-637-draft-release-guard.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: The release workflow can inspect its newly created draft release and continue directly into artifact publication.
+time: 2026-08-29T16:09:52.000000000Z
+custom:
+  Impact: Low
+  PullRequest: 637
+  SecurityImpact: The guard receives contents write permission only because GitHub requires push access to view drafts; its operations remain read-only.

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -20,7 +20,8 @@ jobs:
     if: ${{ github.repository == 'eclipse-basyx/basyx-go-components' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # GitHub only exposes draft releases to tokens with push access.
+      contents: write
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
       release-tag: ${{ steps.check.outputs.release-tag }}


### PR DESCRIPTION
The release guard currently runs with read-only contents permission. GitHub only exposes draft releases to callers with push access, so the guard receives an opaque `release not found` response immediately after the prepare job creates the v1.0.10 draft.

This grants `contents: write` only to the guard job. The workflow already grants this permission to the reusable publisher, and the guard continues to perform read-only operations. This lets it validate the existing draft and resume the idempotent v1.0.10 release flow.

After this PR is merged, rerun the Release workflow with `v1.0.10`; do not create another tag or release.