### PR TITLE
Keep Dependabot PRs compatible with changelog guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 1
+    labels:
+      - "dependencies"
+      - "go"
+      - "no-changelog"
   - package-ecosystem: "docker"
     directories:
       - "/cmd/*"
@@ -15,6 +19,10 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 1
+    labels:
+      - "dependencies"
+      - "docker"
+      - "no-changelog"
     groups:
       golang-base-images:
         group-by: dependency-name
@@ -31,6 +39,10 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 1
+    labels:
+      - "dependencies"
+      - "github_actions"
+      - "no-changelog"
     groups:
       ci-core-actions:
         patterns:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,10 @@ policy, or deployment; otherwise use `Low`. Always describe the security
 consequence, or enter `None.` when there is none. `CHANGELOG.md` is generated
 during releases and must not be edited directly.
 
+Dependabot pull requests receive `no-changelog` by default. Remove that label
+and add a fragment before merging when a dependency update has a notable
+user-visible or security effect.
+
 ## Related Issue
 
 If this pull request is related to an existing issue, please link that issue using the format `#issue_number`.


### PR DESCRIPTION
## What changed

- configure Dependabot to add no-changelog to Go module, Docker, and GitHub Actions update pull requests
- preserve Dependabot's existing dependencies and ecosystem-specific labels
- document that reviewers must remove no-changelog and add a fragment for notable user-visible or security effects

## Why

Dependabot cannot make the repository-specific impact and security assessment required by a Changie fragment. Its pull requests currently contain neither a fragment nor the explicit exception label, so the changelog guard rejects them.

Using Dependabot's native label configuration keeps the exception visible and reviewable without introducing a privileged pull_request_target workflow or bypassing the guard based on author identity.

This configuration applies to newly created or recreated Dependabot pull requests. Existing open pull requests still need the label applied manually.

## Validation

- parsed and checked every Dependabot ecosystem label set
- validated existing Changie fragments and generated changelog consistency
- go clean -testcache && go test -v ./internal/submodelrepository/integration_tests