### PR TITLE
Fix Submodel PUT query planning overhead

### DIFF
--- a/.changes/unreleased/fixed-20260830-100803.yaml
+++ b/.changes/unreleased/fixed-20260830-100803.yaml
@@ -1,5 +1,5 @@
 kind: fixed
-body: Existing Submodel PUT requests reuse generic PostgreSQL plans for their stable reconciliation queries, avoiding repeated planning overhead on large databases.
+body: Existing Submodel PUT requests reuse generic PostgreSQL plans while loading persisted SubmodelElement state, avoiding repeated planning overhead on large databases.
 time: 2026-08-30T10:08:03.897453+02:00
 custom:
     Impact: Low

--- a/.changes/unreleased/fixed-20260830-100803.yaml
+++ b/.changes/unreleased/fixed-20260830-100803.yaml
@@ -3,5 +3,5 @@ body: Existing Submodel PUT requests reuse generic PostgreSQL plans for their st
 time: 2026-08-30T10:08:03.897453+02:00
 custom:
     Impact: Low
-    PullRequest: "640"
+    PullRequest: 640
     SecurityImpact: Authorization and transaction isolation remain unchanged; persisted replacement semantics are unchanged.

--- a/.changes/unreleased/fixed-20260830-100803.yaml
+++ b/.changes/unreleased/fixed-20260830-100803.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: Existing Submodel PUT requests reuse generic PostgreSQL plans for their stable reconciliation queries, avoiding repeated planning overhead on large databases.
+time: 2026-08-30T10:08:03.897453+02:00
+custom:
+    Impact: Low
+    PullRequest: "640"
+    SecurityImpact: Authorization and transaction isolation remain unchanged; persisted replacement semantics are unchanged.

--- a/internal/submodelrepository/persistence/submodel_database_patch_put_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_patch_put_sqlmock_test.go
@@ -250,8 +250,10 @@ func TestPutSubmodelNoOpUpdateAppendsHistoryWithoutLiveMutation(t *testing.T) {
 	require.NoError(t, err)
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(400))
+	expectForceGenericSubmodelPutPlan(mock)
 	expectBareSubmodelStateLoad(mock, "sm-existing", "smexisting")
 	expectSubmodelHistoryAppend(mock)
+	expectRestoreSubmodelPutPlan(mock)
 	mock.ExpectRollback()
 
 	result, err := sut.PutSubmodelInTransactionWithResult(contextWithABACDisabled(t), tx, "sm-existing", submodel)
@@ -278,11 +280,13 @@ func TestPutSubmodelChangedUpdateExecutesReconciliationAndHistory(t *testing.T) 
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(400))
+	expectForceGenericSubmodelPutPlan(mock)
 	expectBareSubmodelStateLoad(mock, "sm-existing", "old")
 	mock.ExpectQuery(`WITH reconciliation_plan`).
 		WillReturnRows(sqlmock.NewRows([]string{"updated_count", "inserted_count", "deleted_count"}).AddRow(0, 0, 0))
 	expectBareSubmodelStateLoad(mock, "sm-existing", "new")
 	expectSubmodelHistoryAppend(mock)
+	expectRestoreSubmodelPutPlan(mock)
 	mock.ExpectCommit()
 
 	isUpdate, err := sut.PutSubmodel(contextWithABACDisabled(t), "sm-existing", submodel)
@@ -301,8 +305,10 @@ func TestPutSubmodelUpdateFormulaDenialRollsBackBeforeDiff(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(400))
+	expectForceGenericSubmodelPutPlan(mock)
 	mock.ExpectQuery(`SELECT .*FROM "submodel".*submodel_payload.*`).
 		WillReturnRows(sqlmock.NewRows(submodelStateColumns()))
+	expectRestoreSubmodelPutPlan(mock)
 	mock.ExpectRollback()
 
 	_, err = sut.PutSubmodel(contextWithUpdateFormula(t, false), "sm-existing", submodel)
@@ -323,14 +329,58 @@ func TestPutSubmodelPostUpdateFormulaDenialRollsBack(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(400))
+	expectForceGenericSubmodelPutPlan(mock)
 	expectBareSubmodelStateLoad(mock, "sm-existing", idShort)
 	mock.ExpectQuery(`SELECT .*FROM "submodel".*submodel_payload.*`).
 		WillReturnRows(sqlmock.NewRows(submodelStateColumns()))
+	expectRestoreSubmodelPutPlan(mock)
 	mock.ExpectRollback()
 
 	_, err = sut.PutSubmodel(contextWithUpdateFormula(t, true), "sm-existing", submodel)
 	require.Error(t, err)
 	require.Truef(t, common.IsErrDenied(err), "got %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestForceGenericPlanForSubmodelPutRestoresPreviousMode(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	mock.ExpectQuery(`SELECT current_setting\('plan_cache_mode'::text\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"current_setting"}).AddRow("force_custom_plan"))
+	mock.ExpectQuery(`SELECT set_config\('plan_cache_mode'::text, 'force_generic_plan'::text, TRUE\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"set_config"}).AddRow("force_generic_plan"))
+	mock.ExpectQuery(`SELECT set_config\('plan_cache_mode'::text, 'force_custom_plan'::text, TRUE\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"set_config"}).AddRow("force_custom_plan"))
+	mock.ExpectRollback()
+
+	restore, err := forceGenericPlanForSubmodelPutTx(contextWithABACDisabled(t), tx)
+	require.NoError(t, err)
+	require.NoError(t, restore())
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestForceGenericPlanForSubmodelPutKeepsExistingGenericMode(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	mock.ExpectQuery(`SELECT current_setting\('plan_cache_mode'::text\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"current_setting"}).AddRow("force_generic_plan"))
+	mock.ExpectRollback()
+
+	restore, err := forceGenericPlanForSubmodelPutTx(contextWithABACDisabled(t), tx)
+	require.NoError(t, err)
+	require.NoError(t, restore())
+	require.NoError(t, tx.Rollback())
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -343,6 +393,18 @@ func contextWithUpdateFormula(t *testing.T, allowed bool) context.Context {
 			grammar.RightsEnumUPDATE: expression,
 		},
 	})
+}
+
+func expectForceGenericSubmodelPutPlan(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery(`SELECT current_setting\('plan_cache_mode'::text\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"current_setting"}).AddRow("auto"))
+	mock.ExpectQuery(`SELECT set_config\('plan_cache_mode'::text, 'force_generic_plan'::text, TRUE\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"set_config"}).AddRow("force_generic_plan"))
+}
+
+func expectRestoreSubmodelPutPlan(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery(`SELECT set_config\('plan_cache_mode'::text, 'auto'::text, TRUE\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"set_config"}).AddRow("auto"))
 }
 
 func expectSubmodelHistoryAppend(mock sqlmock.Sqlmock) {

--- a/internal/submodelrepository/persistence/submodel_database_patch_put_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_patch_put_sqlmock_test.go
@@ -250,10 +250,8 @@ func TestPutSubmodelNoOpUpdateAppendsHistoryWithoutLiveMutation(t *testing.T) {
 	require.NoError(t, err)
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(400))
-	expectForceGenericSubmodelPutPlan(mock)
 	expectBareSubmodelStateLoad(mock, "sm-existing", "smexisting")
 	expectSubmodelHistoryAppend(mock)
-	expectRestoreSubmodelPutPlan(mock)
 	mock.ExpectRollback()
 
 	result, err := sut.PutSubmodelInTransactionWithResult(contextWithABACDisabled(t), tx, "sm-existing", submodel)
@@ -280,13 +278,11 @@ func TestPutSubmodelChangedUpdateExecutesReconciliationAndHistory(t *testing.T) 
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(400))
-	expectForceGenericSubmodelPutPlan(mock)
 	expectBareSubmodelStateLoad(mock, "sm-existing", "old")
 	mock.ExpectQuery(`WITH reconciliation_plan`).
 		WillReturnRows(sqlmock.NewRows([]string{"updated_count", "inserted_count", "deleted_count"}).AddRow(0, 0, 0))
 	expectBareSubmodelStateLoad(mock, "sm-existing", "new")
 	expectSubmodelHistoryAppend(mock)
-	expectRestoreSubmodelPutPlan(mock)
 	mock.ExpectCommit()
 
 	isUpdate, err := sut.PutSubmodel(contextWithABACDisabled(t), "sm-existing", submodel)
@@ -305,10 +301,8 @@ func TestPutSubmodelUpdateFormulaDenialRollsBackBeforeDiff(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(400))
-	expectForceGenericSubmodelPutPlan(mock)
 	mock.ExpectQuery(`SELECT .*FROM "submodel".*submodel_payload.*`).
 		WillReturnRows(sqlmock.NewRows(submodelStateColumns()))
-	expectRestoreSubmodelPutPlan(mock)
 	mock.ExpectRollback()
 
 	_, err = sut.PutSubmodel(contextWithUpdateFormula(t, false), "sm-existing", submodel)
@@ -329,11 +323,9 @@ func TestPutSubmodelPostUpdateFormulaDenialRollsBack(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery(`SELECT .*FROM .*submodel`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(400))
-	expectForceGenericSubmodelPutPlan(mock)
 	expectBareSubmodelStateLoad(mock, "sm-existing", idShort)
 	mock.ExpectQuery(`SELECT .*FROM "submodel".*submodel_payload.*`).
 		WillReturnRows(sqlmock.NewRows(submodelStateColumns()))
-	expectRestoreSubmodelPutPlan(mock)
 	mock.ExpectRollback()
 
 	_, err = sut.PutSubmodel(contextWithUpdateFormula(t, true), "sm-existing", submodel)
@@ -559,7 +551,9 @@ func expectCreatedPutSubmodelSnapshotLoad(mock sqlmock.Sqlmock, submodelID strin
 
 func expectBareSubmodelStateLoad(mock sqlmock.Sqlmock, submodelID string, idShort string) {
 	expectSubmodelMetadataStateLoad(mock, submodelID, idShort, nil, nil, nil, nil, nil, nil, nil, nil)
+	expectForceGenericSubmodelPutPlan(mock)
 	expectEmptyRootSubmodelElementsLoad(mock)
+	expectRestoreSubmodelPutPlan(mock)
 }
 
 func expectSubmodelStateLoad(mock sqlmock.Sqlmock, submodelID string, idShort string, payloads ...any) {

--- a/internal/submodelrepository/persistence/submodel_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_write_database.go
@@ -508,11 +508,22 @@ func (s *SubmodelDatabase) createSubmodelForPutTx(ctx context.Context, tx *sql.T
 	return false, nil
 }
 
-func (s *SubmodelDatabase) reconcileExistingSubmodelForPutTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int, submitted types.ISubmodel) (PutSubmodelResult, error) {
+func (s *SubmodelDatabase) reconcileExistingSubmodelForPutTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int, submitted types.ISubmodel) (result PutSubmodelResult, err error) {
 	readCtx, shouldEnforce, err := selectPutFormulaContext(ctx, true)
 	if err != nil {
 		return PutSubmodelResult{}, err
 	}
+	restorePlanCacheMode, err := forceGenericPlanForSubmodelPutTx(ctx, tx)
+	if err != nil {
+		return PutSubmodelResult{}, err
+	}
+	defer func() {
+		if restoreErr := restorePlanCacheMode(); err == nil && restoreErr != nil {
+			result = PutSubmodelResult{}
+			err = restoreErr
+		}
+	}()
+
 	previous, err := s.readPutSubmodelStateTx(readCtx, tx, submodelDatabaseID, submitted.ID())
 	if err != nil {
 		return PutSubmodelResult{}, mapPutReadbackError(err, shouldEnforce, true)
@@ -549,6 +560,61 @@ func (s *SubmodelDatabase) reconcileExistingSubmodelForPutTx(ctx context.Context
 		return PutSubmodelResult{}, err
 	}
 	return PutSubmodelResult{IsUpdate: true, Changed: true, Previous: previous}, nil
+}
+
+func forceGenericPlanForSubmodelPutTx(ctx context.Context, tx *sql.Tx) (func() error, error) {
+	previousMode, err := currentPostgreSQLPlanCacheModeTx(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	const genericPlanMode = "force_generic_plan"
+	if previousMode == genericPlanMode {
+		return func() error { return nil }, nil
+	}
+	if err = setPostgreSQLPlanCacheModeTx(ctx, tx, genericPlanMode); err != nil {
+		return nil, err
+	}
+	return func() error {
+		return setPostgreSQLPlanCacheModeTx(ctx, tx, previousMode)
+	}, nil
+}
+
+func currentPostgreSQLPlanCacheModeTx(ctx context.Context, tx *sql.Tx) (string, error) {
+	query := goqu.Dialect("postgres").Select(
+		goqu.Func("current_setting", common.PostgreSQLTextLiteral("plan_cache_mode")),
+	)
+	sqlQuery, args, err := query.Prepared(true).ToSQL()
+	if err != nil {
+		return "", common.NewInternalServerError("SMREPO-PUTSM-GETPLANMODE-BUILDQ " + err.Error())
+	}
+	var mode string
+	if err = tx.QueryRowContext(ctx, sqlQuery, args...).Scan(&mode); err != nil {
+		return "", common.NewInternalServerError("SMREPO-PUTSM-GETPLANMODE-EXECQ " + err.Error())
+	}
+	return mode, nil
+}
+
+func setPostgreSQLPlanCacheModeTx(ctx context.Context, tx *sql.Tx, mode string) error {
+	query := goqu.Dialect("postgres").Select(
+		goqu.Func(
+			"set_config",
+			common.PostgreSQLTextLiteral("plan_cache_mode"),
+			common.PostgreSQLTextLiteral(mode),
+			goqu.L("TRUE"),
+		),
+	)
+	sqlQuery, args, err := query.Prepared(true).ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("SMREPO-PUTSM-SETPLANMODE-BUILDQ " + err.Error())
+	}
+	var configuredMode string
+	if err = tx.QueryRowContext(ctx, sqlQuery, args...).Scan(&configuredMode); err != nil {
+		return common.NewInternalServerError("SMREPO-PUTSM-SETPLANMODE-EXECQ " + err.Error())
+	}
+	if configuredMode != mode {
+		return common.NewInternalServerError("SMREPO-PUTSM-SETPLANMODE-MISMATCH expected " + mode + " but PostgreSQL returned " + configuredMode)
+	}
+	return nil
 }
 
 func (s *SubmodelDatabase) appendAcknowledgedSubmodelPutHistoryTx(

--- a/internal/submodelrepository/persistence/submodel_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_write_database.go
@@ -508,23 +508,12 @@ func (s *SubmodelDatabase) createSubmodelForPutTx(ctx context.Context, tx *sql.T
 	return false, nil
 }
 
-func (s *SubmodelDatabase) reconcileExistingSubmodelForPutTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int, submitted types.ISubmodel) (result PutSubmodelResult, err error) {
+func (s *SubmodelDatabase) reconcileExistingSubmodelForPutTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int, submitted types.ISubmodel) (PutSubmodelResult, error) {
 	readCtx, shouldEnforce, err := selectPutFormulaContext(ctx, true)
 	if err != nil {
 		return PutSubmodelResult{}, err
 	}
-	restorePlanCacheMode, err := forceGenericPlanForSubmodelPutTx(ctx, tx)
-	if err != nil {
-		return PutSubmodelResult{}, err
-	}
-	defer func() {
-		if restoreErr := restorePlanCacheMode(); err == nil && restoreErr != nil {
-			result = PutSubmodelResult{}
-			err = restoreErr
-		}
-	}()
-
-	previous, err := s.readPutSubmodelStateTx(readCtx, tx, submodelDatabaseID, submitted.ID())
+	previous, err := s.readExistingPutSubmodelStateTx(readCtx, tx, submodelDatabaseID, submitted.ID())
 	if err != nil {
 		return PutSubmodelResult{}, mapPutReadbackError(err, shouldEnforce, true)
 	}
@@ -535,7 +524,7 @@ func (s *SubmodelDatabase) reconcileExistingSubmodelForPutTx(ctx context.Context
 	if !plan.hasLiveMutation() {
 		persisted := previous
 		if shouldEnforce {
-			persisted, err = s.readPutSubmodelStateTx(readCtx, tx, submodelDatabaseID, submitted.ID())
+			persisted, err = s.readExistingPutSubmodelStateTx(readCtx, tx, submodelDatabaseID, submitted.ID())
 			if err != nil {
 				return PutSubmodelResult{}, mapPutReadbackError(err, true, false)
 			}
@@ -552,7 +541,7 @@ func (s *SubmodelDatabase) reconcileExistingSubmodelForPutTx(ctx context.Context
 	if !shouldEnforce && !recordHistory {
 		return PutSubmodelResult{IsUpdate: true, Changed: true, Previous: previous}, nil
 	}
-	persisted, err := s.readPutSubmodelStateTx(readCtx, tx, submodelDatabaseID, submitted.ID())
+	persisted, err := s.readExistingPutSubmodelStateTx(readCtx, tx, submodelDatabaseID, submitted.ID())
 	if err != nil {
 		return PutSubmodelResult{}, mapPutReadbackError(err, shouldEnforce, false)
 	}
@@ -673,6 +662,24 @@ func selectPutFormulaContext(ctx context.Context, exists bool) (context.Context,
 }
 
 func (s *SubmodelDatabase) readPutSubmodelStateTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int, submodelID string) (types.ISubmodel, error) {
+	return s.readPutSubmodelStateWithElementsTx(
+		ctx, tx, submodelDatabaseID, submodelID, readPutSubmodelElementsTx,
+	)
+}
+
+func (s *SubmodelDatabase) readExistingPutSubmodelStateTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int, submodelID string) (types.ISubmodel, error) {
+	return s.readPutSubmodelStateWithElementsTx(
+		ctx, tx, submodelDatabaseID, submodelID, readPutSubmodelElementsWithGenericPlanTx,
+	)
+}
+
+func (s *SubmodelDatabase) readPutSubmodelStateWithElementsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	submodelDatabaseID int,
+	submodelID string,
+	readElements func(context.Context, *sql.Tx, int) ([]types.ISubmodelElement, error),
+) (types.ISubmodel, error) {
 	metadataCtx, err := contextWithoutFragmentFilters(ctx)
 	if err != nil {
 		return nil, err
@@ -681,14 +688,33 @@ func (s *SubmodelDatabase) readPutSubmodelStateTx(ctx context.Context, tx *sql.T
 	if err != nil {
 		return nil, err
 	}
-	elements, err := submodelelements.GetSubmodelElementsByDatabaseIDTxInPersistenceOrder(
-		auth.ContextWithoutQueryFilter(ctx), tx, submodelDatabaseID, true,
-	)
+	elements, err := readElements(ctx, tx, submodelDatabaseID)
 	if err != nil {
 		return nil, err
 	}
 	submodel.SetSubmodelElements(elements)
 	return submodel, nil
+}
+
+func readPutSubmodelElementsTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int) ([]types.ISubmodelElement, error) {
+	return submodelelements.GetSubmodelElementsByDatabaseIDTxInPersistenceOrder(
+		auth.ContextWithoutQueryFilter(ctx), tx, submodelDatabaseID, true,
+	)
+}
+
+func readPutSubmodelElementsWithGenericPlanTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int) (elements []types.ISubmodelElement, err error) {
+	restorePlanCacheMode, err := forceGenericPlanForSubmodelPutTx(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if restoreErr := restorePlanCacheMode(); err == nil && restoreErr != nil {
+			elements = nil
+			err = restoreErr
+		}
+	}()
+
+	return readPutSubmodelElementsTx(ctx, tx, submodelDatabaseID)
 }
 
 func contextWithoutFragmentFilters(ctx context.Context) (context.Context, error) {


### PR DESCRIPTION
## Description of Changes

This PR reduces PostgreSQL planning overhead for existing Submodel PUT requests.

The persisted SubmodelElement state query has a stable shape, but PostgreSQL was selecting and planning a custom execution plan for nearly every request. On the one-million-resource benchmark database, planning that snapshot took around 200 ms while executing it took around 1.3 ms.

Existing Submodel PUT transactions now temporarily use a generic plan only while reconstructing persisted SubmodelElement state. The previous transaction setting is restored before diff reconciliation, history writes, authorization readback completion, or surrounding AAS Environment/DPP work continues. Other endpoints and transaction work keep their original plan mode.

The optimization uses pgx's default `cache_statement` execution mode. Connections explicitly configured with `default_query_exec_mode=exec` or `simple_protocol` remain correct, but cannot reuse a server-side generic plan and therefore should not be expected to receive the same performance improvement.

Measurements at concurrency 40 on the fp-rke benchmark cluster with the representative HARTING-derived dataset and one million Submodels:

| Workload | Before | Narrowed implementation |
|---|---:|---:|
| Semantic no-op PUT | 170 RPS, p50 233 ms | 1,637 RPS, p50 19.1 ms, p95 47.4 ms |
| One Property value changed | 166 RPS, p50 242 ms | 1,274 RPS, p50 26.9 ms, p95 51.7 ms |
| Broad value and element-order changes | — | 852 RPS, p50 39.1 ms, p95 75.6 ms |

All measurements completed without request failures. The structural-change profile alternates real HARTING-derived Submodels while changing every string Property value and reordering nested element collections.

## Changelog

- [x] I added a Changie fragment under `.changes/unreleased` for every notable user-visible or security-related change.
- [ ] This pull request has no notable user-visible or security effect; a reviewer may apply the `no-changelog` label.

## Related Issue

None.

## BaSyx Configuration for Testing

No special BaSyx configuration is required.

The performance comparison uses the representative HARTING-derived dataset with one million Submodels on the fp-rke benchmark cluster.

## AAS Files Used for Testing

The existing Submodel Repository integration-test fixtures and the HARTING-derived benchmark dataset were used.

## Additional Information

The complete Submodel Repository integration suite passes, including reconciliation of 1,200 SubmodelElements, concurrent identical PUT requests, ABAC checks, nested elements and managed files.
