### PR TITLE
Update descriptor graphs in place

### DIFF
--- a/.changes/unreleased/fixed-20260830-122000.yaml
+++ b/.changes/unreleased/fixed-20260830-122000.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: Registry PUT operations preserve descriptor root rows and rewrite only changed descriptor fields and child collections.
+time: 2026-08-30T12:20:00.000000+02:00
+custom:
+    Impact: Low
+    PullRequest: 641
+    SecurityImpact: Existing pre-update and post-update ABAC checks remain in place; restricted reads use a complete internal snapshot only after authorization succeeds.

--- a/internal/aasregistry/integration_tests/aasregistry_update_persistence_integration_test.go
+++ b/internal/aasregistry/integration_tests/aasregistry_update_persistence_integration_test.go
@@ -1,0 +1,125 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+//nolint:all
+package main
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/stretchr/testify/require"
+)
+
+type aasDescriptorPersistenceState struct {
+	descriptorID      int64
+	aasUpdatedAt      time.Time
+	payloadUpdatedAt  time.Time
+	endpointID        int64
+	endpointUpdatedAt time.Time
+}
+
+func TestAASDescriptorPutPreservesUnchangedRows(t *testing.T) {
+	aasID := fmt.Sprintf("urn:example:aas:update-persistence:%d", time.Now().UnixNano())
+	t.Cleanup(func() { cleanupAASDescriptor(t, aasRegistryBaseURL, aasID) })
+	identifier := base64.RawURLEncoding.EncodeToString([]byte(aasID))
+	endpoint := fmt.Sprintf("%s/shell-descriptors/%s", aasRegistryBaseURL, identifier)
+	payload := func(description string) string {
+		return fmt.Sprintf(
+			`{"id":"%s","description":[{"language":"en","text":"%s"}],"endpoints":[{"interface":"AAS-3.0","protocolInformation":{"href":"https://example.com/aas/%s","endpointProtocol":"https"}}]}`,
+			aasID,
+			description,
+			identifier,
+		)
+	}
+
+	_, status, _, err := postJSONResponse(aasRegistryBaseURL+"/shell-descriptors", payload("before"))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status)
+
+	db, err := sql.Open("pgx", aasRegistryIntegrationTestDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	before := readAASDescriptorPersistenceState(t, db, aasID)
+
+	time.Sleep(20 * time.Millisecond)
+	_, status, _, err = putJSONResponse(endpoint, payload("after"))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, status)
+	afterChange := readAASDescriptorPersistenceState(t, db, aasID)
+	require.Equal(t, before.descriptorID, afterChange.descriptorID)
+	require.Equal(t, before.endpointID, afterChange.endpointID)
+	require.Equal(t, before.endpointUpdatedAt, afterChange.endpointUpdatedAt)
+	require.True(t, afterChange.aasUpdatedAt.After(before.aasUpdatedAt))
+	require.True(t, afterChange.payloadUpdatedAt.After(before.payloadUpdatedAt))
+
+	time.Sleep(20 * time.Millisecond)
+	_, status, _, err = putJSONResponse(endpoint, payload("after"))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, status)
+	afterNoOp := readAASDescriptorPersistenceState(t, db, aasID)
+	require.Equal(t, afterChange, afterNoOp)
+}
+
+func readAASDescriptorPersistenceState(t *testing.T, db *sql.DB, aasID string) aasDescriptorPersistenceState {
+	t.Helper()
+	aas := goqu.T(common.TblAASDescriptor).As("aas")
+	payload := goqu.T(common.TblDescriptorPayload).As("payload")
+	endpoint := goqu.T(common.TblAASDescriptorEndpoint).As("endpoint")
+	query, args, err := goqu.Dialect(common.Dialect).
+		From(aas).
+		InnerJoin(payload, goqu.On(payload.Col(common.ColDescriptorID).Eq(aas.Col(common.ColDescriptorID)))).
+		InnerJoin(endpoint, goqu.On(endpoint.Col(common.ColDescriptorID).Eq(aas.Col(common.ColDescriptorID)))).
+		Select(
+			aas.Col(common.ColDescriptorID),
+			aas.Col("db_updated_at"),
+			payload.Col("db_updated_at"),
+			endpoint.Col(common.ColID),
+			endpoint.Col("db_updated_at"),
+		).
+		Where(
+			aas.Col(common.ColAASID).Eq(aasID),
+			endpoint.Col(common.ColPosition).Eq(0),
+		).
+		Prepared(true).
+		ToSQL()
+	require.NoError(t, err)
+	var state aasDescriptorPersistenceState
+	err = db.QueryRowContext(t.Context(), query, args...).Scan(
+		&state.descriptorID,
+		&state.aasUpdatedAt,
+		&state.payloadUpdatedAt,
+		&state.endpointID,
+		&state.endpointUpdatedAt,
+	)
+	require.NoError(t, err)
+	return state
+}

--- a/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
+++ b/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
@@ -478,6 +478,18 @@ func (p *PostgreSQLAASRegistryDatabase) DeleteAssetAdministrationShellDescriptor
 	})
 }
 
+func loadAASDescriptorForUpdateTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	aasID string,
+) (model.AssetAdministrationShellDescriptor, error) {
+	descriptor, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasID)
+	if err != nil || descriptors.CanSkipUpdateReadback(ctx) {
+		return descriptor, err
+	}
+	return descriptors.GetAssetAdministrationShellDescriptorByIDTx(auth.ContextWithoutQueryFilter(ctx), tx, aasID)
+}
+
 // ReplaceAdministrationShellDescriptor replaces an existing AAS descriptor
 // with the given value and reports whether it existed.
 func (p *PostgreSQLAASRegistryDatabase) ReplaceAdministrationShellDescriptor(
@@ -490,26 +502,34 @@ func (p *PostgreSQLAASRegistryDatabase) ReplaceAdministrationShellDescriptor(
 		if snapshotErr != nil {
 			return snapshotErr
 		}
-		if _, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id); err != nil {
-			return err
-		}
-		createdAt, err := descriptors.GetAASDescriptorCreatedAtByIDTx(ctx, tx, aasd.Id)
+		descriptorID, err := descriptors.LockAdministrationShellDescriptorForUpdateTx(ctx, tx, aasd.Id)
 		if err != nil {
 			return err
 		}
-		aasd.CreatedAt = &createdAt
-		if err := descriptors.DeleteAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id); err != nil {
-			return err
-		}
-		if err := descriptors.InsertAdministrationShellDescriptorTx(descriptors.WithAllowAASDescriptorCreatedAtOverride(ctx), tx, aasd); err != nil {
-			return err
-		}
-		stored, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id)
+		previous, err := loadAASDescriptorForUpdateTx(ctx, tx, aasd.Id)
 		if err != nil {
 			return err
 		}
-		if err := appendDescriptorHistoryTx(ctx, tx, stored, previousSnapshot, history.ChangeUpdated, false); err != nil {
+		changed, err := descriptors.UpdateAdministrationShellDescriptorTx(ctx, tx, descriptorID, previous, aasd)
+		if err != nil {
 			return err
+		}
+
+		stored := previous
+		if changed {
+			aasd.CreatedAt = previous.CreatedAt
+			stored = aasd
+			if !descriptors.CanSkipUpdateReadback(ctx) || history.MutationRecordingEnabled() {
+				stored, err = descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if history.MutationRecordingEnabled() {
+			if err = appendDescriptorHistoryTx(ctx, tx, stored, previousSnapshot, history.ChangeUpdated, false); err != nil {
+				return err
+			}
 		}
 		result = stored
 		return nil
@@ -535,19 +555,53 @@ func (p *PostgreSQLAASRegistryDatabase) UpsertAdministrationShellDescriptorInTra
 	if err != nil && !common.IsErrNotFound(err) {
 		return err
 	}
-	created, err := descriptors.UpsertAdministrationShellDescriptorTx(ctx, tx, aasd)
-	if err != nil {
-		return err
+	created := false
+	stored := aasd
+	descriptorID, lockErr := descriptors.LockAdministrationShellDescriptorForUpdateTx(ctx, tx, aasd.Id)
+	switch {
+	case lockErr == nil:
+		previous, getErr := loadAASDescriptorForUpdateTx(ctx, tx, aasd.Id)
+		if getErr != nil {
+			return getErr
+		}
+		changed, updateErr := descriptors.UpdateAdministrationShellDescriptorTx(ctx, tx, descriptorID, previous, aasd)
+		if updateErr != nil {
+			return updateErr
+		}
+		stored = previous
+		if changed {
+			aasd.CreatedAt = previous.CreatedAt
+			stored = aasd
+		}
+	case common.IsErrNotFound(lockErr):
+		created = true
+		if insertErr := descriptors.InsertAdministrationShellDescriptorTx(ctx, tx, aasd); insertErr != nil {
+			return insertErr
+		}
+	default:
+		return lockErr
 	}
 
-	stored, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id)
-	if err != nil {
-		return err
+	canSkipReadback := descriptors.CanSkipUpdateReadback(ctx)
+	if created {
+		canSkipReadback = descriptors.CanSkipCreateReadback(ctx)
+	}
+	if !canSkipReadback || history.MutationRecordingEnabled() {
+		stored, err = descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasd.Id)
+		if err != nil {
+			return err
+		}
 	}
 	if created {
-		return appendDescriptorHistoryTx(ctx, tx, stored, nil, history.ChangeCreated, false)
+		if history.MutationRecordingEnabled() {
+			return appendDescriptorHistoryTx(ctx, tx, stored, nil, history.ChangeCreated, false)
+		}
+		return nil
 	}
-	return appendDescriptorHistoryTx(ctx, tx, stored, previousSnapshot, history.ChangeUpdated, false)
+	if history.MutationRecordingEnabled() {
+		return appendDescriptorHistoryTx(ctx, tx, stored, previousSnapshot, history.ChangeUpdated, false)
+	}
+	return nil
 }
 
 // DeleteAssetAdministrationShellDescriptorByIDInTransaction deletes an AAS
@@ -700,6 +754,19 @@ func (p *PostgreSQLAASRegistryDatabase) InsertSubmodelDescriptorForAAS(
 	return result, nil
 }
 
+func loadEmbeddedSubmodelDescriptorForUpdateTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	aasID string,
+	submodelID string,
+) (model.SubmodelDescriptor, error) {
+	descriptor, err := descriptors.GetSubmodelDescriptorForAASByID(ctx, tx, aasID, submodelID)
+	if err != nil || descriptors.CanSkipUpdateReadback(ctx) {
+		return descriptor, err
+	}
+	return descriptors.GetSubmodelDescriptorForAASByID(auth.ContextWithoutQueryFilter(ctx), tx, aasID, submodelID)
+}
+
 // ReplaceSubmodelDescriptorForAAS replaces a submodel descriptor for the given
 // AAS ID and reports whether it existed.
 func (p *PostgreSQLAASRegistryDatabase) ReplaceSubmodelDescriptorForAAS(
@@ -713,18 +780,32 @@ func (p *PostgreSQLAASRegistryDatabase) ReplaceSubmodelDescriptorForAAS(
 		if snapshotErr != nil {
 			return snapshotErr
 		}
-		if _, err := descriptors.GetSubmodelDescriptorForAASByID(ctx, tx, aasID, submodel.Id); err != nil {
-			return err
-		}
-		if err := descriptors.DeleteSubmodelDescriptorForAASByIDTx(ctx, tx, aasID, submodel.Id); err != nil {
-			return err
-		}
-		stored, err := descriptors.InsertSubmodelDescriptorForAASTx(ctx, tx, aasID, submodel)
+		descriptorID, position, err := descriptors.LockSubmodelDescriptorForAASUpdateTx(ctx, tx, aasID, submodel.Id)
 		if err != nil {
 			return err
 		}
-		if err := p.appendReplacedSubmodelDescriptorHistoryTx(ctx, tx, aasID, previousSnapshot, stored); err != nil {
+		previous, err := loadEmbeddedSubmodelDescriptorForUpdateTx(ctx, tx, aasID, submodel.Id)
+		if err != nil {
 			return err
+		}
+		changed, err := descriptors.UpdateSubmodelDescriptorTx(ctx, tx, descriptorID, previous, submodel, position, false)
+		if err != nil {
+			return err
+		}
+		stored := previous
+		if changed {
+			stored = submodel
+			if !descriptors.CanSkipUpdateReadback(ctx) || history.MutationRecordingEnabled() {
+				stored, err = descriptors.GetSubmodelDescriptorForAASByID(ctx, tx, aasID, submodel.Id)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if history.MutationRecordingEnabled() {
+			if err = p.appendReplacedSubmodelDescriptorHistoryTx(ctx, tx, aasID, previousSnapshot, stored); err != nil {
+				return err
+			}
 		}
 		result = stored
 		return nil

--- a/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
+++ b/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
@@ -157,6 +157,10 @@ func loadDescriptorHistorySnapshotBeforeMutationTx(ctx context.Context, tx *sql.
 	if err := history.LockMutationTx(ctx, tx, history.TableDescriptor, aasID); err != nil {
 		return nil, err
 	}
+	return loadDescriptorHistorySnapshotAfterMutationLockTx(ctx, tx, aasID)
+}
+
+func loadDescriptorHistorySnapshotAfterMutationLockTx(ctx context.Context, tx *sql.Tx, aasID string) (map[string]any, error) {
 	descriptor, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(auth.ContextWithoutQueryFilter(ctx), tx, aasID)
 	if err != nil {
 		return nil, err
@@ -490,6 +494,57 @@ func loadAASDescriptorForUpdateTx(
 	return descriptors.GetAssetAdministrationShellDescriptorByIDTx(auth.ContextWithoutQueryFilter(ctx), tx, aasID)
 }
 
+func loadAuthorizedAASDescriptorEvidenceSnapshotTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	aasID string,
+	allowNotFound bool,
+) (map[string]any, error) {
+	if !history.ActiveConfig().EvidenceEnabled {
+		return nil, nil
+	}
+	if err := history.LockMutationTx(ctx, tx, history.TableDescriptor, aasID); err != nil {
+		return nil, err
+	}
+	if !descriptors.CanSkipUpdateReadback(ctx) {
+		if _, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasID); err != nil {
+			if allowNotFound && common.IsErrNotFound(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+	}
+	snapshot, err := loadDescriptorHistorySnapshotAfterMutationLockTx(ctx, tx, aasID)
+	if err != nil {
+		if allowNotFound && common.IsErrNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return snapshot, nil
+}
+
+func loadAuthorizedEmbeddedDescriptorEvidenceSnapshotTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	aasID string,
+	submodelID string,
+	canSkipAuthorization bool,
+) (map[string]any, error) {
+	if !history.ActiveConfig().EvidenceEnabled {
+		return nil, nil
+	}
+	if err := history.LockMutationTx(ctx, tx, history.TableDescriptor, aasID); err != nil {
+		return nil, err
+	}
+	if !canSkipAuthorization {
+		if _, err := descriptors.GetSubmodelDescriptorForAASByID(ctx, tx, aasID, submodelID); err != nil {
+			return nil, err
+		}
+	}
+	return loadDescriptorHistorySnapshotAfterMutationLockTx(ctx, tx, aasID)
+}
+
 // ReplaceAdministrationShellDescriptor replaces an existing AAS descriptor
 // with the given value and reports whether it existed.
 func (p *PostgreSQLAASRegistryDatabase) ReplaceAdministrationShellDescriptor(
@@ -498,7 +553,7 @@ func (p *PostgreSQLAASRegistryDatabase) ReplaceAdministrationShellDescriptor(
 ) (model.AssetAdministrationShellDescriptor, error) {
 	var result model.AssetAdministrationShellDescriptor
 	err := common.ExecuteInTransaction(p.writerDB, "AASREG-REPLACEAASDESC-STARTTX", "AASREG-REPLACEAASDESC-COMMIT", func(tx *sql.Tx) error {
-		previousSnapshot, snapshotErr := loadDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, aasd.Id)
+		previousSnapshot, snapshotErr := loadAuthorizedAASDescriptorEvidenceSnapshotTx(ctx, tx, aasd.Id, false)
 		if snapshotErr != nil {
 			return snapshotErr
 		}
@@ -551,8 +606,8 @@ func (p *PostgreSQLAASRegistryDatabase) UpsertAdministrationShellDescriptorInTra
 		return common.NewInternalServerError("AASREG-UPSERTAASDESC-NILTX transaction must not be nil")
 	}
 
-	previousSnapshot, err := loadDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, aasd.Id)
-	if err != nil && !common.IsErrNotFound(err) {
+	previousSnapshot, err := loadAuthorizedAASDescriptorEvidenceSnapshotTx(ctx, tx, aasd.Id, true)
+	if err != nil {
 		return err
 	}
 	created := false
@@ -738,6 +793,9 @@ func (p *PostgreSQLAASRegistryDatabase) InsertSubmodelDescriptorForAAS(
 		if snapshotErr != nil {
 			return snapshotErr
 		}
+		if _, lockErr := descriptors.LockAdministrationShellDescriptorForUpdateTx(ctx, tx, aasID); lockErr != nil {
+			return lockErr
+		}
 		stored, err := descriptors.InsertSubmodelDescriptorForAASTx(ctx, tx, aasID, submodel)
 		if err != nil {
 			return err
@@ -776,9 +834,14 @@ func (p *PostgreSQLAASRegistryDatabase) ReplaceSubmodelDescriptorForAAS(
 ) (model.SubmodelDescriptor, error) {
 	var result model.SubmodelDescriptor
 	err := common.ExecuteInTransaction(p.writerDB, "AASREG-REPLACESMDESCFORAAS-STARTTX", "AASREG-REPLACESMDESCFORAAS-COMMIT", func(tx *sql.Tx) error {
-		previousSnapshot, snapshotErr := loadDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, aasID)
+		previousSnapshot, snapshotErr := loadAuthorizedEmbeddedDescriptorEvidenceSnapshotTx(
+			ctx, tx, aasID, submodel.Id, descriptors.CanSkipUpdateReadback(ctx),
+		)
 		if snapshotErr != nil {
 			return snapshotErr
+		}
+		if _, lockErr := descriptors.LockAdministrationShellDescriptorForUpdateTx(ctx, tx, aasID); lockErr != nil {
+			return lockErr
 		}
 		descriptorID, position, err := descriptors.LockSubmodelDescriptorForAASUpdateTx(ctx, tx, aasID, submodel.Id)
 		if err != nil {
@@ -840,9 +903,14 @@ func (p *PostgreSQLAASRegistryDatabase) DeleteSubmodelDescriptorForAASByID(
 	submodelID string,
 ) error {
 	return common.ExecuteInTransaction(p.writerDB, "AASREG-DELSMDESCFORAAS-STARTTX", "AASREG-DELSMDESCFORAAS-COMMIT", func(tx *sql.Tx) error {
-		previousSnapshot, snapshotErr := loadDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, aasID)
+		previousSnapshot, snapshotErr := loadAuthorizedEmbeddedDescriptorEvidenceSnapshotTx(
+			ctx, tx, aasID, submodelID, descriptors.CanSkipDeleteReadback(ctx),
+		)
 		if snapshotErr != nil {
 			return snapshotErr
+		}
+		if _, lockErr := descriptors.LockAdministrationShellDescriptorForUpdateTx(ctx, tx, aasID); lockErr != nil {
+			return lockErr
 		}
 		if _, err := descriptors.GetSubmodelDescriptorForAASByID(ctx, tx, aasID, submodelID); err != nil {
 			return err

--- a/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
+++ b/internal/common/descriptors/AssetAdminShellDescriptorHandler.go
@@ -156,6 +156,25 @@ func CanSkipDeleteReadback(ctx context.Context) bool {
 	return auth.HasUnrestrictedFormulaForRight(ctx, grammar.RightsEnumDELETE)
 }
 
+// CanSkipUpdateReadback reports whether the request context has no restrictive
+// update formula or fragment filter that requires post-update authorization.
+func CanSkipUpdateReadback(ctx context.Context) bool {
+	queryFilter := auth.GetQueryFilter(ctx)
+	if queryFilter == nil {
+		return true
+	}
+	if len(queryFilter.Filters) > 0 {
+		return false
+	}
+	if len(queryFilter.FormulasByRight) > 0 {
+		return auth.HasUnrestrictedFormulaForRight(ctx, grammar.RightsEnumUPDATE)
+	}
+	if queryFilter.Formula == nil {
+		return true
+	}
+	return auth.HasUnrestrictedFormulaForRight(ctx, grammar.RightsEnumUPDATE)
+}
+
 // InsertAdministrationShellDescriptorTx performs the same insert as
 // InsertAdministrationShellDescriptor but uses the provided transaction. This allows
 // callers to compose multiple writes into a single atomic unit.

--- a/internal/common/descriptors/WriteSubmodelDescriptor.go
+++ b/internal/common/descriptors/WriteSubmodelDescriptor.go
@@ -50,100 +50,109 @@ func createSubModelDescriptors(tx *sql.Tx, aasDescriptorID sql.NullInt64, submod
 			startPosition = nextPosition
 		}
 
-		d := goqu.Dialect(common.Dialect)
 		for i, val := range submodelDescriptors {
-			var err error
 			position := i
 			if useAppendPosition {
 				position = startPosition + i
 			}
-
-			descriptionPayload, err := buildLangStringTextPayload(val.Description)
-			if err != nil {
-				return common.NewInternalServerError("SMDESC-INSERT-DESCRIPTIONPAYLOAD")
-			}
-			displayNamePayload, err := buildLangStringNamePayload(val.DisplayName)
-			if err != nil {
-				return common.NewInternalServerError("SMDESC-INSERT-DISPLAYNAMEPAYLOAD")
-			}
-			administrationPayload, err := buildAdministrativeInfoPayload(val.Administration)
-			if err != nil {
-				return common.NewInternalServerError("SMDESC-INSERT-ADMINPAYLOAD")
-			}
-			extensionsPayload, err := buildExtensionsPayload(val.Extensions)
-			if err != nil {
-				return common.NewInternalServerError("SMDESC-INSERT-EXTENSIONPAYLOAD")
-			}
-
-			sqlStr, args, err := d.
-				Insert(common.TblDescriptor).
-				Returning(common.TDescriptor.Col(common.ColID)).
-				ToSQL()
-			if err != nil {
-				return err
-			}
-			var submodelDescriptorID int64
-			if err = tx.QueryRow(sqlStr, args...).Scan(&submodelDescriptorID); err != nil {
-				return err
-			}
-
-			sqlStr, args, err = d.
-				Insert(common.TblSubmodelDescriptor).
-				Rows(goqu.Record{
-					common.ColDescriptorID:    submodelDescriptorID,
-					common.ColPosition:        position,
-					common.ColAASDescriptorID: aasDescriptorID,
-					common.ColIDShort:         val.IdShort,
-					common.ColAASID:           val.Id,
-				}).
-				ToSQL()
-			if err != nil {
-				return err
-			}
-			if _, err = tx.Exec(sqlStr, args...); err != nil {
-				return err
-			}
-
-			if err = common.CreateContextReference(
-				tx,
-				submodelDescriptorID,
-				val.SemanticId,
-				"submodel_descriptor_semantic_id_reference",
-				"submodel_descriptor_semantic_id_reference_key",
-			); err != nil {
-				return err
-			}
-
-			sqlStr, args, err = d.
-				Insert(common.TblDescriptorPayload).
-				Rows(goqu.Record{
-					common.ColDescriptorID:              submodelDescriptorID,
-					common.ColDescriptionPayload:        goqu.L("?::jsonb", string(descriptionPayload)),
-					common.ColDisplayNamePayload:        goqu.L("?::jsonb", string(displayNamePayload)),
-					common.ColAdministrativeInfoPayload: goqu.L("?::jsonb", string(administrationPayload)),
-					common.ColExtensionsPayload:         goqu.L("?::jsonb", string(extensionsPayload)),
-				}).
-				ToSQL()
-			if err != nil {
-				return err
-			}
-			if _, err = tx.Exec(sqlStr, args...); err != nil {
-				return err
-			}
-
-			if err = createsubModelDescriptorSupplementalSemantic(tx, submodelDescriptorID, val.SupplementalSemanticId); err != nil {
-				return err
-			}
-
-			if len(val.Endpoints) == 0 {
-				return common.NewErrBadRequest("Submodel Descriptor needs at least 1 Endpoint.")
-			}
-			if err = CreateEndpoints(tx, submodelDescriptorID, val.Endpoints); err != nil {
+			if _, err := insertSubmodelDescriptorAtPositionTx(tx, aasDescriptorID, val, position); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func insertSubmodelDescriptorAtPositionTx(
+	tx *sql.Tx,
+	aasDescriptorID sql.NullInt64,
+	value model.SubmodelDescriptor,
+	position int,
+) (int64, error) {
+	if len(value.Endpoints) == 0 {
+		return 0, common.NewErrBadRequest("Submodel Descriptor needs at least 1 Endpoint.")
+	}
+
+	descriptionPayload, err := buildLangStringTextPayload(value.Description)
+	if err != nil {
+		return 0, common.NewInternalServerError("SMDESC-INSERT-DESCRIPTIONPAYLOAD")
+	}
+	displayNamePayload, err := buildLangStringNamePayload(value.DisplayName)
+	if err != nil {
+		return 0, common.NewInternalServerError("SMDESC-INSERT-DISPLAYNAMEPAYLOAD")
+	}
+	administrationPayload, err := buildAdministrativeInfoPayload(value.Administration)
+	if err != nil {
+		return 0, common.NewInternalServerError("SMDESC-INSERT-ADMINPAYLOAD")
+	}
+	extensionsPayload, err := buildExtensionsPayload(value.Extensions)
+	if err != nil {
+		return 0, common.NewInternalServerError("SMDESC-INSERT-EXTENSIONPAYLOAD")
+	}
+
+	d := goqu.Dialect(common.Dialect)
+	sqlStr, args, err := d.
+		Insert(common.TblDescriptor).
+		Returning(common.TDescriptor.Col(common.ColID)).
+		ToSQL()
+	if err != nil {
+		return 0, err
+	}
+	var descriptorID int64
+	if err = tx.QueryRow(sqlStr, args...).Scan(&descriptorID); err != nil {
+		return 0, err
+	}
+
+	sqlStr, args, err = d.
+		Insert(common.TblSubmodelDescriptor).
+		Rows(goqu.Record{
+			common.ColDescriptorID:    descriptorID,
+			common.ColPosition:        position,
+			common.ColAASDescriptorID: aasDescriptorID,
+			common.ColIDShort:         value.IdShort,
+			common.ColAASID:           value.Id,
+		}).
+		ToSQL()
+	if err != nil {
+		return 0, err
+	}
+	if _, err = tx.Exec(sqlStr, args...); err != nil {
+		return 0, err
+	}
+
+	if err = common.CreateContextReference(
+		tx,
+		descriptorID,
+		value.SemanticId,
+		"submodel_descriptor_semantic_id_reference",
+		"submodel_descriptor_semantic_id_reference_key",
+	); err != nil {
+		return 0, err
+	}
+
+	sqlStr, args, err = d.
+		Insert(common.TblDescriptorPayload).
+		Rows(goqu.Record{
+			common.ColDescriptorID:              descriptorID,
+			common.ColDescriptionPayload:        goqu.L("?::jsonb", string(descriptionPayload)),
+			common.ColDisplayNamePayload:        goqu.L("?::jsonb", string(displayNamePayload)),
+			common.ColAdministrativeInfoPayload: goqu.L("?::jsonb", string(administrationPayload)),
+			common.ColExtensionsPayload:         goqu.L("?::jsonb", string(extensionsPayload)),
+		}).
+		ToSQL()
+	if err != nil {
+		return 0, err
+	}
+	if _, err = tx.Exec(sqlStr, args...); err != nil {
+		return 0, err
+	}
+	if err = createsubModelDescriptorSupplementalSemantic(tx, descriptorID, value.SupplementalSemanticId); err != nil {
+		return 0, err
+	}
+	if err = CreateEndpoints(tx, descriptorID, value.Endpoints); err != nil {
+		return 0, err
+	}
+	return descriptorID, nil
 }
 
 func getNextSubmodelDescriptorPosition(tx *sql.Tx, aasDescriptorID int64) (int, error) {

--- a/internal/common/descriptors/WriteSubmodelDescriptor.go
+++ b/internal/common/descriptors/WriteSubmodelDescriptor.go
@@ -69,8 +69,8 @@ func insertSubmodelDescriptorAtPositionTx(
 	value model.SubmodelDescriptor,
 	position int,
 ) (int64, error) {
-	if len(value.Endpoints) == 0 {
-		return 0, common.NewErrBadRequest("Submodel Descriptor needs at least 1 Endpoint.")
+	if err := validateSubmodelDescriptorEndpoints(value); err != nil {
+		return 0, err
 	}
 
 	descriptionPayload, err := buildLangStringTextPayload(value.Description)
@@ -153,6 +153,13 @@ func insertSubmodelDescriptorAtPositionTx(
 		return 0, err
 	}
 	return descriptorID, nil
+}
+
+func validateSubmodelDescriptorEndpoints(value model.SubmodelDescriptor) error {
+	if len(value.Endpoints) == 0 {
+		return common.NewErrBadRequest("SMDESC-VALIDATE-ENDPOINTS Submodel Descriptor needs at least 1 Endpoint.")
+	}
+	return nil
 }
 
 func getNextSubmodelDescriptorPosition(tx *sql.Tx, aasDescriptorID int64) (int, error) {

--- a/internal/common/descriptors/create_readback_test.go
+++ b/internal/common/descriptors/create_readback_test.go
@@ -128,3 +128,38 @@ func TestCanSkipDeleteReadbackRequiresUnrestrictedDeleteFormula(t *testing.T) {
 		t.Fatal("unrestricted delete should skip descriptor readback")
 	}
 }
+
+func TestCanSkipUpdateReadbackRequiresUnrestrictedUpdateFormula(t *testing.T) {
+	t.Parallel()
+
+	allow := true
+	deny := false
+	restricted := auth.WithQueryFilter(t.Context(), &auth.QueryFilter{
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumUPDATE: {Boolean: &deny},
+		},
+	})
+	unrestricted := auth.WithQueryFilter(t.Context(), &auth.QueryFilter{
+		FormulasByRight: map[grammar.RightsEnum]grammar.LogicalExpression{
+			grammar.RightsEnumUPDATE: {Boolean: &allow},
+		},
+	})
+	fragmentFiltered := auth.WithQueryFilter(t.Context(), &auth.QueryFilter{
+		Filters: auth.FragmentFilters{
+			grammar.FragmentStringPattern("$aasdesc#description"): auth.NewFragmentFilterPredicate(
+				grammar.LogicalExpression{Boolean: &allow},
+				false,
+			),
+		},
+	})
+
+	if CanSkipUpdateReadback(restricted) {
+		t.Fatal("restricted update must retain descriptor readback")
+	}
+	if !CanSkipUpdateReadback(unrestricted) {
+		t.Fatal("unrestricted update should skip descriptor readback")
+	}
+	if CanSkipUpdateReadback(fragmentFiltered) {
+		t.Fatal("fragment-filtered update must retain descriptor readback")
+	}
+}

--- a/internal/common/descriptors/descriptor_update.go
+++ b/internal/common/descriptors/descriptor_update.go
@@ -83,7 +83,7 @@ func LockAdministrationShellDescriptorForUpdateTx(ctx context.Context, tx *sql.T
 	}
 	descriptorID, found, err := selectAASDescriptorIDForUpdateTx(ctx, tx, aasID)
 	if err != nil {
-		return 0, err
+		return 0, common.NewInternalServerError("AASDESC-UPDATE-LOCK-SELECT " + err.Error())
 	}
 	if !found {
 		return 0, common.NewErrNotFound("AAS Descriptor not found")
@@ -146,7 +146,7 @@ func LockSubmodelDescriptorForAASUpdateTx(
 		).
 		Order(submodelDescriptor.Col(common.ColPosition).Asc()).
 		Limit(1).
-		ForUpdate(goqu.Wait).
+		ForUpdate(goqu.Wait, goqu.I("smd")).
 		Prepared(true).
 		ToSQL()
 	if err != nil {
@@ -221,6 +221,9 @@ func UpdateSubmodelDescriptorTx(
 ) (bool, error) {
 	if previous.Id != next.Id {
 		return false, common.NewErrBadRequest("SMDESC-UPDATE-IDMISMATCH descriptor ids do not match")
+	}
+	if err := validateSubmodelDescriptorEndpoints(next); err != nil {
+		return false, err
 	}
 	plan, err := buildSubmodelDescriptorUpdatePlan(previous, next)
 	if err != nil {

--- a/internal/common/descriptors/descriptor_update.go
+++ b/internal/common/descriptors/descriptor_update.go
@@ -1,0 +1,658 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package descriptors
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/doug-martin/goqu/v9"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
+)
+
+const submodelDescriptorSemanticIDTable = "submodel_descriptor_semantic_id_reference"
+
+type administrationShellDescriptorUpdatePlan struct {
+	root                bool
+	payload             descriptorPayloadUpdatePlan
+	endpoints           bool
+	specificAssetIDs    bool
+	submodelDescriptors bool
+}
+
+func (p administrationShellDescriptorUpdatePlan) changed() bool {
+	return p.root || p.payload.changed() || p.endpoints || p.specificAssetIDs || p.submodelDescriptors
+}
+
+type submodelDescriptorUpdatePlan struct {
+	root                 bool
+	payload              descriptorPayloadUpdatePlan
+	endpoints            bool
+	semanticID           bool
+	supplementalSemantic bool
+}
+
+func (p submodelDescriptorUpdatePlan) changed() bool {
+	return p.root || p.payload.changed() || p.endpoints || p.semanticID || p.supplementalSemantic
+}
+
+type descriptorPayloadUpdatePlan struct {
+	description    bool
+	displayName    bool
+	administration bool
+	extensions     bool
+}
+
+func (p descriptorPayloadUpdatePlan) changed() bool {
+	return p.description || p.displayName || p.administration || p.extensions
+}
+
+// LockAdministrationShellDescriptorForUpdateTx locks an existing AAS
+// descriptor and returns its stable internal descriptor id.
+func LockAdministrationShellDescriptorForUpdateTx(ctx context.Context, tx *sql.Tx, aasID string) (int64, error) {
+	if err := lockAASDescriptorUpsertTx(ctx, tx, aasID); err != nil {
+		return 0, err
+	}
+	descriptorID, found, err := selectAASDescriptorIDForUpdateTx(ctx, tx, aasID)
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		return 0, common.NewErrNotFound("AAS Descriptor not found")
+	}
+	return descriptorID, nil
+}
+
+// LockGlobalSubmodelDescriptorForUpdateTx locks an existing global Submodel
+// descriptor and returns its stable internal descriptor id.
+func LockGlobalSubmodelDescriptorForUpdateTx(ctx context.Context, tx *sql.Tx, submodelID string) (int64, error) {
+	d := goqu.Dialect(common.Dialect)
+	submodelDescriptor := goqu.T(common.TblSubmodelDescriptor)
+	query, args, err := d.
+		From(submodelDescriptor).
+		Select(submodelDescriptor.Col(common.ColDescriptorID)).
+		Where(
+			submodelDescriptor.Col(common.ColAASID).Eq(submodelID),
+			submodelDescriptor.Col(common.ColAASDescriptorID).IsNull(),
+		).
+		ForUpdate(goqu.Wait).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return 0, common.NewInternalServerError("SMDESC-UPDATE-LOCK-BUILDQ " + err.Error())
+	}
+	var descriptorID int64
+	if err = tx.QueryRowContext(ctx, query, args...).Scan(&descriptorID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, common.NewErrNotFound("Submodel Descriptor not found")
+		}
+		return 0, common.NewInternalServerError("SMDESC-UPDATE-LOCK-EXECQ " + err.Error())
+	}
+	return descriptorID, nil
+}
+
+// LockSubmodelDescriptorForAASUpdateTx locks an embedded Submodel descriptor
+// and returns its stable internal descriptor id and list position.
+func LockSubmodelDescriptorForAASUpdateTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	aasID string,
+	submodelID string,
+) (int64, int, error) {
+	d := goqu.Dialect(common.Dialect)
+	aasDescriptor := goqu.T(common.TblAASDescriptor).As("aas")
+	submodelDescriptor := goqu.T(common.TblSubmodelDescriptor).As("smd")
+	query, args, err := d.
+		From(submodelDescriptor).
+		InnerJoin(
+			aasDescriptor,
+			goqu.On(submodelDescriptor.Col(common.ColAASDescriptorID).Eq(aasDescriptor.Col(common.ColDescriptorID))),
+		).
+		Select(
+			submodelDescriptor.Col(common.ColDescriptorID),
+			submodelDescriptor.Col(common.ColPosition),
+		).
+		Where(
+			aasDescriptor.Col(common.ColAASID).Eq(aasID),
+			submodelDescriptor.Col(common.ColAASID).Eq(submodelID),
+		).
+		Order(submodelDescriptor.Col(common.ColPosition).Asc()).
+		Limit(1).
+		ForUpdate(goqu.Wait).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return 0, 0, common.NewInternalServerError("SMDESC-UPDATE-EMBEDDEDLOCK-BUILDQ " + err.Error())
+	}
+	var descriptorID int64
+	var position int
+	if err = tx.QueryRowContext(ctx, query, args...).Scan(&descriptorID, &position); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, 0, common.NewErrNotFound("Submodel Descriptor not found")
+		}
+		return 0, 0, common.NewInternalServerError("SMDESC-UPDATE-EMBEDDEDLOCK-EXECQ " + err.Error())
+	}
+	return descriptorID, position, nil
+}
+
+// UpdateAdministrationShellDescriptorTx applies full PUT semantics while
+// preserving unchanged rows of the normalized descriptor graph.
+func UpdateAdministrationShellDescriptorTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	descriptorID int64,
+	previous model.AssetAdministrationShellDescriptor,
+	next model.AssetAdministrationShellDescriptor,
+) (bool, error) {
+	if previous.Id != next.Id {
+		return false, common.NewErrBadRequest("AASDESC-UPDATE-IDMISMATCH descriptor ids do not match")
+	}
+	plan, err := buildAdministrationShellDescriptorUpdatePlan(ctx, previous, next)
+	if err != nil {
+		return false, err
+	}
+	if !plan.changed() {
+		return false, nil
+	}
+	if err = updateAASDescriptorRowTx(ctx, tx, descriptorID, next); err != nil {
+		return false, common.NewInternalServerError("AASDESC-UPDATE-ROOT " + err.Error())
+	}
+	if plan.payload.changed() {
+		if err = updateAdministrationShellDescriptorPayloadTx(ctx, tx, descriptorID, next, plan.payload); err != nil {
+			return false, err
+		}
+	}
+	if plan.endpoints {
+		if err = replaceDescriptorEndpointsTx(ctx, tx, descriptorID, next.Endpoints); err != nil {
+			return false, err
+		}
+	}
+	if plan.specificAssetIDs {
+		if err = replaceAdministrationShellDescriptorAssetIDsTx(ctx, tx, descriptorID, next); err != nil {
+			return false, err
+		}
+	}
+	if plan.submodelDescriptors {
+		if err = reconcileEmbeddedSubmodelDescriptorsTx(ctx, tx, descriptorID, previous.SubmodelDescriptors, next.SubmodelDescriptors); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// UpdateSubmodelDescriptorTx applies full PUT semantics while preserving
+// unchanged rows of a Submodel descriptor graph.
+func UpdateSubmodelDescriptorTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	descriptorID int64,
+	previous model.SubmodelDescriptor,
+	next model.SubmodelDescriptor,
+	position int,
+	positionChanged bool,
+) (bool, error) {
+	if previous.Id != next.Id {
+		return false, common.NewErrBadRequest("SMDESC-UPDATE-IDMISMATCH descriptor ids do not match")
+	}
+	plan, err := buildSubmodelDescriptorUpdatePlan(previous, next)
+	if err != nil {
+		return false, err
+	}
+	if !plan.changed() && !positionChanged {
+		return false, nil
+	}
+	if err = updateSubmodelDescriptorRowTx(ctx, tx, descriptorID, next, position); err != nil {
+		return false, err
+	}
+	if plan.payload.changed() {
+		if err = updateSubmodelDescriptorPayloadTx(ctx, tx, descriptorID, next, plan.payload); err != nil {
+			return false, err
+		}
+	}
+	if plan.endpoints {
+		if err = replaceDescriptorEndpointsTx(ctx, tx, descriptorID, next.Endpoints); err != nil {
+			return false, err
+		}
+	}
+	if plan.semanticID {
+		if err = replaceSubmodelDescriptorSemanticIDTx(ctx, tx, descriptorID, next); err != nil {
+			return false, err
+		}
+	}
+	if plan.supplementalSemantic {
+		if err = common.ReplaceContextReferences1ToMany(
+			tx,
+			descriptorID,
+			next.SupplementalSemanticId,
+			common.TblSubmodelDescriptorSuppSemantic,
+			common.ColDescriptorID,
+		); err != nil {
+			return false, common.NewInternalServerError("SMDESC-UPDATE-SUPPLEMENTALSEMANTIC " + err.Error())
+		}
+	}
+	return true, nil
+}
+
+func buildAdministrationShellDescriptorUpdatePlan(
+	ctx context.Context,
+	previous model.AssetAdministrationShellDescriptor,
+	next model.AssetAdministrationShellDescriptor,
+) (administrationShellDescriptorUpdatePlan, error) {
+	previousJSON, err := previous.ToJsonable()
+	if err != nil {
+		return administrationShellDescriptorUpdatePlan{}, common.NewInternalServerError("AASDESC-UPDATE-PREVIOUSJSON " + err.Error())
+	}
+	nextJSON, err := next.ToJsonable()
+	if err != nil {
+		return administrationShellDescriptorUpdatePlan{}, common.NewInternalServerError("AASDESC-UPDATE-NEXTJSON " + err.Error())
+	}
+	assetIDsChanged := !jsonFieldsEqual(previousJSON, nextJSON, "specificAssetIds")
+	if discoveryIntegrationEnabled(ctx) && previous.GlobalAssetId != next.GlobalAssetId {
+		assetIDsChanged = true
+	}
+	rootChanged := !jsonFieldsEqual(previousJSON, nextJSON, "assetKind", "assetType", "globalAssetId", "idShort", "id")
+	return administrationShellDescriptorUpdatePlan{
+		root:                rootChanged,
+		payload:             buildDescriptorPayloadUpdatePlan(previousJSON, nextJSON),
+		endpoints:           !jsonFieldsEqual(previousJSON, nextJSON, "endpoints"),
+		specificAssetIDs:    assetIDsChanged,
+		submodelDescriptors: !jsonFieldsEqual(previousJSON, nextJSON, "submodelDescriptors"),
+	}, nil
+}
+
+func buildSubmodelDescriptorUpdatePlan(previous, next model.SubmodelDescriptor) (submodelDescriptorUpdatePlan, error) {
+	previousJSON, err := previous.ToJsonable()
+	if err != nil {
+		return submodelDescriptorUpdatePlan{}, common.NewInternalServerError("SMDESC-UPDATE-PREVIOUSJSON " + err.Error())
+	}
+	nextJSON, err := next.ToJsonable()
+	if err != nil {
+		return submodelDescriptorUpdatePlan{}, common.NewInternalServerError("SMDESC-UPDATE-NEXTJSON " + err.Error())
+	}
+	return submodelDescriptorUpdatePlan{
+		root:                 !jsonFieldsEqual(previousJSON, nextJSON, "idShort", "id"),
+		payload:              buildDescriptorPayloadUpdatePlan(previousJSON, nextJSON),
+		endpoints:            !jsonFieldsEqual(previousJSON, nextJSON, "endpoints"),
+		semanticID:           !jsonFieldsEqual(previousJSON, nextJSON, "semanticId"),
+		supplementalSemantic: !jsonFieldsEqual(previousJSON, nextJSON, "supplementalSemanticId", "supplementalSemanticIds"),
+	}, nil
+}
+
+func buildDescriptorPayloadUpdatePlan(previous, next map[string]any) descriptorPayloadUpdatePlan {
+	return descriptorPayloadUpdatePlan{
+		description:    !jsonFieldsEqual(previous, next, "description"),
+		displayName:    !jsonFieldsEqual(previous, next, "displayName"),
+		administration: !jsonFieldsEqual(previous, next, "administration"),
+		extensions:     !jsonFieldsEqual(previous, next, "extensions"),
+	}
+}
+
+func jsonFieldsEqual(previous, next map[string]any, fields ...string) bool {
+	for _, field := range fields {
+		previousJSON, previousErr := json.Marshal(previous[field])
+		nextJSON, nextErr := json.Marshal(next[field])
+		if previousErr != nil || nextErr != nil || !bytes.Equal(previousJSON, nextJSON) {
+			return false
+		}
+	}
+	return true
+}
+
+func updateAdministrationShellDescriptorPayloadTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	descriptorID int64,
+	descriptor model.AssetAdministrationShellDescriptor,
+	plan descriptorPayloadUpdatePlan,
+) error {
+	return updateDescriptorPayloadTx(
+		ctx,
+		tx,
+		descriptorID,
+		descriptor.Description,
+		descriptor.DisplayName,
+		descriptor.Administration,
+		descriptor.Extensions,
+		plan,
+	)
+}
+
+func updateSubmodelDescriptorPayloadTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	descriptorID int64,
+	descriptor model.SubmodelDescriptor,
+	plan descriptorPayloadUpdatePlan,
+) error {
+	return updateDescriptorPayloadTx(
+		ctx,
+		tx,
+		descriptorID,
+		descriptor.Description,
+		descriptor.DisplayName,
+		descriptor.Administration,
+		descriptor.Extensions,
+		plan,
+	)
+}
+
+func updateDescriptorPayloadTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	descriptorID int64,
+	description []types.ILangStringTextType,
+	displayName []types.ILangStringNameType,
+	administration types.IAdministrativeInformation,
+	extensions []types.Extension,
+	plan descriptorPayloadUpdatePlan,
+) error {
+	record := goqu.Record{}
+	if plan.description {
+		descriptionPayload, err := buildLangStringTextPayload(description)
+		if err != nil {
+			return common.NewInternalServerError("DESC-UPDATE-DESCRIPTIONPAYLOAD " + err.Error())
+		}
+		record[common.ColDescriptionPayload] = goqu.L("?::jsonb", string(descriptionPayload))
+	}
+	if plan.displayName {
+		displayNamePayload, err := buildLangStringNamePayload(displayName)
+		if err != nil {
+			return common.NewInternalServerError("DESC-UPDATE-DISPLAYNAMEPAYLOAD " + err.Error())
+		}
+		record[common.ColDisplayNamePayload] = goqu.L("?::jsonb", string(displayNamePayload))
+	}
+	if plan.administration {
+		administrationPayload, err := buildAdministrativeInfoPayload(administration)
+		if err != nil {
+			return common.NewInternalServerError("DESC-UPDATE-ADMINPAYLOAD " + err.Error())
+		}
+		record[common.ColAdministrativeInfoPayload] = goqu.L("?::jsonb", string(administrationPayload))
+	}
+	if plan.extensions {
+		extensionsPayload, err := buildExtensionsPayload(extensions)
+		if err != nil {
+			return common.NewInternalServerError("DESC-UPDATE-EXTENSIONPAYLOAD " + err.Error())
+		}
+		record[common.ColExtensionsPayload] = goqu.L("?::jsonb", string(extensionsPayload))
+	}
+	d := goqu.Dialect(common.Dialect)
+	query, args, err := d.
+		Update(common.TblDescriptorPayload).
+		Set(record).
+		Where(goqu.C(common.ColDescriptorID).Eq(descriptorID)).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("DESC-UPDATE-PAYLOAD-BUILDQ " + err.Error())
+	}
+	if _, err = tx.ExecContext(ctx, query, args...); err != nil {
+		return common.NewInternalServerError("DESC-UPDATE-PAYLOAD-EXECQ " + err.Error())
+	}
+	return nil
+}
+
+func replaceDescriptorEndpointsTx(ctx context.Context, tx *sql.Tx, descriptorID int64, endpoints []model.Endpoint) error {
+	d := goqu.Dialect(common.Dialect)
+	query, args, err := d.
+		Delete(common.TblAASDescriptorEndpoint).
+		Where(goqu.C(common.ColDescriptorID).Eq(descriptorID)).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("DESC-UPDATE-ENDPOINTS-BUILDDELETE " + err.Error())
+	}
+	if _, err = tx.ExecContext(ctx, query, args...); err != nil {
+		return common.NewInternalServerError("DESC-UPDATE-ENDPOINTS-EXECDELETE " + err.Error())
+	}
+	if err = CreateEndpoints(tx, descriptorID, endpoints); err != nil {
+		return common.NewInternalServerError("DESC-UPDATE-ENDPOINTS-INSERT " + err.Error())
+	}
+	return nil
+}
+
+func replaceAdministrationShellDescriptorAssetIDsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	descriptorID int64,
+	descriptor model.AssetAdministrationShellDescriptor,
+) error {
+	d := goqu.Dialect(common.Dialect)
+	query, args, err := d.
+		Delete(common.TblSpecificAssetID).
+		Where(goqu.C(common.ColDescriptorID).Eq(descriptorID)).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("AASDESC-UPDATE-ASSETIDS-BUILDDELETE " + err.Error())
+	}
+	if _, err = tx.ExecContext(ctx, query, args...); err != nil {
+		return common.NewInternalServerError("AASDESC-UPDATE-ASSETIDS-EXECDELETE " + err.Error())
+	}
+
+	var aasReference sql.NullInt64
+	if discoveryIntegrationEnabled(ctx) {
+		reference, referenceErr := ensureAASIdentifierTx(ctx, tx, descriptor.Id)
+		if referenceErr != nil {
+			return referenceErr
+		}
+		aasReference = sql.NullInt64{Int64: reference, Valid: true}
+	}
+	if err = common.CreateSpecificAssetIDDescriptor(
+		tx,
+		descriptorID,
+		aasReference,
+		specificAssetIDsWithGlobalAssetID(ctx, descriptor),
+	); err != nil {
+		return common.NewInternalServerError("AASDESC-UPDATE-ASSETIDS-INSERT " + err.Error())
+	}
+	return nil
+}
+
+func updateSubmodelDescriptorRowTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	descriptorID int64,
+	descriptor model.SubmodelDescriptor,
+	position int,
+) error {
+	d := goqu.Dialect(common.Dialect)
+	query, args, err := d.
+		Update(common.TblSubmodelDescriptor).
+		Set(goqu.Record{
+			common.ColIDShort:  descriptor.IdShort,
+			common.ColAASID:    descriptor.Id,
+			common.ColPosition: position,
+		}).
+		Where(goqu.C(common.ColDescriptorID).Eq(descriptorID)).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("SMDESC-UPDATE-ROOT-BUILDQ " + err.Error())
+	}
+	if _, err = tx.ExecContext(ctx, query, args...); err != nil {
+		return common.NewInternalServerError("SMDESC-UPDATE-ROOT-EXECQ " + err.Error())
+	}
+	return nil
+}
+
+func replaceSubmodelDescriptorSemanticIDTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	descriptorID int64,
+	descriptor model.SubmodelDescriptor,
+) error {
+	d := goqu.Dialect(common.Dialect)
+	query, args, err := d.
+		Delete(submodelDescriptorSemanticIDTable).
+		Where(goqu.C(common.ColID).Eq(descriptorID)).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("SMDESC-UPDATE-SEMANTIC-BUILDDELETE " + err.Error())
+	}
+	if _, err = tx.ExecContext(ctx, query, args...); err != nil {
+		return common.NewInternalServerError("SMDESC-UPDATE-SEMANTIC-EXECDELETE " + err.Error())
+	}
+	if err = common.CreateContextReference(
+		tx,
+		descriptorID,
+		descriptor.SemanticId,
+		submodelDescriptorSemanticIDTable,
+		submodelDescriptorSemanticIDTable+"_key",
+	); err != nil {
+		return common.NewInternalServerError("SMDESC-UPDATE-SEMANTIC-INSERT " + err.Error())
+	}
+	return nil
+}
+
+type embeddedSubmodelDescriptorRow struct {
+	descriptorID int64
+	position     int
+	descriptor   model.SubmodelDescriptor
+}
+
+func reconcileEmbeddedSubmodelDescriptorsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	aasDescriptorID int64,
+	previous []model.SubmodelDescriptor,
+	next []model.SubmodelDescriptor,
+) error {
+	rows, err := lockEmbeddedSubmodelDescriptorRowsTx(ctx, tx, aasDescriptorID, previous)
+	if err != nil {
+		return err
+	}
+	available := make(map[string][]embeddedSubmodelDescriptorRow, len(rows))
+	for _, row := range rows {
+		available[row.descriptor.Id] = append(available[row.descriptor.Id], row)
+	}
+	for position, descriptor := range next {
+		candidates := available[descriptor.Id]
+		if len(candidates) == 0 {
+			if _, err = insertSubmodelDescriptorAtPositionTx(
+				tx,
+				sql.NullInt64{Int64: aasDescriptorID, Valid: true},
+				descriptor,
+				position,
+			); err != nil {
+				return common.NewInternalServerError("AASDESC-UPDATE-SUBMODELS-INSERT " + err.Error())
+			}
+			continue
+		}
+		current := candidates[0]
+		available[descriptor.Id] = candidates[1:]
+		if _, err = UpdateSubmodelDescriptorTx(
+			ctx,
+			tx,
+			current.descriptorID,
+			current.descriptor,
+			descriptor,
+			position,
+			current.position != position,
+		); err != nil {
+			return err
+		}
+	}
+	for _, candidates := range available {
+		for _, candidate := range candidates {
+			if err = deleteDescriptorByIDTx(ctx, tx, candidate.descriptorID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func lockEmbeddedSubmodelDescriptorRowsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	aasDescriptorID int64,
+	previous []model.SubmodelDescriptor,
+) ([]embeddedSubmodelDescriptorRow, error) {
+	d := goqu.Dialect(common.Dialect)
+	submodelDescriptor := goqu.T(common.TblSubmodelDescriptor)
+	query, args, err := d.
+		From(submodelDescriptor).
+		Select(
+			submodelDescriptor.Col(common.ColDescriptorID),
+			submodelDescriptor.Col(common.ColPosition),
+		).
+		Where(submodelDescriptor.Col(common.ColAASDescriptorID).Eq(aasDescriptorID)).
+		Order(submodelDescriptor.Col(common.ColPosition).Asc()).
+		ForUpdate(goqu.Wait).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return nil, common.NewInternalServerError("AASDESC-UPDATE-SUBMODELS-BUILDLOCK " + err.Error())
+	}
+	databaseRows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, common.NewInternalServerError("AASDESC-UPDATE-SUBMODELS-EXECLOCK " + err.Error())
+	}
+	defer func() {
+		_ = databaseRows.Close()
+	}()
+
+	rows := make([]embeddedSubmodelDescriptorRow, 0, len(previous))
+	for databaseRows.Next() {
+		var row embeddedSubmodelDescriptorRow
+		if err = databaseRows.Scan(&row.descriptorID, &row.position); err != nil {
+			return nil, common.NewInternalServerError("AASDESC-UPDATE-SUBMODELS-SCANLOCK " + err.Error())
+		}
+		rows = append(rows, row)
+	}
+	if err = databaseRows.Err(); err != nil {
+		return nil, common.NewInternalServerError("AASDESC-UPDATE-SUBMODELS-ITERATELOCK " + err.Error())
+	}
+	if len(rows) != len(previous) {
+		return nil, common.NewInternalServerError("AASDESC-UPDATE-SUBMODELS-COUNT persisted descriptor count changed during update")
+	}
+	for index := range rows {
+		rows[index].descriptor = previous[index]
+	}
+	return rows, nil
+}
+
+func deleteDescriptorByIDTx(ctx context.Context, tx *sql.Tx, descriptorID int64) error {
+	d := goqu.Dialect(common.Dialect)
+	query, args, err := d.
+		Delete(common.TblDescriptor).
+		Where(goqu.C(common.ColID).Eq(descriptorID)).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("DESC-UPDATE-DELETE-BUILDQ " + err.Error())
+	}
+	if _, err = tx.ExecContext(ctx, query, args...); err != nil {
+		return common.NewInternalServerError("DESC-UPDATE-DELETE-EXECQ " + err.Error())
+	}
+	return nil
+}

--- a/internal/common/descriptors/descriptor_update_test.go
+++ b/internal/common/descriptors/descriptor_update_test.go
@@ -28,10 +28,45 @@ package descriptors
 import (
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
 	"github.com/stretchr/testify/require"
 )
+
+func TestUpdateSubmodelDescriptorTxRejectsEmptyEndpointsBeforeDatabaseWork(t *testing.T) {
+	previous := testSubmodelDescriptor("sm-1", "original")
+	next := previous
+	next.Endpoints = nil
+
+	changed, err := UpdateSubmodelDescriptorTx(t.Context(), nil, 1, previous, next, 0, false)
+
+	require.Error(t, err)
+	require.True(t, common.IsErrBadRequest(err))
+	require.Contains(t, err.Error(), "SMDESC-VALIDATE-ENDPOINTS")
+	require.False(t, changed)
+}
+
+func TestLockSubmodelDescriptorForAASUpdateTxLocksOnlySubmodelDescriptor(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	mock.ExpectQuery(`FOR UPDATE OF "smd"`).
+		WillReturnRows(sqlmock.NewRows([]string{"descriptor_id", "position"}).AddRow(int64(42), 3))
+	mock.ExpectRollback()
+
+	descriptorID, position, err := LockSubmodelDescriptorForAASUpdateTx(t.Context(), tx, "aas-1", "sm-1")
+	require.NoError(t, err)
+	require.Equal(t, int64(42), descriptorID)
+	require.Equal(t, 3, position)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
 
 func TestBuildAdministrationShellDescriptorUpdatePlan(t *testing.T) {
 	base := testAdministrationShellDescriptor()

--- a/internal/common/descriptors/descriptor_update_test.go
+++ b/internal/common/descriptors/descriptor_update_test.go
@@ -1,0 +1,149 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package descriptors
+
+import (
+	"testing"
+
+	"github.com/FriedJannik/aas-go-sdk/types"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAdministrationShellDescriptorUpdatePlan(t *testing.T) {
+	base := testAdministrationShellDescriptor()
+
+	t.Run("unchanged", func(t *testing.T) {
+		plan, err := buildAdministrationShellDescriptorUpdatePlan(t.Context(), base, base)
+		require.NoError(t, err)
+		require.False(t, plan.changed())
+	})
+
+	t.Run("payload only", func(t *testing.T) {
+		updated := base
+		updated.Description = []types.ILangStringTextType{types.NewLangStringTextType("en", "updated")}
+		plan, err := buildAdministrationShellDescriptorUpdatePlan(t.Context(), base, updated)
+		require.NoError(t, err)
+		require.True(t, plan.payload.description)
+		require.False(t, plan.payload.displayName)
+		require.False(t, plan.payload.administration)
+		require.False(t, plan.payload.extensions)
+		require.False(t, plan.root)
+		require.False(t, plan.endpoints)
+		require.False(t, plan.specificAssetIDs)
+		require.False(t, plan.submodelDescriptors)
+	})
+
+	t.Run("endpoint only", func(t *testing.T) {
+		updated := base
+		updated.Endpoints = []model.Endpoint{testDescriptorEndpoint("https://example.com/updated")}
+		plan, err := buildAdministrationShellDescriptorUpdatePlan(t.Context(), base, updated)
+		require.NoError(t, err)
+		require.True(t, plan.endpoints)
+		require.False(t, plan.root)
+		require.False(t, plan.payload.changed())
+		require.False(t, plan.specificAssetIDs)
+		require.False(t, plan.submodelDescriptors)
+	})
+
+	t.Run("embedded descriptor only", func(t *testing.T) {
+		updated := base
+		updated.SubmodelDescriptors = []model.SubmodelDescriptor{testSubmodelDescriptor("sm-1", "updated")}
+		plan, err := buildAdministrationShellDescriptorUpdatePlan(t.Context(), base, updated)
+		require.NoError(t, err)
+		require.True(t, plan.submodelDescriptors)
+		require.False(t, plan.root)
+		require.False(t, plan.payload.changed())
+		require.False(t, plan.endpoints)
+		require.False(t, plan.specificAssetIDs)
+	})
+}
+
+func TestBuildSubmodelDescriptorUpdatePlan(t *testing.T) {
+	base := testSubmodelDescriptor("sm-1", "original")
+
+	t.Run("unchanged", func(t *testing.T) {
+		plan, err := buildSubmodelDescriptorUpdatePlan(base, base)
+		require.NoError(t, err)
+		require.False(t, plan.changed())
+	})
+
+	t.Run("payload only", func(t *testing.T) {
+		updated := base
+		updated.Description = []types.ILangStringTextType{types.NewLangStringTextType("en", "updated")}
+		plan, err := buildSubmodelDescriptorUpdatePlan(base, updated)
+		require.NoError(t, err)
+		require.True(t, plan.payload.description)
+		require.False(t, plan.payload.displayName)
+		require.False(t, plan.payload.administration)
+		require.False(t, plan.payload.extensions)
+		require.False(t, plan.root)
+		require.False(t, plan.endpoints)
+		require.False(t, plan.semanticID)
+		require.False(t, plan.supplementalSemantic)
+	})
+
+	t.Run("endpoint only", func(t *testing.T) {
+		updated := base
+		updated.Endpoints = []model.Endpoint{testDescriptorEndpoint("https://example.com/updated")}
+		plan, err := buildSubmodelDescriptorUpdatePlan(base, updated)
+		require.NoError(t, err)
+		require.True(t, plan.endpoints)
+		require.False(t, plan.root)
+		require.False(t, plan.payload.changed())
+		require.False(t, plan.semanticID)
+		require.False(t, plan.supplementalSemantic)
+	})
+}
+
+func testAdministrationShellDescriptor() model.AssetAdministrationShellDescriptor {
+	return model.AssetAdministrationShellDescriptor{
+		Id:                  "aas-1",
+		IdShort:             "AASOne",
+		Description:         []types.ILangStringTextType{types.NewLangStringTextType("en", "original")},
+		Endpoints:           []model.Endpoint{testDescriptorEndpoint("https://example.com/aas")},
+		SubmodelDescriptors: []model.SubmodelDescriptor{testSubmodelDescriptor("sm-1", "original")},
+	}
+}
+
+func testSubmodelDescriptor(id string, description string) model.SubmodelDescriptor {
+	return model.SubmodelDescriptor{
+		Id:          id,
+		IdShort:     "SubmodelOne",
+		Description: []types.ILangStringTextType{types.NewLangStringTextType("en", description)},
+		Endpoints:   []model.Endpoint{testDescriptorEndpoint("https://example.com/submodel")},
+	}
+}
+
+func testDescriptorEndpoint(href string) model.Endpoint {
+	return model.Endpoint{
+		Interface: "SUBMODEL-3.0",
+		ProtocolInformation: model.ProtocolInformation{
+			Href:             href,
+			EndpointProtocol: "https",
+		},
+	}
+}

--- a/internal/smregistry/integration_tests/smregistry_update_persistence_integration_test.go
+++ b/internal/smregistry/integration_tests/smregistry_update_persistence_integration_test.go
@@ -81,6 +81,12 @@ func TestSubmodelDescriptorPutPreservesUnchangedRows(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 	before := readSubmodelDescriptorPersistenceState(t, db, submodelID)
 
+	invalidPayload := payload("invalid")
+	invalidPayload["endpoints"] = []any{}
+	status, body, _ = doRequest(t, smNoRedirectClient, http.MethodPut, endpoint, invalidPayload)
+	require.Equal(t, http.StatusBadRequest, status, "response=%s", string(body))
+	require.Equal(t, before, readSubmodelDescriptorPersistenceState(t, db, submodelID))
+
 	time.Sleep(20 * time.Millisecond)
 	status, body, _ = doRequest(t, smNoRedirectClient, http.MethodPut, endpoint, payload("after"))
 	require.Equal(t, http.StatusNoContent, status, "response=%s", string(body))

--- a/internal/smregistry/integration_tests/smregistry_update_persistence_integration_test.go
+++ b/internal/smregistry/integration_tests/smregistry_update_persistence_integration_test.go
@@ -1,0 +1,136 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+//nolint:all
+package main
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/testenv"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+)
+
+type submodelDescriptorPersistenceState struct {
+	descriptorID      int64
+	rootUpdatedAt     time.Time
+	payloadUpdatedAt  time.Time
+	endpointID        int64
+	endpointUpdatedAt time.Time
+}
+
+func TestSubmodelDescriptorPutPreservesUnchangedRows(t *testing.T) {
+	submodelID := fmt.Sprintf("urn:example:submodel:update-persistence:%d", time.Now().UnixNano())
+	t.Cleanup(func() { cleanupSubmodelDescriptorHTTP(t, submodelID) })
+	identifier := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
+	endpoint := fmt.Sprintf("%s/submodel-descriptors/%s", smRegistryBaseURL, identifier)
+	payload := func(description string) map[string]any {
+		return map[string]any{
+			"id": submodelID,
+			"description": []any{
+				map[string]any{"language": "en", "text": description},
+			},
+			"endpoints": []any{
+				map[string]any{
+					"interface": "SUBMODEL-3.0",
+					"protocolInformation": map[string]any{
+						"href":             "https://example.com/submodels/" + identifier,
+						"endpointProtocol": "https",
+					},
+				},
+			},
+		}
+	}
+
+	status, body, _ := doRequest(t, smNoRedirectClient, http.MethodPost, smRegistryBaseURL+"/submodel-descriptors", payload("before"))
+	require.Equal(t, http.StatusCreated, status, "response=%s", string(body))
+
+	dsn := testenv.PostgresURLFromEnv("BASYX_IT_DB_PORT", 6432, "basyxTestDB")
+	db, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	before := readSubmodelDescriptorPersistenceState(t, db, submodelID)
+
+	time.Sleep(20 * time.Millisecond)
+	status, body, _ = doRequest(t, smNoRedirectClient, http.MethodPut, endpoint, payload("after"))
+	require.Equal(t, http.StatusNoContent, status, "response=%s", string(body))
+	afterChange := readSubmodelDescriptorPersistenceState(t, db, submodelID)
+	require.Equal(t, before.descriptorID, afterChange.descriptorID)
+	require.Equal(t, before.endpointID, afterChange.endpointID)
+	require.Equal(t, before.endpointUpdatedAt, afterChange.endpointUpdatedAt)
+	require.True(t, afterChange.rootUpdatedAt.After(before.rootUpdatedAt))
+	require.True(t, afterChange.payloadUpdatedAt.After(before.payloadUpdatedAt))
+
+	time.Sleep(20 * time.Millisecond)
+	status, body, _ = doRequest(t, smNoRedirectClient, http.MethodPut, endpoint, payload("after"))
+	require.Equal(t, http.StatusNoContent, status, "response=%s", string(body))
+	afterNoOp := readSubmodelDescriptorPersistenceState(t, db, submodelID)
+	require.Equal(t, afterChange, afterNoOp)
+}
+
+func readSubmodelDescriptorPersistenceState(t *testing.T, db *sql.DB, submodelID string) submodelDescriptorPersistenceState {
+	t.Helper()
+	submodel := goqu.T(common.TblSubmodelDescriptor).As("submodel")
+	payload := goqu.T(common.TblDescriptorPayload).As("payload")
+	endpoint := goqu.T(common.TblAASDescriptorEndpoint).As("endpoint")
+	query, args, err := goqu.Dialect(common.Dialect).
+		From(submodel).
+		InnerJoin(payload, goqu.On(payload.Col(common.ColDescriptorID).Eq(submodel.Col(common.ColDescriptorID)))).
+		InnerJoin(endpoint, goqu.On(endpoint.Col(common.ColDescriptorID).Eq(submodel.Col(common.ColDescriptorID)))).
+		Select(
+			submodel.Col(common.ColDescriptorID),
+			submodel.Col("db_updated_at"),
+			payload.Col("db_updated_at"),
+			endpoint.Col(common.ColID),
+			endpoint.Col("db_updated_at"),
+		).
+		Where(
+			submodel.Col(common.ColAASID).Eq(submodelID),
+			submodel.Col(common.ColAASDescriptorID).IsNull(),
+			endpoint.Col(common.ColPosition).Eq(0),
+		).
+		Prepared(true).
+		ToSQL()
+	require.NoError(t, err)
+
+	var state submodelDescriptorPersistenceState
+	err = db.QueryRowContext(t.Context(), query, args...).Scan(
+		&state.descriptorID,
+		&state.rootUpdatedAt,
+		&state.payloadUpdatedAt,
+		&state.endpointID,
+		&state.endpointUpdatedAt,
+	)
+	require.NoError(t, err)
+	return state
+}

--- a/internal/smregistry/persistence/PostgreSQLSMDatabase.go
+++ b/internal/smregistry/persistence/PostgreSQLSMDatabase.go
@@ -295,6 +295,18 @@ func mapBulkInsertSubmodelDescriptorError(err error) error {
 	return err
 }
 
+func loadSubmodelDescriptorForUpdateTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	submodelID string,
+) (model.SubmodelDescriptor, error) {
+	descriptor, err := descriptors.GetSubmodelDescriptorByID(ctx, tx, submodelID)
+	if err != nil || descriptors.CanSkipUpdateReadback(ctx) {
+		return descriptor, err
+	}
+	return descriptors.GetSubmodelDescriptorByID(auth.ContextWithoutQueryFilter(ctx), tx, submodelID)
+}
+
 // ReplaceSubmodelDescriptor replaces a global Submodel Descriptor (no AAS association).
 func (p *PostgreSQLSMDatabase) ReplaceSubmodelDescriptor(
 	ctx context.Context,
@@ -306,18 +318,32 @@ func (p *PostgreSQLSMDatabase) ReplaceSubmodelDescriptor(
 		if snapshotErr != nil {
 			return snapshotErr
 		}
-		if _, err := descriptors.GetSubmodelDescriptorByID(ctx, tx, submodel.Id); err != nil {
-			return err
-		}
-		if err := descriptors.DeleteSubmodelDescriptorByIDTx(ctx, tx, submodel.Id); err != nil {
-			return err
-		}
-		stored, err := descriptors.InsertSubmodelDescriptorTx(ctx, tx, submodel)
+		descriptorID, err := descriptors.LockGlobalSubmodelDescriptorForUpdateTx(ctx, tx, submodel.Id)
 		if err != nil {
 			return err
 		}
-		if err = appendSubmodelDescriptorHistoryTx(ctx, tx, stored, previousSnapshot, history.ChangeUpdated, false); err != nil {
+		previous, err := loadSubmodelDescriptorForUpdateTx(ctx, tx, submodel.Id)
+		if err != nil {
 			return err
+		}
+		changed, err := descriptors.UpdateSubmodelDescriptorTx(ctx, tx, descriptorID, previous, submodel, 0, false)
+		if err != nil {
+			return err
+		}
+		stored := previous
+		if changed {
+			stored = submodel
+			if !descriptors.CanSkipUpdateReadback(ctx) || history.MutationRecordingEnabled() {
+				stored, err = descriptors.GetSubmodelDescriptorByID(ctx, tx, submodel.Id)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if history.MutationRecordingEnabled() {
+			if err = appendSubmodelDescriptorHistoryTx(ctx, tx, stored, previousSnapshot, history.ChangeUpdated, false); err != nil {
+				return err
+			}
 		}
 		result = stored
 		return nil
@@ -348,29 +374,51 @@ func (p *PostgreSQLSMDatabase) UpsertSubmodelDescriptorInTransaction(
 	}
 
 	created := false
-	_, err = descriptors.GetSubmodelDescriptorByID(ctx, tx, submodel.Id)
-	if err != nil && !common.IsErrNotFound(err) {
-		return err
-	}
-	if common.IsErrNotFound(err) {
+	var stored model.SubmodelDescriptor
+	descriptorID, lockErr := descriptors.LockGlobalSubmodelDescriptorForUpdateTx(ctx, tx, submodel.Id)
+	switch {
+	case lockErr == nil:
+		previous, getErr := loadSubmodelDescriptorForUpdateTx(ctx, tx, submodel.Id)
+		if getErr != nil {
+			return getErr
+		}
+		changed, updateErr := descriptors.UpdateSubmodelDescriptorTx(ctx, tx, descriptorID, previous, submodel, 0, false)
+		if updateErr != nil {
+			return updateErr
+		}
+		stored = previous
+		if changed {
+			stored = submodel
+		}
+	case common.IsErrNotFound(lockErr):
 		created = true
+		var insertErr error
+		stored, insertErr = descriptors.InsertSubmodelDescriptorTx(ctx, tx, submodel)
+		if insertErr != nil {
+			return insertErr
+		}
+	default:
+		return lockErr
 	}
 
-	if err := descriptors.DeleteSubmodelDescriptorByIDTx(ctx, tx, submodel.Id); err != nil {
-		if !common.IsErrNotFound(err) {
+	canSkipReadback := descriptors.CanSkipUpdateReadback(ctx)
+	if created {
+		canSkipReadback = descriptors.CanSkipCreateReadback(ctx)
+	}
+	if !canSkipReadback || history.MutationRecordingEnabled() {
+		stored, err = descriptors.GetSubmodelDescriptorByID(ctx, tx, submodel.Id)
+		if err != nil {
 			return err
 		}
-	}
-
-	stored, err := descriptors.InsertSubmodelDescriptorTx(ctx, tx, submodel)
-	if err != nil {
-		return err
 	}
 	changeType := history.ChangeUpdated
 	if created {
 		changeType = history.ChangeCreated
 	}
-	return appendSubmodelDescriptorHistoryTx(ctx, tx, stored, previousSnapshot, changeType, false)
+	if history.MutationRecordingEnabled() {
+		return appendSubmodelDescriptorHistoryTx(ctx, tx, stored, previousSnapshot, changeType, false)
+	}
+	return nil
 }
 
 func lockSubmodelDescriptorUpsertTx(ctx context.Context, tx *sql.Tx, submodelID string) error {

--- a/internal/smregistry/persistence/PostgreSQLSMDatabase.go
+++ b/internal/smregistry/persistence/PostgreSQLSMDatabase.go
@@ -147,6 +147,10 @@ func loadSubmodelDescriptorHistorySnapshotBeforeMutationTx(ctx context.Context, 
 	if err := history.LockMutationTx(ctx, tx, history.TableSubmodelDescriptor, submodelID); err != nil {
 		return nil, err
 	}
+	return loadSubmodelDescriptorHistorySnapshotAfterMutationLockTx(ctx, tx, submodelID)
+}
+
+func loadSubmodelDescriptorHistorySnapshotAfterMutationLockTx(ctx context.Context, tx *sql.Tx, submodelID string) (map[string]any, error) {
 	descriptor, err := descriptors.GetSubmodelDescriptorByID(auth.ContextWithoutQueryFilter(ctx), tx, submodelID)
 	if err != nil {
 		return nil, err
@@ -307,6 +311,36 @@ func loadSubmodelDescriptorForUpdateTx(
 	return descriptors.GetSubmodelDescriptorByID(auth.ContextWithoutQueryFilter(ctx), tx, submodelID)
 }
 
+func loadAuthorizedSubmodelDescriptorEvidenceSnapshotTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	submodelID string,
+	allowNotFound bool,
+) (map[string]any, error) {
+	if !history.ActiveConfig().EvidenceEnabled {
+		return nil, nil
+	}
+	if err := history.LockMutationTx(ctx, tx, history.TableSubmodelDescriptor, submodelID); err != nil {
+		return nil, err
+	}
+	if !descriptors.CanSkipUpdateReadback(ctx) {
+		if _, err := descriptors.GetSubmodelDescriptorByID(ctx, tx, submodelID); err != nil {
+			if allowNotFound && common.IsErrNotFound(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+	}
+	snapshot, err := loadSubmodelDescriptorHistorySnapshotAfterMutationLockTx(ctx, tx, submodelID)
+	if err != nil {
+		if allowNotFound && common.IsErrNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return snapshot, nil
+}
+
 // ReplaceSubmodelDescriptor replaces a global Submodel Descriptor (no AAS association).
 func (p *PostgreSQLSMDatabase) ReplaceSubmodelDescriptor(
 	ctx context.Context,
@@ -314,7 +348,7 @@ func (p *PostgreSQLSMDatabase) ReplaceSubmodelDescriptor(
 ) (model.SubmodelDescriptor, error) {
 	var result model.SubmodelDescriptor
 	err := common.ExecuteInTransaction(p.writerDB, "SMREG-REPLACESMDESC-STARTTX", "SMREG-REPLACESMDESC-COMMITTX", func(tx *sql.Tx) error {
-		previousSnapshot, snapshotErr := loadSubmodelDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, submodel.Id)
+		previousSnapshot, snapshotErr := loadAuthorizedSubmodelDescriptorEvidenceSnapshotTx(ctx, tx, submodel.Id, false)
 		if snapshotErr != nil {
 			return snapshotErr
 		}
@@ -365,8 +399,8 @@ func (p *PostgreSQLSMDatabase) UpsertSubmodelDescriptorInTransaction(
 		return common.NewInternalServerError("SMREG-UPSERTSMDESC-NILTX transaction must not be nil")
 	}
 
-	previousSnapshot, err := loadSubmodelDescriptorHistorySnapshotBeforeMutationTx(ctx, tx, submodel.Id)
-	if err != nil && !common.IsErrNotFound(err) {
+	previousSnapshot, err := loadAuthorizedSubmodelDescriptorEvidenceSnapshotTx(ctx, tx, submodel.Id, true)
+	if err != nil {
 		return err
 	}
 	if err := lockSubmodelDescriptorUpsertTx(ctx, tx, submodel.Id); err != nil {


### PR DESCRIPTION
## What changed

- update AAS and Submodel Descriptor graphs in place instead of deleting and recreating them
- preserve unchanged endpoint, asset ID, semantic reference, payload and embedded descriptor rows
- skip persistence entirely for true no-op PUTs when no history or restricted readback is required
- use the same update path for direct registries, bulk operations, AAS Environment synchronization and DTR delegation
- keep the existing pre-update/post-update authorization behavior, history snapshots and AAS `createdAt`

## Why

Descriptor PUT currently rebuilds the complete normalized graph even when only one field changes. On the million-record benchmark dataset this makes a no-op PUT cost essentially the same as a real update and creates unnecessary writes for every unchanged child collection.

This keeps full PUT replacement semantics but limits persistence to the fields and collections that actually changed.

Closes #569.

## Validation

- AAS Registry integration tests
- Submodel Registry integration tests
- AAS Registry security tests
- Submodel Registry security tests
- DTR integration tests
- Tractus-X integration tests
- AAS Environment integration tests
- `go vet ./...`
- golangci-lint 2.13.2

| Profile | Before | This PR |
|---|---:|---:|
| updateShellDescriptorById | 604 RPS at c40, p50 60.6 ms, p95 94.3 ms | 2,957 RPS at c80, p50 24.8 ms, p95 46.2 ms |
| updateSubmodelDescriptorById | 1,572 RPS at c80, p50 44.9 ms, p95 93.0 ms | 3,437 RPS at c80, p50 21.6 ms, p95 39.1 ms |

This is a 390% throughput increase for AAS Descriptor updates and a 119% increase for Submodel Descriptor updates. Both measurements completed without request failures.

The neighboring descriptor reads were repeated at their previous concurrency sweet spots to check for regressions:

| Profile | Previous | This PR |
|---|---:|---:|
| readShellDescriptorById at c160 | 6,913 RPS, p50 21.8 ms, p95 40.2 ms | 7,196 RPS, p50 20.4 ms, p95 38.1 ms |
| readSubmodelDescriptorById at c80 | 6,112 RPS, p50 12.4 ms, p95 19.7 ms | 6,105 RPS, p50 12.4 ms, p95 19.7 ms |

The read results are unchanged within normal run-to-run variation.

## Changelog

- [x] I added a Changie fragment under `.changes/unreleased` for every notable user-visible or security-related change.
- [ ] This pull request has no notable user-visible or security effect; a reviewer may apply the `no-changelog` label.

## Related Issue

#569
