### PR TITLE
Update Concept Descriptions in place

### DIFF
--- a/.changes/unreleased/fixed-20260830-170000.yaml
+++ b/.changes/unreleased/fixed-20260830-170000.yaml
@@ -1,7 +1,7 @@
 kind: fixed
-body: Concept Description PUT operations update existing rows in place instead of deleting and recreating them.
+body: Concept Description PUT operations update existing rows in place and reject mismatching path and body identifiers.
 time: 2026-08-30T17:00:00.000000+02:00
 custom:
     Impact: Low
     PullRequest: 642
-    SecurityImpact: Existing pre-update and post-update ABAC checks remain unchanged.
+    SecurityImpact: Prevents PUT authorization and history from being split across different Concept Description identifiers.

--- a/.changes/unreleased/fixed-20260830-170000.yaml
+++ b/.changes/unreleased/fixed-20260830-170000.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: Concept Description PUT operations update existing rows in place instead of deleting and recreating them.
+time: 2026-08-30T17:00:00.000000+02:00
+custom:
+    Impact: Low
+    PullRequest: 0
+    SecurityImpact: Existing pre-update and post-update ABAC checks remain unchanged.

--- a/.changes/unreleased/fixed-20260830-170000.yaml
+++ b/.changes/unreleased/fixed-20260830-170000.yaml
@@ -3,5 +3,5 @@ body: Concept Description PUT operations update existing rows in place instead o
 time: 2026-08-30T17:00:00.000000+02:00
 custom:
     Impact: Low
-    PullRequest: 0
+    PullRequest: 642
     SecurityImpact: Existing pre-update and post-update ABAC checks remain unchanged.

--- a/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_update_persistence_integration_test.go
+++ b/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_update_persistence_integration_test.go
@@ -1,0 +1,151 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+//nolint:all
+package main
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/doug-martin/goqu/v9"
+	_ "github.com/doug-martin/goqu/v9/dialect/postgres"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+)
+
+type conceptDescriptionPersistenceState struct {
+	dbCreatedAt             time.Time
+	dbUpdatedAt             time.Time
+	administrationCreatedAt sql.NullTime
+	administrationUpdatedAt sql.NullTime
+	idShort                 sql.NullString
+	data                    map[string]any
+}
+
+func TestConceptDescriptionPutUpdatesExistingRowInPlace(t *testing.T) {
+	conceptDescriptionID := fmt.Sprintf("urn:example:cd:update-persistence:%d", time.Now().UnixNano())
+	endpoint := conceptDescriptionRepositoryBaseURL + "/concept-descriptions"
+	t.Cleanup(func() { cleanupConceptDescription(t, endpoint, conceptDescriptionID) })
+	encodedIdentifier := base64.RawURLEncoding.EncodeToString([]byte(conceptDescriptionID))
+
+	status, body, err := requestJSON(
+		http.MethodPost,
+		endpoint,
+		conceptDescriptionUpdatePayload(conceptDescriptionID, "BeforeUpdate", "2030-01-02T03:04:06Z", true),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status, "response=%s", string(body))
+
+	db, err := sql.Open("pgx", conceptDescriptionRepositoryIntegrationTestDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	before := readConceptDescriptionPersistenceState(t, db, conceptDescriptionID)
+
+	time.Sleep(20 * time.Millisecond)
+	status, body, err = requestJSON(
+		http.MethodPut,
+		endpoint+"/"+encodedIdentifier,
+		conceptDescriptionUpdatePayload(conceptDescriptionID, "AfterUpdate", "2030-01-02T03:04:07Z", false),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, status, "response=%s", string(body))
+
+	after := readConceptDescriptionPersistenceState(t, db, conceptDescriptionID)
+	require.Equal(t, before.dbCreatedAt, after.dbCreatedAt)
+	require.True(t, after.dbUpdatedAt.After(before.dbUpdatedAt))
+	require.Equal(t, "AfterUpdate", after.idShort.String)
+	require.True(t, after.administrationCreatedAt.Valid)
+	require.Equal(t, before.administrationCreatedAt, after.administrationCreatedAt)
+	require.True(t, after.administrationUpdatedAt.Valid)
+	require.True(t, after.administrationUpdatedAt.Time.After(before.administrationUpdatedAt.Time))
+	require.NotContains(t, after.data, "description")
+	require.Equal(t, "AfterUpdate", after.data["idShort"])
+}
+
+func conceptDescriptionUpdatePayload(
+	id string,
+	idShort string,
+	updatedAt string,
+	includeDescription bool,
+) map[string]any {
+	payload := map[string]any{
+		"id":        id,
+		"idShort":   idShort,
+		"modelType": "ConceptDescription",
+		"administration": map[string]any{
+			"createdAt": "2030-01-02T03:04:05Z",
+			"updatedAt": updatedAt,
+		},
+	}
+	if includeDescription {
+		payload["description"] = []any{
+			map[string]any{"language": "en", "text": "removed by full PUT"},
+		}
+	}
+	return payload
+}
+
+func readConceptDescriptionPersistenceState(
+	t *testing.T,
+	db *sql.DB,
+	id string,
+) conceptDescriptionPersistenceState {
+	t.Helper()
+
+	query, args, err := goqu.Dialect("postgres").
+		From("concept_description").
+		Select(
+			"db_created_at",
+			"db_updated_at",
+			"administration_created_at",
+			"administration_updated_at",
+			"id_short",
+			"data",
+		).
+		Where(goqu.C("id").Eq(id)).
+		Prepared(true).
+		ToSQL()
+	require.NoError(t, err)
+
+	var state conceptDescriptionPersistenceState
+	var data []byte
+	err = db.QueryRowContext(t.Context(), query, args...).Scan(
+		&state.dbCreatedAt,
+		&state.dbUpdatedAt,
+		&state.administrationCreatedAt,
+		&state.administrationUpdatedAt,
+		&state.idShort,
+		&data,
+	)
+	require.NoError(t, err, "query=%s args=%v", query, args)
+	require.NoError(t, json.Unmarshal(data, &state.data))
+	return state
+}

--- a/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_update_persistence_integration_test.go
+++ b/internal/conceptdescriptionrepository/integration_tests/conceptdescriptionrepository_update_persistence_integration_test.go
@@ -90,6 +90,138 @@ func TestConceptDescriptionPutUpdatesExistingRowInPlace(t *testing.T) {
 	require.Equal(t, "AfterUpdate", after.data["idShort"])
 }
 
+func TestConceptDescriptionPutRejectsPathAndBodyIdentifierMismatch(t *testing.T) {
+	endpoint := conceptDescriptionRepositoryBaseURL + "/concept-descriptions"
+	existingID := fmt.Sprintf("urn:example:cd:mismatch-existing:%d", time.Now().UnixNano())
+	updateBodyID := existingID + ":moved"
+	missingPathID := existingID + ":missing"
+	createBodyID := existingID + ":created-elsewhere"
+	for _, id := range []string{existingID, updateBodyID, missingPathID, createBodyID} {
+		t.Cleanup(func() { cleanupConceptDescription(t, endpoint, id) })
+	}
+
+	status, body, err := requestJSON(
+		http.MethodPost,
+		endpoint,
+		conceptDescriptionUpdatePayload(existingID, "BeforeMismatch", "2030-01-02T03:04:06Z", false),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status, "response=%s", string(body))
+
+	status, body, err = requestJSON(
+		http.MethodPut,
+		endpoint+"/"+base64.RawURLEncoding.EncodeToString([]byte(existingID)),
+		conceptDescriptionUpdatePayload(updateBodyID, "MovedByUpdate", "2030-01-02T03:04:07Z", false),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, status, "response=%s", string(body))
+
+	status, body, err = requestJSON(
+		http.MethodGet,
+		endpoint+"/"+base64.RawURLEncoding.EncodeToString([]byte(existingID)),
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status, "response=%s", string(body))
+
+	status, body, err = requestJSON(
+		http.MethodPut,
+		endpoint+"/"+base64.RawURLEncoding.EncodeToString([]byte(missingPathID)),
+		conceptDescriptionUpdatePayload(createBodyID, "MovedByCreate", "2030-01-02T03:04:07Z", false),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, status, "response=%s", string(body))
+
+	for _, id := range []string{updateBodyID, missingPathID, createBodyID} {
+		status, body, err = requestJSON(
+			http.MethodGet,
+			endpoint+"/"+base64.RawURLEncoding.EncodeToString([]byte(id)),
+			nil,
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, status, "id=%s response=%s", id, string(body))
+	}
+}
+
+func TestConceptDescriptionPutRecreatesResourceDeletedDuringExistenceCheck(t *testing.T) {
+	conceptDescriptionID := fmt.Sprintf("urn:example:cd:concurrent-delete:%d", time.Now().UnixNano())
+	endpoint := conceptDescriptionRepositoryBaseURL + "/concept-descriptions"
+	t.Cleanup(func() { cleanupConceptDescription(t, endpoint, conceptDescriptionID) })
+
+	status, body, err := requestJSON(
+		http.MethodPost,
+		endpoint,
+		conceptDescriptionUpdatePayload(conceptDescriptionID, "BeforeConcurrentDelete", "2030-01-02T03:04:06Z", false),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status, "response=%s", string(body))
+
+	db, err := sql.Open("pgx", conceptDescriptionRepositoryIntegrationTestDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	deleteTx, err := db.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = deleteTx.Rollback() })
+
+	backendPIDQuery, _, err := goqu.Select(goqu.Func("pg_backend_pid")).ToSQL()
+	require.NoError(t, err)
+	var deleteBackendPID int
+	require.NoError(t, deleteTx.QueryRowContext(t.Context(), backendPIDQuery).Scan(&deleteBackendPID))
+
+	deleteQuery, deleteArgs, err := goqu.Dialect("postgres").
+		Delete("concept_description").
+		Where(goqu.C("id").Eq(conceptDescriptionID)).
+		Prepared(true).
+		ToSQL()
+	require.NoError(t, err)
+	deleteResult, err := deleteTx.ExecContext(t.Context(), deleteQuery, deleteArgs...)
+	require.NoError(t, err)
+	deletedRows, err := deleteResult.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deletedRows)
+
+	type putResult struct {
+		status int
+		body   []byte
+		err    error
+	}
+	putResultChannel := make(chan putResult, 1)
+	go func() {
+		putStatus, putBody, putErr := requestJSON(
+			http.MethodPut,
+			endpoint+"/"+base64.RawURLEncoding.EncodeToString([]byte(conceptDescriptionID)),
+			conceptDescriptionUpdatePayload(conceptDescriptionID, "AfterConcurrentDelete", "2030-01-02T03:04:07Z", false),
+		)
+		putResultChannel <- putResult{status: putStatus, body: putBody, err: putErr}
+	}()
+
+	blockedQuery, blockedArgs, err := goqu.Dialect("postgres").
+		From("pg_stat_activity").
+		Select(goqu.COUNT("*")).
+		Where(goqu.L("? = ANY(pg_blocking_pids(pid))", deleteBackendPID)).
+		Prepared(true).
+		ToSQL()
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		var blockedCount int
+		queryErr := db.QueryRowContext(t.Context(), blockedQuery, blockedArgs...).Scan(&blockedCount)
+		return queryErr == nil && blockedCount > 0
+	}, 5*time.Second, 20*time.Millisecond)
+
+	require.NoError(t, deleteTx.Commit())
+
+	select {
+	case result := <-putResultChannel:
+		require.NoError(t, result.err)
+		require.Equal(t, http.StatusCreated, result.status, "response=%s", string(result.body))
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for PUT after concurrent delete committed")
+	}
+
+	after := readConceptDescriptionPersistenceState(t, db, conceptDescriptionID)
+	require.Equal(t, "AfterConcurrentDelete", after.idShort.String)
+}
+
 func conceptDescriptionUpdatePayload(
 	id string,
 	idShort string,

--- a/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
+++ b/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
@@ -249,7 +249,6 @@ func (b *ConceptDescriptionBackend) updateConceptDescriptionInTx(
 	updateQuery, args, err := goqu.Dialect("postgres").
 		Update("concept_description").
 		Set(goqu.Record{
-			"id":       cd.ID(),
 			"id_short": cd.IDShort(),
 			"data":     goqu.L("?::jsonb", conceptDescriptionString),
 		}).
@@ -294,20 +293,23 @@ func (b *ConceptDescriptionBackend) deleteConceptDescriptionInTx(ctx context.Con
 	return rowsAffected > 0, nil
 }
 
-func conceptDescriptionExistsInTx(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
+func queryConceptDescriptionExistenceInTx(ctx context.Context, tx *sql.Tx, id string, forUpdate bool) (bool, error) {
 	dialect := goqu.Dialect("postgres")
-	query, args, err := dialect.From("concept_description").
+	query := dialect.From("concept_description").
 		Select(goqu.L("1")).
 		Where(goqu.Ex{"id": id}).
 		Limit(1).
-		Prepared(true).
-		ToSQL()
+		Prepared(true)
+	if forUpdate {
+		query = query.ForUpdate(goqu.Wait)
+	}
+	querySQL, args, err := query.ToSQL()
 	if err != nil {
 		return false, common.NewInternalServerError("CDREPO-CDEXIST-BUILDSQL " + err.Error())
 	}
 
 	var existsMarker int
-	scanErr := tx.QueryRowContext(ctx, query, args...).Scan(&existsMarker)
+	scanErr := tx.QueryRowContext(ctx, querySQL, args...).Scan(&existsMarker)
 	if scanErr == nil {
 		return true, nil
 	}
@@ -316,6 +318,14 @@ func conceptDescriptionExistsInTx(ctx context.Context, tx *sql.Tx, id string) (b
 	}
 
 	return false, common.NewInternalServerError("CDREPO-CDEXIST-EXECSQL " + scanErr.Error())
+}
+
+func conceptDescriptionExistsInTx(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
+	return queryConceptDescriptionExistenceInTx(ctx, tx, id, false)
+}
+
+func lockConceptDescriptionForUpdateInTx(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
+	return queryConceptDescriptionExistenceInTx(ctx, tx, id, true)
 }
 
 func (b *ConceptDescriptionBackend) checkConceptDescriptionVisibilityInTx(ctx context.Context, tx *sql.Tx, id string) (bool, bool, error) {
@@ -636,6 +646,10 @@ func (b *ConceptDescriptionBackend) GetConceptDescriptionByID(ctx context.Contex
 
 // PutConceptDescription creates or replaces the concept description with the given identifier and reports whether an existing row was replaced.
 func (b *ConceptDescriptionBackend) PutConceptDescription(ctx context.Context, id string, cd types.IConceptDescription) (bool, error) {
+	if id != cd.ID() {
+		return false, common.NewErrBadRequest("CDREPO-PUTCD-IDMISMATCH Concept Description ID in path and body do not match")
+	}
+
 	tx, cleanup, err := common.StartTransaction(b.db)
 	if err != nil {
 		return false, common.NewInternalServerError("CDREPO-PUTCD-STARTTX " + err.Error())
@@ -645,7 +659,7 @@ func (b *ConceptDescriptionBackend) PutConceptDescription(ctx context.Context, i
 		return false, err
 	}
 
-	existingExists, existsErr := conceptDescriptionExistsInTx(ctx, tx, id)
+	existingExists, existsErr := lockConceptDescriptionForUpdateInTx(ctx, tx, id)
 	if existsErr != nil {
 		return false, existsErr
 	}

--- a/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
+++ b/internal/conceptdescriptionrepository/persistence/ConceptDescriptionBackend.go
@@ -235,6 +235,46 @@ func (b *ConceptDescriptionBackend) createConceptDescriptionInTx(ctx context.Con
 	return nil
 }
 
+func (b *ConceptDescriptionBackend) updateConceptDescriptionInTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	id string,
+	cd types.IConceptDescription,
+) error {
+	conceptDescriptionString, err := conceptDescriptionToJSONString(cd)
+	if err != nil {
+		return err
+	}
+
+	updateQuery, args, err := goqu.Dialect("postgres").
+		Update("concept_description").
+		Set(goqu.Record{
+			"id":       cd.ID(),
+			"id_short": cd.IDShort(),
+			"data":     goqu.L("?::jsonb", conceptDescriptionString),
+		}).
+		Where(goqu.C("id").Eq(id)).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("CDREPO-PUTCD-BUILDUPDATE " + err.Error())
+	}
+
+	result, err := tx.ExecContext(ctx, updateQuery, args...)
+	if err != nil {
+		return common.NewInternalServerError("CDREPO-PUTCD-EXECUPDATE " + err.Error())
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return common.NewInternalServerError("CDREPO-PUTCD-UPDATECOUNT " + err.Error())
+	}
+	if rowsAffected != 1 {
+		return common.NewInternalServerError("CDREPO-PUTCD-UPDATEMISSING existing concept description disappeared during update")
+	}
+
+	return nil
+}
+
 func (b *ConceptDescriptionBackend) deleteConceptDescriptionInTx(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
 	delQuery, args, err := goqu.Delete("concept_description").Where(goqu.Ex{"id": id}).ToSQL()
 	if err != nil {
@@ -634,15 +674,15 @@ func (b *ConceptDescriptionBackend) PutConceptDescription(ctx context.Context, i
 		}
 	}
 
-	isUpdate := false
-	if existingExists {
-		if isUpdate, err = b.deleteConceptDescriptionInTx(ctx, tx, id); err != nil {
+	isUpdate := existingExists
+	if isUpdate {
+		if err = b.updateConceptDescriptionInTx(ctx, tx, id, cd); err != nil {
 			return false, err
 		}
-	}
-
-	if err = b.createConceptDescriptionInTx(ctx, tx, cd); err != nil {
-		return false, err
+	} else {
+		if err = b.createConceptDescriptionInTx(ctx, tx, cd); err != nil {
+			return false, err
+		}
 	}
 
 	if shouldEnforceFormula {

--- a/internal/conceptdescriptionrepository/security_tests/it_config.json
+++ b/internal/conceptdescriptionrepository/security_tests/it_config.json
@@ -163,6 +163,14 @@
     "expectedStatus": 201
   },
   {
+    "context": "PUT editor-allowed concept description with mismatched body identifier - editor rejected",
+    "token": { "user": "userx", "password": "pwd" },
+    "method": "PUT",
+    "endpoint": "{{BASYX_IT_API_URL}}/concept-descriptions/dXJuOmV4YW1wbGU6Y2Q6ZWRpdG9yOnBvc3QtYWxsb3dlZA",
+    "data": "postBody/cdEditorAllowedMismatchedID.json",
+    "expectedStatus": 400
+  },
+  {
     "context": "POST editor-denied concept description - editor",
     "token": { "user": "userx", "password": "pwd" },
     "method": "POST",

--- a/internal/conceptdescriptionrepository/security_tests/postBody/cdEditorAllowedMismatchedID.json
+++ b/internal/conceptdescriptionrepository/security_tests/postBody/cdEditorAllowedMismatchedID.json
@@ -1,0 +1,5 @@
+{
+  "id": "urn:example:cd:editor:mismatched-body",
+  "idShort": "EditorAllowed",
+  "modelType": "ConceptDescription"
+}


### PR DESCRIPTION
## What changed

- update existing Concept Description rows in place instead of deleting and recreating them
- update `idShort` and the complete JSON payload in one PostgreSQL `UPDATE`
- preserve the persistence creation timestamp while the existing database triggers advance update timestamps
- keep PUT-create behavior, pre-update/post-update authorization checks and history snapshots unchanged
- reject path/body identifier mismatches before persistence
- lock an existing row before deciding between update and create so concurrent deletes cannot turn PUT into a 500 response

## Why

Concept Descriptions are stored in one JSON-backed row. Recreating that row for every PUT adds unnecessary index, WAL and constraint work and resets persistence metadata even though the resource can be replaced with one update.

This keeps full PUT replacement semantics, including removing fields omitted from the request, without deleting the existing row.

Closes #568.

## Validation

- Concept Description persistence tests
- Concept Description Repository integration tests
- Concept Description Repository security tests
- Submodel Repository integration tests
- `go vet ./...`
- golangci-lint 2.13.2

The new integration coverage verifies that PUT preserves `db_created_at`, advances `db_updated_at`, updates `idShort` and administration timestamps, and removes omitted JSON fields. It also covers update/create identifier mismatches, secured mismatch handling, and a forced concurrent PUT-versus-DELETE race.

### Cluster benchmark

Compared commit `43635050` with the BaSyx Go 1.0.10 release baseline.

| Endpoint | Concurrency | RPS before | RPS after | Change | p50 before → after | p95 before → after | p99 before → after | Failures |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `createConceptDescription` | 160 | 11,426 | 11,658 | +2.0% | 9.6 → 9.8 ms | 36.9 → 34.2 ms | 64.5 → 59.4 ms | 0 |
| `deleteConceptDescriptionById` | 160 | 16,034 | 15,778 | -1.6% | 7.0 → 7.1 ms | 25.2 → 25.7 ms | 44.2 → 47.4 ms | 0 |
| `getAllConceptDescriptions?limit=100` | 160 | 6,145 | 6,242 | +1.6% | 21.1 → 20.1 ms | 48.5 → 48.0 ms | 128.0 → 225.3 ms | 0 |
| `readConceptDescriptionById` | 320 | 29,294 | 30,594 | +4.4% | 8.9 → 8.4 ms | 21.4 → 20.1 ms | 38.9 → 38.9 ms | 0 |
| `updateConceptDescriptionById` | 160 | 9,615 | 12,224 | **+27.1%** | 11.0 → 9.1 ms | 47.8 → 34.9 ms | 84.8 → 60.6 ms | 0 |

The PUT sweep covered concurrency 20–640. Peak throughput was approximately 12.9k RPS at c320–c480; c160 was retained by the benchmark's 5% peak-tolerance rule because it delivers nearly the same throughput with materially lower tail latency. No neighboring endpoint showed a throughput regression. The list endpoint's p99 varied upward in this run, while its RPS, p50 and p95 remained stable and its code path is unchanged by this pull request.

## Changelog

- [x] I added a Changie fragment under `.changes/unreleased` for every notable user-visible or security-related change.
- [ ] This pull request has no notable user-visible or security effect; a reviewer may apply the `no-changelog` label.

## Related Issue

#568
