### PR TITLE
Adds base Schema cutoff to prevent recreation of deleted indexes

### DIFF
--- a/.changes/unreleased/fixed-644-config-baseline.yaml
+++ b/.changes/unreleased/fixed-644-config-baseline.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: The configuration service skips the baseline schema for initialized databases, preventing later configuration runs from recreating objects removed by versioned patches.
+time: 2026-08-31T09:24:33+02:00
+custom:
+  Impact: Low
+  PullRequest: 644
+  SecurityImpact: None.

--- a/internal/basyxconfigurationservice/sequences/schema_patch.go
+++ b/internal/basyxconfigurationservice/sequences/schema_patch.go
@@ -26,8 +26,6 @@
 package sequences
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -131,28 +129,11 @@ func (sp *SchemaPatch) GetDescription(stepIndex int) string {
 }
 
 func (sp *SchemaPatch) getCurrentSchemaVersion() (string, error) {
-	query, _, err := goqu.Dialect("postgres").
-		From(goqu.T("basyxsystem")).
-		Select(goqu.C("schema_version")).
-		Order(goqu.C("identifier").Asc()).
-		Limit(1).
-		ToSQL()
+	version, err := readCurrentSchemaVersion(sp.ctx.DB)
 	if err != nil {
-		return "", fmt.Errorf("BASYXCFG-PATCH-BUILDVERSIONQUERY: %w", err)
+		return "", fmt.Errorf("BASYXCFG-PATCH-READVERSION: %w", err)
 	}
-
-	var version string
-	err = sp.ctx.DB.QueryRow(query).Scan(&version)
-	if err == nil {
-		return strings.TrimSpace(version), nil
-	}
-	if errors.Is(err, sql.ErrNoRows) {
-		if seedErr := seedSystemTableIfMissing(sp.ctx.DB); seedErr != nil {
-			return "", fmt.Errorf("BASYXCFG-PATCH-SEEDVERSION: %w", seedErr)
-		}
-		return initialSchemaVersion, nil
-	}
-	return "", fmt.Errorf("BASYXCFG-PATCH-READVERSION: %w", err)
+	return version, nil
 }
 
 func (sp *SchemaPatch) failPatchDirty(errorCode string, cause error) (int, error) {

--- a/internal/basyxconfigurationservice/sequences/schema_upload.go
+++ b/internal/basyxconfigurationservice/sequences/schema_upload.go
@@ -33,8 +33,9 @@ import (
 )
 
 const (
-	schemaFilePath       = "/app/base.sql"
-	schemaAdvisoryLockID = int64(860424611912345001)
+	schemaFilePath              = "/app/base.sql"
+	schemaAdvisoryLockID        = int64(860424611912345001)
+	baselineUploadCutoffVersion = "v1.0.2"
 )
 
 // SchemaUpload uploads the SQL schema to the configured PostgreSQL database.
@@ -60,6 +61,25 @@ func (su *SchemaUpload) Execute(stepIndex int) (int, error) {
 	defer func() {
 		_, _ = su.ctx.DB.Exec("SELECT pg_advisory_unlock($1)", schemaAdvisoryLockID)
 	}()
+
+	currentVersion, err := readCurrentSchemaVersion(su.ctx.DB)
+	if err != nil {
+		return 1, fmt.Errorf("BASYXCFG-SCHEMA-READVERSION: %w", err)
+	}
+
+	versionComparison, err := compareSemanticVersions(currentVersion, baselineUploadCutoffVersion)
+	if err != nil {
+		return 1, fmt.Errorf("BASYXCFG-SCHEMA-VERSIONCOMPARE: %w", err)
+	}
+	if versionComparison >= 0 {
+		slog.Info(
+			"schema upload skipped",
+			"step", stepIndex,
+			"database.version", currentVersion,
+			"schema.cutoff.version", baselineUploadCutoffVersion,
+		)
+		return 0, nil
+	}
 
 	schemaToLoad, err := su.resolveSchemaPath()
 	if err != nil {

--- a/internal/basyxconfigurationservice/sequences/schema_upload_test.go
+++ b/internal/basyxconfigurationservice/sequences/schema_upload_test.go
@@ -34,6 +34,7 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
 
 func TestSchemaUploadGetDescription(t *testing.T) {
@@ -73,6 +74,7 @@ func TestSchemaUploadExecuteReturnsReadFileError(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta("SELECT pg_advisory_lock($1)")).
 		WithArgs(schemaAdvisoryLockID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectCurrentSchemaVersion(mock, initialSchemaVersion)
 
 	mock.ExpectExec(regexp.QuoteMeta("SELECT pg_advisory_unlock($1)")).
 		WithArgs(schemaAdvisoryLockID).
@@ -108,6 +110,7 @@ func TestSchemaUploadExecuteSuccess(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta("SELECT pg_advisory_lock($1)")).
 		WithArgs(schemaAdvisoryLockID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectCurrentSchemaVersion(mock, initialSchemaVersion)
 
 	mock.ExpectExec(regexp.QuoteMeta(schema)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -150,6 +153,7 @@ func TestSchemaUploadExecuteLoadsBaseSchemaFromDirectory(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta("SELECT pg_advisory_lock($1)")).
 		WithArgs(schemaAdvisoryLockID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectCurrentSchemaVersion(mock, initialSchemaVersion)
 
 	mock.ExpectExec(regexp.QuoteMeta(schemaSQL)).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -212,6 +216,7 @@ func TestSchemaUploadExecuteReturnsSchemaExecutionError(t *testing.T) {
 	schemaErr := errors.New("invalid schema")
 
 	expectSchemaAdvisoryLock(mock)
+	expectCurrentSchemaVersion(mock, initialSchemaVersion)
 	mock.ExpectExec(regexp.QuoteMeta(schema)).
 		WillReturnError(schemaErr)
 	expectSchemaAdvisoryUnlock(mock)
@@ -241,6 +246,7 @@ func TestSchemaUploadExecuteAppliesRc01CompatibilityAndRetriesOnce(t *testing.T)
 	step, mock := newSchemaUploadTestStep(t, schemaPath)
 
 	expectSchemaAdvisoryLock(mock)
+	expectCurrentSchemaVersion(mock, "v1.0.1")
 	mock.ExpectExec(regexp.QuoteMeta(schema)).
 		WillReturnError(newRc01PgError())
 	mock.ExpectExec(regexp.QuoteMeta(compatibilitySQL)).
@@ -269,6 +275,7 @@ func TestSchemaUploadExecuteReturnsErrorAfterFailedRc01Retry(t *testing.T) {
 	retryErr := newRc01PgError()
 
 	expectSchemaAdvisoryLock(mock)
+	expectCurrentSchemaVersion(mock, "v1.0.1")
 	mock.ExpectExec(regexp.QuoteMeta(schema)).
 		WillReturnError(newRc01PgError())
 	mock.ExpectExec(regexp.QuoteMeta(compatibilitySQL)).
@@ -289,6 +296,87 @@ func TestSchemaUploadExecuteReturnsErrorAfterFailedRc01Retry(t *testing.T) {
 	}
 	if !errors.Is(execErr, retryErr) {
 		t.Fatalf("expected retry failure cause, got: %v", execErr)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestSchemaUploadExecuteSkipsBaselineForInitializedDatabase(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{name: "cutoff version", version: baselineUploadCutoffVersion},
+		{name: "current dirty version awaiting patch retry", version: common.CURRENT_DATABASE_VERSION},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := "CREATE INDEX IF NOT EXISTS index_removed_by_patch ON test_table (id);"
+			step, mock := newSchemaUploadTestStep(t, writeTempSchema(t, schema))
+
+			expectSchemaAdvisoryLock(mock)
+			expectCurrentSchemaVersion(mock, tc.version)
+			expectSchemaAdvisoryUnlock(mock)
+
+			statusCode, execErr := step.Execute(3)
+			if execErr != nil {
+				t.Fatalf("unexpected error: %v", execErr)
+			}
+			if statusCode != 0 {
+				t.Fatalf("expected status code 0, got %d", statusCode)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("baseline schema must not execute: %v", err)
+			}
+		})
+	}
+}
+
+func TestSchemaUploadExecuteReturnsVersionReadError(t *testing.T) {
+	step, mock := newSchemaUploadTestStep(t, "/not/read/schema.sql")
+	versionErr := errors.New("version unavailable")
+
+	expectSchemaAdvisoryLock(mock)
+	mock.ExpectQuery(regexp.QuoteMeta(schemaVersionQuery)).
+		WillReturnError(versionErr)
+	expectSchemaAdvisoryUnlock(mock)
+
+	statusCode, execErr := step.Execute(3)
+	if execErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if statusCode != 1 {
+		t.Fatalf("expected status code 1, got %d", statusCode)
+	}
+	if !strings.Contains(execErr.Error(), "BASYXCFG-SCHEMA-READVERSION") {
+		t.Fatalf("unexpected error: %v", execErr)
+	}
+	if !errors.Is(execErr, versionErr) {
+		t.Fatalf("expected version read cause, got: %v", execErr)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestSchemaUploadExecuteReturnsInvalidVersionError(t *testing.T) {
+	step, mock := newSchemaUploadTestStep(t, "/not/read/schema.sql")
+
+	expectSchemaAdvisoryLock(mock)
+	expectCurrentSchemaVersion(mock, "invalid")
+	expectSchemaAdvisoryUnlock(mock)
+
+	statusCode, execErr := step.Execute(3)
+	if execErr == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if statusCode != 1 {
+		t.Fatalf("expected status code 1, got %d", statusCode)
+	}
+	if !strings.Contains(execErr.Error(), "BASYXCFG-SCHEMA-VERSIONCOMPARE") {
+		t.Fatalf("unexpected error: %v", execErr)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)
@@ -330,6 +418,13 @@ func expectSchemaAdvisoryLock(mock sqlmock.Sqlmock) {
 	mock.ExpectExec(regexp.QuoteMeta("SELECT pg_advisory_lock($1)")).
 		WithArgs(schemaAdvisoryLockID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+const schemaVersionQuery = `SELECT "schema_version" FROM "basyxsystem" ORDER BY "identifier" ASC LIMIT 1`
+
+func expectCurrentSchemaVersion(mock sqlmock.Sqlmock, version string) {
+	mock.ExpectQuery(regexp.QuoteMeta(schemaVersionQuery)).
+		WillReturnRows(sqlmock.NewRows([]string{"schema_version"}).AddRow(version))
 }
 
 func expectSchemaAdvisoryUnlock(mock sqlmock.Sqlmock) {

--- a/internal/basyxconfigurationservice/sequences/system_table.go
+++ b/internal/basyxconfigurationservice/sequences/system_table.go
@@ -30,6 +30,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/doug-martin/goqu/v9"
 	_ "github.com/doug-martin/goqu/v9/dialect/postgres"
@@ -134,4 +135,29 @@ func seedSystemTableIfMissing(db *sql.DB) error {
 		return fmt.Errorf("BASYXCFG-SYSTEM-INSERTSEED: %w", err)
 	}
 	return nil
+}
+
+func readCurrentSchemaVersion(db *sql.DB) (string, error) {
+	query, _, err := goqu.Dialect("postgres").
+		From(goqu.T("basyxsystem")).
+		Select(goqu.C("schema_version")).
+		Order(goqu.C("identifier").Asc()).
+		Limit(1).
+		ToSQL()
+	if err != nil {
+		return "", fmt.Errorf("BASYXCFG-VERSION-BUILDQUERY: %w", err)
+	}
+
+	var version string
+	err = db.QueryRow(query).Scan(&version)
+	if err == nil {
+		return strings.TrimSpace(version), nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		if seedErr := seedSystemTableIfMissing(db); seedErr != nil {
+			return "", fmt.Errorf("BASYXCFG-VERSION-SEED: %w", seedErr)
+		}
+		return initialSchemaVersion, nil
+	}
+	return "", fmt.Errorf("BASYXCFG-VERSION-READ: %w", err)
 }


### PR DESCRIPTION
## Description of Changes

This pull request improves the configuration service's handling of database schema initialization and patching. The main change is that the service now skips applying the baseline schema to databases that have already been initialized, preventing accidental recreation of objects that may have been intentionally removed by versioned patches. The implementation introduces a version cutoff check and refactors schema version reading for better code reuse and testability. Several new and updated tests ensure the robustness of this logic.

**Schema upload logic improvements:**

* The `SchemaUpload` step now checks the current database schema version before applying the baseline schema, skipping the upload if the version is at or above `v1.0.2`. This prevents re-creating objects that were removed by later patches.
* Extracted schema version reading logic into a new `readCurrentSchemaVersion` function in `system_table.go` for reuse and clarity. [[1]](diffhunk://#diff-c756ef3c6a0f9d8c37c3f57b50736037342e8b4eb1ae80651669fbd24c8e1cd3R139-R163) [[2]](diffhunk://#diff-b6494ba095fc93e9f5ff32bd7bf04e7058910c6e094d3c4f1b2be777022037e7L134-R137)

**Testing enhancements:**

* Added comprehensive tests to ensure that baseline schema upload is skipped for already-initialized databases, and to verify correct error handling when reading or comparing schema versions fails.
* Refactored tests to use a helper function for mocking current schema version queries, improving test readability and maintainability.

**Documentation and changelog:**

* Added a changelog entry describing the fix and its impact.

## Changelog

Select exactly one option:

- [x] I added a Changie fragment under `.changes/unreleased` for every notable user-visible or security-related change.
- [ ] This pull request has no notable user-visible or security effect; a reviewer may apply the `no-changelog` label.
