### PR TITLE
Reduce database round trips for AAS create and delete

### DIFF
--- a/.changes/unreleased/changed-645-aas-write-roundtrips.yaml
+++ b/.changes/unreleased/changed-645-aas-write-roundtrips.yaml
@@ -1,5 +1,5 @@
 kind: changed
-body: AAS create and delete operations use one PostgreSQL execution for their core persistence work, reducing writer connection occupation under concurrent load.
+body: AAS create and delete operations avoid separate root and lookup executions for batches within the existing size limits, reducing writer connection occupation under concurrent load.
 time: 2026-08-31T11:00:00.000000+02:00
 custom:
   Impact: Low

--- a/.changes/unreleased/changed-645-aas-write-roundtrips.yaml
+++ b/.changes/unreleased/changed-645-aas-write-roundtrips.yaml
@@ -1,0 +1,7 @@
+kind: changed
+body: AAS create and delete operations use one PostgreSQL execution for their core persistence work, reducing writer connection occupation under concurrent load.
+time: 2026-08-31T11:00:00.000000+02:00
+custom:
+  Impact: Low
+  PullRequest: 645
+  SecurityImpact: Existing duplicate visibility, ABAC, history, row-locking, not-found, and managed-thumbnail cleanup behavior remains unchanged.

--- a/internal/aasrepository/integration_tests/aasrepository_delete_lock_integration_test.go
+++ b/internal/aasrepository/integration_tests/aasrepository_delete_lock_integration_test.go
@@ -1,0 +1,144 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/eclipse-basyx/basyx-go-components/internal/aasrepository/persistence"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/history"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvidenceDeleteLocksAASBeforeLoadingSnapshot(t *testing.T) {
+	aasID := "https://example.com/ids/aas/evidence-delete-lock"
+	status, err := createAASForThumbnailTest(aasRepositoryBaseURL, aasID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status)
+	t.Cleanup(func() {
+		request, requestErr := http.NewRequest(
+			http.MethodDelete,
+			aasRepositoryBaseURL+"/shells/"+base64.RawURLEncoding.EncodeToString([]byte(aasID)),
+			nil,
+		)
+		if requestErr != nil {
+			return
+		}
+		response, requestErr := (&http.Client{Timeout: 10 * time.Second}).Do(request)
+		if requestErr == nil {
+			_ = response.Body.Close()
+		}
+	})
+
+	db, err := sql.Open("pgx", integrationTestDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	repository, err := persistence.NewAssetAdministrationShellDatabaseFromDB(db, "off")
+	require.NoError(t, err)
+
+	previousHistoryConfig := history.ActiveConfig()
+	history.Configure(history.Config{Mode: history.ModeOff, EvidenceEnabled: true})
+	t.Cleanup(func() { history.Configure(previousHistoryConfig) })
+
+	blocker, err := db.Begin()
+	require.NoError(t, err)
+	blockerFinished := false
+	t.Cleanup(func() {
+		if !blockerFinished {
+			_ = blocker.Rollback()
+		}
+	})
+
+	lockQuery, lockArgs, err := goqu.Dialect("postgres").
+		From("aas").
+		Select("id").
+		Where(goqu.C("aas_id").Eq(aasID)).
+		ForUpdate(goqu.Wait).
+		Prepared(true).
+		ToSQL()
+	require.NoError(t, err)
+	var aasDBID int64
+	require.NoError(t, blocker.QueryRow(lockQuery, lockArgs...).Scan(&aasDBID))
+
+	updateQuery, updateArgs, err := goqu.Dialect("postgres").
+		Update("aas").
+		Set(goqu.Record{"category": "committed-before-delete"}).
+		Where(goqu.C("id").Eq(aasDBID)).
+		Prepared(true).
+		ToSQL()
+	require.NoError(t, err)
+	_, err = blocker.Exec(updateQuery, updateArgs...)
+	require.NoError(t, err)
+
+	deleteResult := make(chan error, 1)
+	deleteCtx := common.ContextWithConfig(context.Background(), &common.Config{})
+	go func() {
+		deleteResult <- repository.DeleteAssetAdministrationShellByID(deleteCtx, aasID)
+	}()
+
+	require.Eventually(t, func() bool {
+		return waitingForAASDeleteRowLock(db)
+	}, 5*time.Second, 20*time.Millisecond)
+
+	require.NoError(t, blocker.Commit())
+	blockerFinished = true
+
+	select {
+	case deleteErr := <-deleteResult:
+		require.Error(t, deleteErr)
+		require.Contains(t, deleteErr.Error(), "HISTORY-EVIDENCE-MUTATION-NILSTORE")
+	case <-time.After(5 * time.Second):
+		t.Fatal("evidence-enabled delete did not finish after the row lock was released")
+	}
+}
+
+func waitingForAASDeleteRowLock(db *sql.DB) bool {
+	query, args, err := goqu.Dialect("postgres").
+		From("pg_stat_activity").
+		Select(goqu.COUNT("*")).
+		Where(
+			goqu.C("wait_event_type").Eq("Lock"),
+			goqu.C("query").ILike("SELECT \"id\" FROM \"aas\"%FOR UPDATE%"),
+		).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return false
+	}
+	var count int
+	if err = db.QueryRow(query, args...).Scan(&count); err != nil {
+		return false
+	}
+	return count > 0
+}

--- a/internal/aasrepository/persistence/aas_asset_information_thumbnail_test.go
+++ b/internal/aasrepository/persistence/aas_asset_information_thumbnail_test.go
@@ -55,9 +55,7 @@ func TestCreateAssetAdministrationShellPersistsDefaultThumbnail(t *testing.T) {
 		[]types.IKey{types.NewKey(types.KeyTypesSubmodel, "https://example.com/ids/sm/1")},
 	)})
 
-	mock.ExpectQuery(`INSERT INTO "aas".*RETURNING "id"`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(17))
-	mock.ExpectExec(`(?s)INSERT INTO "aas_payload".*INSERT INTO "asset_information".*INSERT INTO "thumbnail_file_element".*INSERT INTO "specific_asset_id".*INSERT INTO "specific_asset_id_payload".*INSERT INTO "aas_submodel_reference".*INSERT INTO "aas_submodel_reference_key".*INSERT INTO "aas_submodel_reference_payload"`).
+	mock.ExpectExec(`(?s)INSERT INTO "aas".*INSERT INTO "aas_payload".*currval.*INSERT INTO "asset_information".*INSERT INTO "thumbnail_file_element".*INSERT INTO "specific_asset_id".*INSERT INTO "specific_asset_id_payload".*INSERT INTO "aas_submodel_reference".*INSERT INTO "aas_submodel_reference_key".*INSERT INTO "aas_submodel_reference_payload"`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	repository := &AssetAdministrationShellDatabase{}
@@ -85,7 +83,7 @@ func TestCreateAssetAdministrationShellLargeDuplicateStopsAfterRootInsert(t *tes
 	aas.SetSubmodels(references)
 
 	duplicateErr := &pgconn.PgError{Code: "23505", ConstraintName: "aas_aas_id_key"}
-	mock.ExpectQuery(`INSERT INTO "aas".*RETURNING "id"`).WillReturnError(duplicateErr)
+	mock.ExpectExec(`(?s)^INSERT INTO "aas"`).WillReturnError(duplicateErr)
 	mock.ExpectRollback()
 
 	repository := &AssetAdministrationShellDatabase{}
@@ -130,10 +128,8 @@ func TestCreateAssetAdministrationShellDependentConflictRemainsInternal(t *testi
 		types.NewAssetInformation(types.AssetKindInstance),
 	)
 
-	mock.ExpectQuery(`INSERT INTO "aas".*RETURNING "id"`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(17))
 	dependentErr := &pgconn.PgError{Code: "23505"}
-	mock.ExpectExec(`(?s)INSERT INTO "aas_payload".*INSERT INTO "asset_information"`).
+	mock.ExpectExec(`(?s)INSERT INTO "aas".*INSERT INTO "aas_payload".*INSERT INTO "asset_information"`).
 		WillReturnError(dependentErr)
 	mock.ExpectRollback()
 

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -503,12 +503,13 @@ func (s *AssetAdministrationShellDatabase) createAssetAdministrationShellInTrans
 	if err := validateAASCreateSubmodelReferences(aas.Submodels()); err != nil {
 		return err
 	}
-	aasDBID, err := insertAASCreateRoot(ctx, tx, dialect, aas)
-	if err != nil {
-		return err
-	}
 
 	batch := &common.PostgreSQLBatch{}
+	if err := appendAASCreateRoot(batch, dialect, aas); err != nil {
+		return err
+	}
+	aasDBID := common.PostgreSQLCurrentSequenceValue("aas", "id")
+
 	jsonizedPayload, err := jsonizeAssetAdministrationShellPayload(aas)
 	if err != nil {
 		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-JSON " + err.Error())
@@ -543,29 +544,23 @@ func (s *AssetAdministrationShellDatabase) createAssetAdministrationShellInTrans
 		return err
 	}
 	if err = common.ExecutePostgreSQLBatchInTransaction(ctx, tx, batch.Statements()); err != nil {
+		if mappedErr := mapCreateAASInsertError(err); mappedErr != nil {
+			return mappedErr
+		}
 		return fmt.Errorf("%s %w", common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECBATCH"), err)
 	}
 	return nil
 }
 
-func insertAASCreateRoot(ctx context.Context, tx *sql.Tx, dialect goqu.DialectWrapper, aas types.IAssetAdministrationShell) (int64, error) {
-	query, args, err := dialect.Insert("aas").Rows(goqu.Record{
+func appendAASCreateRoot(batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, aas types.IAssetAdministrationShell) error {
+	if err := batch.AppendDataset(dialect.Insert("aas").Rows(goqu.Record{
 		"aas_id":   aas.ID(),
 		"category": aas.Category(),
 		"id_short": aas.IDShort(),
-	}).Returning(goqu.C("id")).Prepared(true).ToSQL()
-	if err != nil {
-		return 0, common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDINSERTSQL " + err.Error())
+	})); err != nil {
+		return common.NewInternalServerError("AASREPO-NEWAAS-CREATE-BUILDINSERTSQL " + err.Error())
 	}
-
-	var aasDBID int64
-	if err = tx.QueryRowContext(ctx, query, args...).Scan(&aasDBID); err != nil {
-		if mappedErr := mapCreateAASInsertError(err); mappedErr != nil {
-			return 0, mappedErr
-		}
-		return 0, fmt.Errorf("%s %w", common.NewInternalServerError("AASREPO-NEWAAS-CREATE-EXECINSERT"), err)
-	}
-	return aasDBID, nil
+	return nil
 }
 
 func validateAASCreateSubmodelReferences(references []types.IReference) error {
@@ -1296,50 +1291,34 @@ func (s *AssetAdministrationShellDatabase) DeleteAssetAdministrationShellByIDInT
 		}
 	}
 
-	dialect := goqu.Dialect("postgres")
-	aasDBID, err := getAssetAdministrationShellDBIDForDelete(tx, aasIdentifier)
-	if err != nil {
-		return err
-	}
 	previousSnapshot, err := s.loadAASHistorySnapshotBeforeMutationTx(ctx, tx, aasIdentifier)
 	if err != nil {
 		return err
 	}
 
-	if err = cleanupAndDeleteAASByDatabaseID(ctx, tx, &dialect, aasDBID); err != nil {
+	dialect := goqu.Dialect("postgres")
+	deleted, err := cleanupAndDeleteAASByIdentifier(ctx, tx, &dialect, aasIdentifier)
+	if err != nil {
 		return err
+	}
+	if !deleted {
+		return common.NewErrNotFound("AASREPO-DELAAS-AASNOTFOUND Asset Administration Shell with ID '" + aasIdentifier + "' not found")
 	}
 
 	return history.AppendVersionTx(ctx, tx, history.TableAAS, aasIdentifier, history.ChangeDeleted, previousSnapshot, map[string]any{"id": aasIdentifier}, true)
 }
 
-func cleanupAndDeleteAASByDatabaseID(ctx context.Context, tx *sql.Tx, dialect *goqu.DialectWrapper, aasDBID int64) error {
-	cleanupQuery, cleanupArgs, err := buildCleanupThumbnailLargeObjectsByAASDBIDQuery(dialect, aasDBID)
+func cleanupAndDeleteAASByIdentifier(ctx context.Context, tx *sql.Tx, dialect *goqu.DialectWrapper, aasIdentifier string) (bool, error) {
+	query, args, err := buildCleanupAndDeleteAssetAdministrationShellQuery(dialect, aasIdentifier)
 	if err != nil {
-		return common.NewInternalServerError("AASREPO-DELAAS-BUILDUNLINKLO " + err.Error())
+		return false, common.NewInternalServerError("AASREPO-DELAAS-BUILDSQL " + err.Error())
 	}
-	deleteQuery, deleteArgs, err := buildDeleteAssetAdministrationShellByDBIDQuery(dialect, aasDBID)
-	if err != nil {
-		return common.NewInternalServerError("AASREPO-DELAAS-BUILDSQL " + err.Error())
+	var deletedCount int64
+	var unlinkedCount int64
+	if err = tx.QueryRowContext(ctx, query, args...).Scan(&deletedCount, &unlinkedCount); err != nil {
+		return false, common.NewInternalServerError("AASREPO-DELAAS-EXECQUERY " + err.Error())
 	}
-	batch := &common.PostgreSQLBatch{}
-	batch.AppendStatement(cleanupQuery, cleanupArgs...)
-	batch.AppendStatement(deleteQuery, deleteArgs...)
-	if err = common.ExecutePostgreSQLBatchInTransaction(ctx, tx, batch.Statements()); err != nil {
-		return common.NewInternalServerError("AASREPO-DELAAS-EXECBATCH " + err.Error())
-	}
-	return nil
-}
-
-func getAssetAdministrationShellDBIDForDelete(tx *sql.Tx, aasIdentifier string) (int64, error) {
-	aasDBID, scanErr := persistenceutils.GetAssetAdministrationShellDatabaseIDForUpdate(tx, aasIdentifier)
-	if scanErr != nil {
-		if scanErr == sql.ErrNoRows {
-			return 0, common.NewErrNotFound("AASREPO-DELAAS-AASNOTFOUND Asset Administration Shell with ID '" + aasIdentifier + "' not found")
-		}
-		return 0, common.NewInternalServerError("AASREPO-DELAAS-EXECSELECT " + scanErr.Error())
-	}
-	return aasDBID, nil
+	return deletedCount == 1, nil
 }
 
 // GetAssetAdministrationShellReferences returns paginated model references while preserving ABAC filters from ctx.

--- a/internal/aasrepository/persistence/aas_database.go
+++ b/internal/aasrepository/persistence/aas_database.go
@@ -1291,7 +1291,7 @@ func (s *AssetAdministrationShellDatabase) DeleteAssetAdministrationShellByIDInT
 		}
 	}
 
-	previousSnapshot, err := s.loadAASHistorySnapshotBeforeMutationTx(ctx, tx, aasIdentifier)
+	previousSnapshot, err := s.loadAASDeleteHistorySnapshotTx(ctx, tx, aasIdentifier)
 	if err != nil {
 		return err
 	}
@@ -1306,6 +1306,20 @@ func (s *AssetAdministrationShellDatabase) DeleteAssetAdministrationShellByIDInT
 	}
 
 	return history.AppendVersionTx(ctx, tx, history.TableAAS, aasIdentifier, history.ChangeDeleted, previousSnapshot, map[string]any{"id": aasIdentifier}, true)
+}
+
+func (s *AssetAdministrationShellDatabase) loadAASDeleteHistorySnapshotTx(ctx context.Context, tx *sql.Tx, aasIdentifier string) (map[string]any, error) {
+	if !history.ActiveConfig().EvidenceEnabled {
+		return nil, nil
+	}
+	aasDBID, err := persistenceutils.GetAssetAdministrationShellDatabaseIDForUpdate(tx, aasIdentifier)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, common.NewErrNotFound("AASREPO-DELAAS-AASNOTFOUND Asset Administration Shell with ID '" + aasIdentifier + "' not found")
+		}
+		return nil, common.NewInternalServerError("AASREPO-DELAAS-LOCKAAS " + err.Error())
+	}
+	return s.loadAASHistorySnapshotByDBIDBeforeMutationTx(ctx, tx, aasDBID)
 }
 
 func cleanupAndDeleteAASByIdentifier(ctx context.Context, tx *sql.Tx, dialect *goqu.DialectWrapper, aasIdentifier string) (bool, error) {

--- a/internal/aasrepository/persistence/aas_database_query_utils.go
+++ b/internal/aasrepository/persistence/aas_database_query_utils.go
@@ -342,20 +342,36 @@ func buildGetAssetAdministrationShellDBIDByIdentifierDataset(dialect *goqu.Diale
 		Limit(1)
 }
 
-func buildDeleteAssetAdministrationShellByDBIDQuery(dialect *goqu.DialectWrapper, aasDBID int64) (string, []any, error) {
-	return dialect.Delete("aas").Where(goqu.I("id").Eq(aasDBID)).ToSQL()
-}
+func buildCleanupAndDeleteAssetAdministrationShellQuery(dialect *goqu.DialectWrapper, aasIdentifier string) (string, []any, error) {
+	target := dialect.From(goqu.T("aas").As("a")).
+		LeftJoin(
+			goqu.T("thumbnail_file_data").As("tfd"),
+			goqu.On(goqu.I("tfd.id").Eq(goqu.I("a.id"))),
+		).
+		Select(goqu.I("a.id"), goqu.I("tfd.file_oid")).
+		Where(goqu.I("a.aas_id").Eq(aasIdentifier)).
+		ForUpdate(goqu.Wait, goqu.T("a"))
 
-func buildCleanupThumbnailLargeObjectsByAASDBIDQuery(dialect *goqu.DialectWrapper, aasDBID int64) (string, []any, error) {
-	unlinkSubquery := dialect.From(goqu.T("thumbnail_file_data").As("tfd")).
-		Select(goqu.Func("lo_unlink", goqu.I("tfd.file_oid")).As("unlink_result")).
-		Where(
-			goqu.I("tfd.id").Eq(aasDBID),
-			goqu.I("tfd.file_oid").IsNotNull(),
-		)
+	deleted := dialect.Delete("aas").
+		Where(goqu.C("id").In(dialect.From("target_aas").Select("id"))).
+		Returning("id")
 
-	return dialect.From(unlinkSubquery.As("unlink_results")).
-		Select(goqu.COUNT("*")).
+	unlinked := dialect.From("target_aas").
+		Select(goqu.Func("lo_unlink", goqu.C("file_oid")).As("unlink_result")).
+		Where(goqu.C("file_oid").IsNotNull())
+
+	return dialect.Select(
+		goqu.L("(SELECT COUNT(*) FROM ?)", goqu.I("deleted_aas")).As("deleted_count"),
+		goqu.L(
+			"(SELECT COALESCE(SUM(?), 0) FROM ?)",
+			goqu.I("unlink_result"),
+			goqu.I("unlinked_large_objects"),
+		).As("unlinked_count"),
+	).
+		With("target_aas", target).
+		With("deleted_aas", deleted).
+		With("unlinked_large_objects", unlinked).
+		Prepared(true).
 		ToSQL()
 }
 

--- a/internal/aasrepository/persistence/aas_large_object_cleanup_test.go
+++ b/internal/aasrepository/persistence/aas_large_object_cleanup_test.go
@@ -46,14 +46,32 @@ func TestDeleteAssetAdministrationShellCleansThumbnailLargeObjectBeforeDelete(t 
 	repository := &AssetAdministrationShellDatabase{}
 	aasID := "https://example.com/ids/aas/delete-cleanup"
 
-	mock.ExpectQuery(`SELECT .*FROM "aas".*FOR UPDATE`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
-	mock.ExpectExec(`(?s)SELECT COUNT\(\*\).*lo_unlink.*thumbnail_file_data.*DELETE FROM "aas"`).
-		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`(?s)WITH target_aas AS .*thumbnail_file_data.*FOR UPDATE OF "a".*, deleted_aas AS \(DELETE FROM "aas".*unlinked_large_objects AS .*lo_unlink.*SELECT .*deleted_count.*unlinked_count`).
+		WillReturnRows(sqlmock.NewRows([]string{"deleted_count", "unlinked_count"}).AddRow(int64(1), int64(1)))
 	mock.ExpectRollback()
 
 	err = repository.DeleteAssetAdministrationShellByIDInTransaction(contextWithConfig(), tx, aasID)
 	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeleteAssetAdministrationShellReturnsNotFoundFromCombinedQuery(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tx := beginMockTransaction(t, db, mock)
+	repository := &AssetAdministrationShellDatabase{}
+	aasID := "https://example.com/ids/aas/delete-missing"
+
+	mock.ExpectQuery(`(?s)WITH target_aas AS .*DELETE FROM "aas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"deleted_count", "unlinked_count"}).AddRow(int64(0), int64(0)))
+	mock.ExpectRollback()
+
+	err = repository.DeleteAssetAdministrationShellByIDInTransaction(contextWithConfig(), tx, aasID)
+	require.Error(t, err)
+	require.True(t, common.IsErrNotFound(err), "expected not-found error, got %v", err)
 	require.NoError(t, tx.Rollback())
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/aasrepository/persistence/aas_large_object_cleanup_test.go
+++ b/internal/aasrepository/persistence/aas_large_object_cleanup_test.go
@@ -76,6 +76,32 @@ func TestDeleteAssetAdministrationShellReturnsNotFoundFromCombinedQuery(t *testi
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestLoadAASDeleteEvidenceSnapshotLocksRowBeforeRead(t *testing.T) {
+	previousHistoryConfig := history.ActiveConfig()
+	history.Configure(history.Config{Mode: history.ModeOff, EvidenceEnabled: true})
+	t.Cleanup(func() { history.Configure(previousHistoryConfig) })
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	tx := beginMockTransaction(t, db, mock)
+	repository := &AssetAdministrationShellDatabase{}
+	aasID := "https://example.com/ids/aas/delete-evidence-lock"
+	globalAssetID := "https://example.com/global-assets/delete-evidence-lock"
+
+	mock.ExpectQuery(`SELECT .*FROM "aas".*FOR UPDATE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
+	expectExistingAASRead(mock, aasID, globalAssetID, "locked-snapshot")
+	mock.ExpectRollback()
+
+	snapshot, err := repository.loadAASDeleteHistorySnapshotTx(t.Context(), tx, aasID)
+	require.NoError(t, err)
+	require.Equal(t, "locked-snapshot", snapshot["category"])
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPutAssetAdministrationShellReconcilesExistingRootWithoutReplacement(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed

- execute the AAS root insert and dependent inserts in one atomic PostgreSQL batch when it remains within the existing batch limits
- resolve dependent ownership through the transaction-local AAS sequence value
- replace the separate delete lookup and cleanup/delete batch with one prepared, row-locking query
- keep thumbnail large-object cleanup and explicit not-found reporting in the combined delete query
- preserve the pre-snapshot AAS row lock when WORM evidence is enabled

## Why

The release benchmark shows a strong tail-latency increase once AAS writes saturate the available writer connections:

| Endpoint | Selected concurrency | RPS | p50 | p95 | p99 |
|---|---:|---:|---:|---:|---:|
| CreateShell | 160 | 1,345 | 63 ms | 398 ms | 716 ms |
| DeleteShellById | 160 | 4,369 | 19 ms | 129 ms | 239 ms |

For representative shells within the existing batch thresholds, both paths performed two database executions while holding the same transaction and writer connection. This change removes one execution from each operation, which shortens the connection occupation time and should reduce queue amplification under load. Larger create batches continue to use the existing 1,000-statement and 4 MiB splitting limits.

Duplicate handling, authorization checks, mutation history, delete row locking, not-found responses, and managed-thumbnail cleanup keep their existing behavior. Evidence-enabled deletion retains the row lock before capturing its previous snapshot. No schema change is required.

## Validation

- `go test ./internal/aasrepository/persistence ./internal/common/...`
- `go clean -testcache && go test -v ./internal/aasrepository/integration_tests`
- `go test ./internal/aasrepository/security_tests ./internal/aasrepository/persistence`
- `go vet ./internal/aasrepository/persistence ./internal/aasrepository/integration_tests`
- `golangci-lint run ./internal/aasrepository/...`
- real PostgreSQL contention test for evidence snapshot lock ordering

Longer before/after validation at the previously selected concurrency:

| Endpoint | c | Before RPS | PR RPS | Change | Before p50/p95/p99 | PR p50/p95/p99 |
|---|---:|---:|---:|---:|---:|---:|
| CreateShell | 160 | 1,345 | 1,439 | +7.0% | 63/398/716 ms | 64/351/650 ms |
| DeleteShellById | 160 | 4,369 | 4,757 | +8.9% | 19/129/239 ms | 18/114/214 ms |

The remaining CreateShell tail is saturation-driven. A focused concurrency check showed that c160 was already beyond the throughput optimum:

| c | RPS | p50 | p95 | p99 | Average writer-pool wait |
|---:|---:|---:|---:|---:|---:|
| 80 | 1,421 | 42 ms | 113 ms | 248 ms | 16 ms |
| 120 | 1,504 | 55 ms | 219 ms | 373 ms | 45 ms |
| 160 | 1,439 | 64 ms | 351 ms | 650 ms | 77 ms |

The common c160 path still improves p95 and p99 compared with the previous implementation. For throughput-oriented operation, c120 is the better CreateShell operating point; c80 retains nearly the same throughput with a substantially lower tail.

Neighboring endpoint regression check:

| Endpoint | c | Before RPS | PR image RPS | Change | Result |
|---|---:|---:|---:|---:|---|
| GetAllShells?limit=100 | 160 | 1,129 | 1,119 | -0.9% | stable |
| ReadShellById | 80 | 5,547 | 5,563 | +0.3% | stable |
| UpdateShellByIdSingleValue | 80 | 1,892 | 2,849 | +50.6% | no regression |

All focused measurements completed without request failures. The alternating single-value update control changes one description value with every request. Its gain is recorded only as a regression check because this PR does not change the AAS update path; it is not attributed to this PR.
