### PR TITLE
Reduce create-path write amplification

### DIFF
--- a/.changes/unreleased/changed-646-shell-descriptor-create.yaml
+++ b/.changes/unreleased/changed-646-shell-descriptor-create.yaml
@@ -1,0 +1,7 @@
+kind: changed
+body: Shell descriptor creates avoid rewriting newly inserted embedded Submodel descriptors while synchronizing administration timestamps.
+time: 2026-08-31T13:30:00.000000+02:00
+custom:
+  Impact: Low
+  PullRequest: 646
+  SecurityImpact: Descriptor validation, authorization, history, and stored graph semantics remain unchanged.

--- a/.changes/unreleased/changed-646-submodel-element-create.yaml
+++ b/.changes/unreleased/changed-646-submodel-element-create.yaml
@@ -1,0 +1,7 @@
+kind: changed
+body: Nested SubmodelElement creates combine child position, duplicate, and identifier allocation state into one database statement.
+time: 2026-08-31T13:30:00.000000+02:00
+custom:
+  Impact: Low
+  PullRequest: 646
+  SecurityImpact: Existing parent locking and ABAC-aware duplicate visibility checks remain unchanged.

--- a/internal/aasregistry/integration_tests/aasregistry_update_persistence_integration_test.go
+++ b/internal/aasregistry/integration_tests/aasregistry_update_persistence_integration_test.go
@@ -89,6 +89,46 @@ func TestAASDescriptorPutPreservesUnchangedRows(t *testing.T) {
 	require.Equal(t, afterChange, afterNoOp)
 }
 
+func TestAASDescriptorPostPreservesEmbeddedSubmodelAdministrationTimestamps(t *testing.T) {
+	aasID := fmt.Sprintf("urn:example:aas:nested-administration:%d", time.Now().UnixNano())
+	submodelID := fmt.Sprintf("urn:example:submodel:nested-administration:%d", time.Now().UnixNano())
+	t.Cleanup(func() { cleanupAASDescriptor(t, aasRegistryBaseURL, aasID) })
+	createdAt := "2030-01-02T03:04:05Z"
+	updatedAt := "2030-01-02T03:04:06Z"
+	payload := fmt.Sprintf(
+		`{"id":"%s","endpoints":[{"interface":"AAS-3.0","protocolInformation":{"href":"https://example.com/aas","endpointProtocol":"https"}}],"submodelDescriptors":[{"id":"%s","administration":{"createdAt":"%s","updatedAt":"%s"},"endpoints":[{"interface":"SUBMODEL-3.0","protocolInformation":{"href":"https://example.com/submodels","endpointProtocol":"https"}}]}]}`,
+		aasID,
+		submodelID,
+		createdAt,
+		updatedAt,
+	)
+
+	_, status, _, err := postJSONResponse(aasRegistryBaseURL+"/shell-descriptors", payload)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status)
+
+	db, err := sql.Open("pgx", aasRegistryIntegrationTestDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	query, args, err := goqu.Dialect(common.Dialect).
+		From(common.TblSubmodelDescriptor).
+		Select("administration_created_at", "administration_updated_at").
+		Where(goqu.C(common.ColAASID).Eq(submodelID)).
+		Prepared(true).
+		ToSQL()
+	require.NoError(t, err)
+
+	var storedCreatedAt time.Time
+	var storedUpdatedAt time.Time
+	require.NoError(t, db.QueryRowContext(t.Context(), query, args...).Scan(&storedCreatedAt, &storedUpdatedAt))
+	expectedCreatedAt, err := time.Parse(time.RFC3339, createdAt)
+	require.NoError(t, err)
+	expectedUpdatedAt, err := time.Parse(time.RFC3339, updatedAt)
+	require.NoError(t, err)
+	require.True(t, expectedCreatedAt.Equal(storedCreatedAt))
+	require.True(t, expectedUpdatedAt.Equal(storedUpdatedAt))
+}
+
 func readAASDescriptorPersistenceState(t *testing.T, db *sql.DB, aasID string) aasDescriptorPersistenceState {
 	t.Helper()
 	aas := goqu.T(common.TblAASDescriptor).As("aas")

--- a/internal/common/descriptors/postgres_create_batch.go
+++ b/internal/common/descriptors/postgres_create_batch.go
@@ -107,6 +107,9 @@ func appendSubmodelDescriptors(
 			return err
 		}
 		descriptorID := common.PostgreSQLCurrentSequenceValue(common.TblDescriptor, common.ColID)
+		if err := appendDescriptorPayload(batch, descriptorID, descriptor.Description, descriptor.DisplayName, descriptor.Administration, descriptor.Extensions); err != nil {
+			return err
+		}
 		if err := batch.AppendDataset(goqu.Insert(common.TblSubmodelDescriptor).Rows(goqu.Record{
 			common.ColDescriptorID:    descriptorID,
 			common.ColPosition:        position,
@@ -122,9 +125,6 @@ func appendSubmodelDescriptors(
 			"submodel_descriptor_semantic_id_reference",
 			"submodel_descriptor_semantic_id_reference_key",
 		); err != nil {
-			return err
-		}
-		if err := appendDescriptorPayload(batch, descriptorID, descriptor.Description, descriptor.DisplayName, descriptor.Administration, descriptor.Extensions); err != nil {
 			return err
 		}
 		if err := batch.AppendContextReferences(

--- a/internal/common/descriptors/postgres_create_batch_test.go
+++ b/internal/common/descriptors/postgres_create_batch_test.go
@@ -85,3 +85,48 @@ func TestBuildAdministrationShellDescriptorCreateBatchCollectsCompleteGraph(t *t
 		}
 	}
 }
+
+func TestBuildAdministrationShellDescriptorCreateBatchInsertsNestedPayloadBeforeParent(t *testing.T) {
+	t.Parallel()
+
+	descriptor := model.AssetAdministrationShellDescriptor{
+		Id: "urn:example:aas:1",
+		SubmodelDescriptors: []model.SubmodelDescriptor{{
+			Id: "urn:example:submodel:1",
+			Endpoints: []model.Endpoint{{
+				Interface: "SUBMODEL-3.0",
+				ProtocolInformation: model.ProtocolInformation{
+					Href: "https://example.com/submodels/1",
+				},
+			}},
+		}},
+	}
+
+	batch, err := BuildAdministrationShellDescriptorCreateBatch(context.Background(), descriptor)
+	if err != nil {
+		t.Fatalf("BuildAdministrationShellDescriptorCreateBatch returned error: %v", err)
+	}
+
+	nestedDescriptorIndex := -1
+	nestedPayloadIndex := -1
+	nestedParentIndex := -1
+	for index, statement := range batch.Statements() {
+		switch {
+		case statement.SQL == `INSERT INTO "descriptor" DEFAULT VALUES`:
+			nestedDescriptorIndex = index
+		case nestedDescriptorIndex >= 0 && strings.HasPrefix(statement.SQL, `INSERT INTO "descriptor_payload"`):
+			nestedPayloadIndex = index
+		case strings.HasPrefix(statement.SQL, `INSERT INTO "submodel_descriptor"`):
+			nestedParentIndex = index
+		}
+	}
+
+	if nestedDescriptorIndex < 0 || nestedPayloadIndex <= nestedDescriptorIndex || nestedParentIndex <= nestedPayloadIndex {
+		t.Fatalf(
+			"expected nested descriptor, payload, and parent insertion order, got descriptor=%d payload=%d parent=%d",
+			nestedDescriptorIndex,
+			nestedPayloadIndex,
+			nestedParentIndex,
+		)
+	}
+}

--- a/internal/submodelrepository/persistence/queries/submodel_database_queries.go
+++ b/internal/submodelrepository/persistence/queries/submodel_database_queries.go
@@ -359,14 +359,46 @@ func BuildSubmodelElementParentForInsertSQL(submodelID string, parentPath string
 		ToSQL()
 }
 
-// BuildSubmodelElementNextPositionSQL builds the indexed position lookup used
-// after the parent row has been locked in the current transaction.
-func BuildSubmodelElementNextPositionSQL(parentElementID int) (string, []any, error) {
+// BuildSubmodelElementChildInsertStateSQL builds the state lookup used after
+// the parent row has been locked in the current transaction.
+func BuildSubmodelElementChildInsertStateSQL(submodelDatabaseID int, parentElementID int, idShort string) (string, []any, error) {
 	dialect := goqu.Dialect(common.Dialect)
-	return dialect.
+	nextPosition := dialect.
 		From(goqu.T("submodel_element").As("child")).
 		Select(goqu.L("COALESCE(MAX(?), -1) + 1", goqu.I("child.position"))).
-		Where(goqu.I("child.parent_sme_id").Eq(parentElementID)).
+		Where(goqu.I("child.parent_sme_id").Eq(parentElementID))
+	collisionPath := dialect.
+		From(goqu.T("submodel_element").As("sibling")).
+		Select(goqu.I("sibling.idshort_path")).
+		Where(
+			goqu.I("sibling.submodel_id").Eq(submodelDatabaseID),
+			goqu.I("sibling.parent_sme_id").Eq(parentElementID),
+			goqu.I("sibling.id_short").Eq(idShort),
+		).
+		Limit(1)
+	collisionProjection := goqu.L("NULL").As("collision_path")
+	if idShort != "" {
+		collisionProjection = goqu.L("(?)", collisionPath).As("collision_path")
+	}
+	insertState := dialect.Select(
+		goqu.L("(?)", nextPosition).As("next_position"),
+		collisionProjection,
+	)
+
+	return dialect.
+		From("child_insert_state").
+		Select(
+			"next_position",
+			"collision_path",
+			goqu.Case().
+				When(
+					goqu.C("collision_path").IsNull(),
+					goqu.Func("nextval", goqu.Func("pg_get_serial_sequence", "submodel_element", "id")),
+				).
+				Else(goqu.L("NULL")).
+				As("first_node_id"),
+		).
+		With("child_insert_state", insertState).
 		Prepared(true).
 		ToSQL()
 }

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_batch_insert_test.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_batch_insert_test.go
@@ -69,6 +69,45 @@ func TestInsertSubmodelElementsExecutesGraphAsSingleBatch(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestInsertSubmodelElementsUsesPreallocatedFirstNodeID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+
+	property := types.NewProperty(types.DataTypeDefXSDString)
+	propertyIDShort := "temperature"
+	property.SetIDShort(&propertyIDShort)
+	collection := types.NewSubmodelElementCollection()
+	collectionIDShort := "measurements"
+	collection.SetIDShort(&collectionIDShort)
+	collection.SetValue([]types.ISubmodelElement{property})
+
+	mock.ExpectQuery(`SELECT .*nextval.*generate_series`).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"nextval"}).AddRow(102))
+	mock.ExpectExec(`(?s)INSERT INTO "submodel_element".*(?:INSERT INTO "property_element".*INSERT INTO "submodel_element_collection"|INSERT INTO "submodel_element_collection".*INSERT INTO "property_element")`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectRollback()
+
+	ids, err := InsertSubmodelElementsForSubmodelDatabaseIDContext(
+		t.Context(),
+		db,
+		42,
+		[]types.ISubmodelElement{collection},
+		tx,
+		&BatchInsertContext{FirstNodeID: 101},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int{101}, ids)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestInsertSubmodelElementsRollsBackOwnedTransactionAfterConflict(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_database.go
@@ -711,7 +711,7 @@ func insertSubmodelElements(requestCtx *context.Context, executeBatch func(*sql.
 		return nil, err
 	}
 
-	insertBaseErr := insertBaseNodesDepthWise(requestCtx, localTx, batch, dialect, int64(submodelDatabaseID), nodes)
+	insertBaseErr := insertBaseNodesDepthWise(requestCtx, localTx, batch, dialect, int64(submodelDatabaseID), nodes, ctx.FirstNodeID)
 	if insertBaseErr != nil {
 		err = insertBaseErr
 		return nil, err

--- a/internal/submodelrepository/persistence/submodelElements/submodel_element_database_utils.go
+++ b/internal/submodelrepository/persistence/submodelElements/submodel_element_database_utils.go
@@ -45,6 +45,7 @@ type BatchInsertContext struct {
 	ParentID      int    // Database ID of the parent element (0 for top-level elements)
 	ParentPath    string // Path of the parent element (empty for top-level elements)
 	RootSmeID     int    // Database ID of the root submodel element (0 for top-level elements, will be set to own ID)
+	FirstNodeID   int    // Optional preallocated database ID for the first inserted element
 	IsFromList    bool   // Whether elements are being inserted into a SubmodelElementList
 	StartPosition int    // Starting position for elements (used when adding to existing containers)
 	StartDepth    int    // Depth of inserted root elements (0 for top-level elements)
@@ -189,12 +190,12 @@ func buildIDShortPath(parentPath string, isFromList bool, position int, idShort 
 	return parentPath + "." + idShort
 }
 
-func insertBaseNodesDepthWise(requestCtx *context.Context, tx *sql.Tx, batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, submodelDatabaseID int64, nodes []*flattenedInsertNode) error {
+func insertBaseNodesDepthWise(requestCtx *context.Context, tx *sql.Tx, batch *common.PostgreSQLBatch, dialect goqu.DialectWrapper, submodelDatabaseID int64, nodes []*flattenedInsertNode, firstNodeID int) error {
 	if len(nodes) == 0 {
 		return nil
 	}
 
-	if err := assignReservedNodeIDs(requestCtx, tx, nodes); err != nil {
+	if err := assignReservedNodeIDs(requestCtx, tx, nodes, firstNodeID); err != nil {
 		return err
 	}
 
@@ -239,11 +240,16 @@ func insertBaseNodesDepthWise(requestCtx *context.Context, tx *sql.Tx, batch *co
 	return nil
 }
 
-func assignReservedNodeIDs(requestCtx *context.Context, tx *sql.Tx, nodes []*flattenedInsertNode) error {
-	reservedIDs, err := reserveSubmodelElementIDs(requestCtx, tx, len(nodes))
+func assignReservedNodeIDs(requestCtx *context.Context, tx *sql.Tx, nodes []*flattenedInsertNode, firstNodeID int) error {
+	reservedIDs := make([]int, 0, len(nodes))
+	if firstNodeID > 0 && len(nodes) > 0 {
+		reservedIDs = append(reservedIDs, firstNodeID)
+	}
+	remainingIDs, err := reserveSubmodelElementIDs(requestCtx, tx, len(nodes)-len(reservedIDs))
 	if err != nil {
 		return err
 	}
+	reservedIDs = append(reservedIDs, remainingIDs...)
 	if len(reservedIDs) != len(nodes) {
 		return common.NewInternalServerError("SMREPO-INSSME-RESERVEID-COUNTMISMATCH reserved IDs count does not match node count")
 	}
@@ -256,6 +262,9 @@ func assignReservedNodeIDs(requestCtx *context.Context, tx *sql.Tx, nodes []*fla
 }
 
 func reserveSubmodelElementIDs(requestCtx *context.Context, tx *sql.Tx, count int) ([]int, error) {
+	if count == 0 {
+		return nil, nil
+	}
 	if tx == nil {
 		return nil, common.NewInternalServerError("SMREPO-INSSME-RESERVEID-NILTX transaction must not be nil")
 	}

--- a/internal/submodelrepository/persistence/submodel_create_visibility_test.go
+++ b/internal/submodelrepository/persistence/submodel_create_visibility_test.go
@@ -102,6 +102,51 @@ func TestSubmodelRepositoryCreateExistingUnauthorizedSubmodelElementDoesNotRetur
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestAddSubmodelElementWithPathExistingUnauthorizedElementDoesNotReturnConflict(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	sut := &SubmodelDatabase{db: db}
+	element := types.NewProperty(types.DataTypeDefXSDString)
+	idShort := "HiddenElement"
+	element.SetIDShort(&idShort)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT .*FROM \(SELECT .*FROM "submodel" AS "sm_lock".*FOR KEY SHARE.*\) AS "sm".*JOIN "submodel_element" AS "parent".*FOR UPDATE OF "parent"`).
+		WithArgs("sm", "container").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"submodel_id",
+			"parent_id",
+			"root_sme_id",
+			"model_type",
+			"child_depth",
+		}).AddRow(42, 7, 7, types.ModelTypeSubmodelElementCollection, 2))
+	mock.ExpectQuery(`WITH RECURSIVE visible_sme_path_ancestors.*`).
+		WithArgs(42, "container", 42, 42, "container", false, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"visible"}).AddRow(7))
+	mock.ExpectQuery(`WITH child_insert_state AS .*MAX.*FROM "submodel_element" AS "child".*"collision_path".*SELECT "next_position", "collision_path", CASE.*nextval.*first_node_id`).
+		WithArgs(7, 42, 7, "HiddenElement", 1, "submodel_element", "id").
+		WillReturnRows(sqlmock.NewRows([]string{"next_position", "collision_path", "first_node_id"}).AddRow(3, "container.HiddenElement", nil))
+	mock.ExpectQuery(`SELECT "id" FROM "submodel"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+	mock.ExpectQuery(`SELECT "sme"\."id" FROM "submodel_element" AS "sme"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(8))
+	mock.ExpectQuery(`SELECT "sme"\."id" FROM "submodel_element" AS "sme".*FALSE`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectRollback()
+
+	err = sut.AddSubmodelElementWithPath(contextWithRestrictedCreateSubmodel(t), "sm", "container", element)
+	require.Error(t, err)
+	require.Truef(t, common.IsErrDenied(err), "got %v", err)
+	require.False(t, common.IsErrConflict(err))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func contextWithRestrictedCreateSubmodel(t *testing.T) context.Context {
 	t.Helper()
 

--- a/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_public_methods_sqlmock_test.go
@@ -774,11 +774,9 @@ func TestAddSubmodelElementWithPathUnrestrictedDuplicateReturnsConflict(t *testi
 			"model_type",
 			"child_depth",
 		}).AddRow(42, 7, 7, types.ModelTypeSubmodelElementList, 2))
-	mock.ExpectQuery(`SELECT COALESCE.*MAX.*FROM "submodel_element" AS "child"`).
-		WithArgs(7).
-		WillReturnRows(sqlmock.NewRows([]string{"next_position"}).AddRow(3))
-	mock.ExpectQuery(`SELECT "idshort_path" FROM "submodel_element"`).
-		WillReturnRows(sqlmock.NewRows([]string{"idshort_path"}).AddRow("container[0]"))
+	mock.ExpectQuery(`WITH child_insert_state AS .*MAX.*FROM "submodel_element" AS "child".*"collision_path".*SELECT "next_position", "collision_path", CASE.*nextval.*first_node_id`).
+		WithArgs(7, 42, 7, "Created", 1, "submodel_element", "id").
+		WillReturnRows(sqlmock.NewRows([]string{"next_position", "collision_path", "first_node_id"}).AddRow(3, "container[0]", nil))
 	mock.ExpectRollback()
 
 	err = sut.AddSubmodelElementWithPath(contextWithABACDisabled(t), "sm", "container", element)
@@ -812,13 +810,9 @@ func TestAddSubmodelElementWithPathInTransactionUsesOnlyTransactionConnection(t 
 			"model_type",
 			"child_depth",
 		}).AddRow(42, 7, 7, types.ModelTypeSubmodelElementCollection, 2))
-	mock.ExpectQuery(`SELECT COALESCE.*MAX.*FROM "submodel_element" AS "child"`).
-		WithArgs(7).
-		WillReturnRows(sqlmock.NewRows([]string{"next_position"}).AddRow(3))
-	mock.ExpectQuery(`SELECT "idshort_path" FROM "submodel_element"`).
-		WillReturnRows(sqlmock.NewRows([]string{"idshort_path"}))
-	mock.ExpectQuery(`SELECT .*nextval.*generate_series`).
-		WillReturnRows(sqlmock.NewRows([]string{"nextval"}).AddRow(101))
+	mock.ExpectQuery(`WITH child_insert_state AS .*MAX.*FROM "submodel_element" AS "child".*"collision_path".*SELECT "next_position", "collision_path", CASE.*nextval.*first_node_id`).
+		WithArgs(7, 42, 7, "Created", 1, "submodel_element", "id").
+		WillReturnRows(sqlmock.NewRows([]string{"next_position", "collision_path", "first_node_id"}).AddRow(3, nil, 101))
 	mock.ExpectExec(`(?s)INSERT INTO "submodel_element".*INSERT INTO "property_element"`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectRollback()

--- a/internal/submodelrepository/persistence/submodel_element_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_element_write_database.go
@@ -278,18 +278,27 @@ func (s *SubmodelDatabase) addSubmodelElementWithPathInTransaction(ctx context.C
 	default:
 		return common.NewErrBadRequest("SMREPO-ADDSMEBYPATH-BADPARENT Parent element does not support child elements")
 	}
-	parent.nextPosition, err = nextSubmodelElementPosition(ctx, tx, parent.elementID)
+	idShort := ""
+	if elementIDShort := submodelElement.IDShort(); elementIDShort != nil {
+		idShort = *elementIDShort
+	}
+	var collisionPath string
+	parent.nextPosition, collisionPath, parent.firstNodeID, err = submodelElementChildInsertState(
+		ctx,
+		tx,
+		parent.submodelDatabaseID,
+		parent.elementID,
+		idShort,
+	)
 	if err != nil {
 		return err
 	}
 
-	if err = s.ensureVisibleSubmodelElementCreateDoesNotExist(
+	if err = s.ensureVisibleSubmodelElementCreateCollisionAllowed(
 		ctx,
 		tx,
 		submodelID,
-		parent.submodelDatabaseID,
-		&parent.elementID,
-		submodelElement,
+		collisionPath,
 		"SMREPO-ADDSMEBYPATH-COLLISION Duplicate submodel element idShort",
 		"SMREPO-ADDSMEBYPATH-CHKDUP-ABACDENIED existing submodel element is not accessible under ABAC constraints",
 	); err != nil {
@@ -306,6 +315,7 @@ func (s *SubmodelDatabase) addSubmodelElementWithPathInTransaction(ctx context.C
 			ParentID:      parent.elementID,
 			ParentPath:    parentPath,
 			RootSmeID:     parent.rootSmeID,
+			FirstNodeID:   parent.firstNodeID,
 			IsFromList:    isFromList,
 			StartPosition: parent.nextPosition,
 			StartDepth:    parent.childDepth,
@@ -325,6 +335,7 @@ type submodelElementInsertParent struct {
 	rootSmeID          int
 	modelType          types.ModelType
 	nextPosition       int
+	firstNodeID        int
 	childDepth         int
 }
 
@@ -351,17 +362,19 @@ func (s *SubmodelDatabase) lockSubmodelElementParentForInsert(ctx context.Contex
 	return submodelElementInsertParent{}, submodelElementParentNotFoundError(ctx, tx, submodelID, parentPath)
 }
 
-func nextSubmodelElementPosition(ctx context.Context, tx *sql.Tx, parentElementID int) (int, error) {
-	query, args, err := submodelqueries.BuildSubmodelElementNextPositionSQL(parentElementID)
+func submodelElementChildInsertState(ctx context.Context, tx *sql.Tx, submodelDatabaseID int, parentElementID int, idShort string) (int, string, int, error) {
+	query, args, err := submodelqueries.BuildSubmodelElementChildInsertStateSQL(submodelDatabaseID, parentElementID, idShort)
 	if err != nil {
-		return 0, common.NewInternalServerError("SMREPO-ADDSMEBYPATH-BUILDNEXTPOSQ " + err.Error())
+		return 0, "", 0, common.NewInternalServerError("SMREPO-ADDSMEBYPATH-BUILDSTATEQ " + err.Error())
 	}
 
 	var nextPosition int
-	if err = tx.QueryRowContext(ctx, query, args...).Scan(&nextPosition); err != nil {
-		return 0, common.NewInternalServerError("SMREPO-ADDSMEBYPATH-EXECNEXTPOSQ " + err.Error())
+	var collisionPath sql.NullString
+	var firstNodeID sql.NullInt64
+	if err = tx.QueryRowContext(ctx, query, args...).Scan(&nextPosition, &collisionPath, &firstNodeID); err != nil {
+		return 0, "", 0, common.NewInternalServerError("SMREPO-ADDSMEBYPATH-EXECSTATEQ " + err.Error())
 	}
-	return nextPosition, nil
+	return nextPosition, collisionPath.String, int(firstNodeID.Int64), nil
 }
 
 func submodelElementParentNotFoundError(ctx context.Context, tx *sql.Tx, submodelID string, parentPath string) error {
@@ -875,6 +888,37 @@ func (s *SubmodelDatabase) ensureVisibleSubmodelElementCreateDoesNotExist(
 			if duplicatePath == "" {
 				return common.NewInternalServerError("SMREPO-CHKSMEDUP-EMPTYPATH existing submodel element duplicate path is empty")
 			}
+			exists, visible, err := s.checkSubmodelElementVisibilityInTx(readCtx, tx, submodelID, duplicatePath)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return common.NewErrNotFound("SMREPO-CHKSMEDUP-NOTFOUND existing submodel element not found")
+			}
+			if !visible {
+				return common.NewErrDenied(deniedMessage)
+			}
+			return nil
+		},
+		conflictMessage,
+		deniedMessage,
+	)
+}
+
+func (s *SubmodelDatabase) ensureVisibleSubmodelElementCreateCollisionAllowed(
+	ctx context.Context,
+	tx *sql.Tx,
+	submodelID string,
+	duplicatePath string,
+	conflictMessage string,
+	deniedMessage string,
+) error {
+	return createprecheck.EnsureVisibleCreate(
+		ctx,
+		func(context.Context) (bool, error) {
+			return duplicatePath != "", nil
+		},
+		func(readCtx context.Context) error {
 			exists, visible, err := s.checkSubmodelElementVisibilityInTx(readCtx, tx, submodelID, duplicatePath)
 			if err != nil {
 				return err


### PR DESCRIPTION
## What changed

- combine nested SubmodelElement position lookup, duplicate lookup, and first ID allocation into one database statement after the parent lock
- reuse the preallocated first ID when the inserted element contains a larger subtree
- insert embedded Submodel descriptor payloads before their parent rows so the timestamp synchronization trigger can populate the parent during the initial insert instead of rewriting it immediately afterward

## Why

CreateSubmodelElementAtIdShortPath spent most of its wall time in several short sequential database round trips. The representative baseline reached 4,154 requests/s at concurrency 80, with p50 12.1 ms, p95 49.3 ms, and p99 161.3 ms. The new path keeps the existing parent lock and duplicate visibility handling, but reduces the three state reads and allocations after that lock to one statement.

PostShellDescriptor reached 1,274 requests/s at concurrency 80, with p50 51.2 ms, p95 122.9 ms, and p99 262.7 ms. The sampled descriptors contained about 5.5 embedded Submodel descriptors on average. PostgreSQL recorded 274,399 immediate Submodel descriptor rewrites for 49,949 shell descriptor creates. Reordering the existing batch removes those rewrites without changing the stored descriptor graph.

## Compatibility and security

- no API or schema changes
- parent row locking and race-free child position allocation remain unchanged
- duplicate conflicts still use the existing ABAC-aware visibility check
- conflicting creates do not consume a preallocated ID
- descriptor validation, history, and readback behavior remain unchanged

## Benchmark results

Focused before/after runs used the same dataset, concurrency 80, a 10-second warm-up, and a 30-second measured phase. All measured requests succeeded.

| Endpoint | RPS before | RPS after | Change | p50 before / after | p95 before / after | p99 before / after |
|---|---:|---:|---:|---:|---:|---:|
| CreateSubmodelElementAtIdShortPath | 4,154 | 4,706 | +13.3% | 12.1 / 7.1 ms | 49.3 / 71.3 ms | 161.3 / 208.5 ms |
| PostShellDescriptor | 1,274 | 1,325 | +4.0% | 51.2 / 52.9 ms | 122.9 / 108.0 ms | 262.7 / 173.5 ms |
| DeleteShellDescriptorById | 2,971 | 3,237 | +9.0% | 12.9 / 10.9 ms | 36.1 / 28.6 ms | 217.8 / 73.8 ms |

An exact repeat of CreateSubmodelElementAtIdShortPath reached 4,390 requests/s with p50 7.4 ms, p95 74.1 ms, and p99 192.4 ms. This confirms the throughput and median-latency improvement, but not a tail-latency improvement. The remaining tail is associated with periodic PostgreSQL WAL-write stalls and is separate from the removed round trips.

PostgreSQL evidence for PostShellDescriptor shows that the reordered insert removes the immediate nested descriptor rewrites:

- statement execution time per commit: 6.478 ms to 3.447 ms (-46.8%)
- WAL per commit: 54,289 bytes to 28,300 bytes (-47.9%)
- nested Submodel descriptor rewrite rows: 274,399 to 0
- nested Submodel descriptor rewrite WAL: 1.148 GB to 0

## Validation

- go test ./internal/common/descriptors ./internal/submodelrepository/persistence/queries ./internal/submodelrepository/persistence/submodelElements ./internal/submodelrepository/persistence
- go test -v ./internal/submodelrepository/integration_tests
- go test -v ./internal/aasregistry/integration_tests
- golangci-lint v2.13.2 on the affected packages
