### PR TITLE
Reduce descriptor PUT database round trips

### DIFF
--- a/.changes/unreleased/fixed-20260903-164000.yaml
+++ b/.changes/unreleased/fixed-20260903-164000.yaml
@@ -2,6 +2,6 @@ kind: fixed
 body: Reduce database round trips and redundant root writes when updating AAS and Submodel Descriptors.
 time: 2026-09-03T16:40:00.000000+02:00
 custom:
-    Impact: Medium
+    Impact: Low
     PullRequest: 658
-    SecurityImpact: Existing create/update formula selection, fragment masking, and authorized update reconciliation remain unchanged.
+    SecurityImpact: None.

--- a/.changes/unreleased/fixed-20260903-164000.yaml
+++ b/.changes/unreleased/fixed-20260903-164000.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: Reduce database round trips and redundant root writes when updating AAS and Submodel Descriptors.
+time: 2026-09-03T16:40:00.000000+02:00
+custom:
+    Impact: Medium
+    PullRequest: 658
+    SecurityImpact: Existing create/update formula selection, fragment masking, and authorized update reconciliation remain unchanged.

--- a/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
+++ b/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
@@ -557,7 +557,7 @@ func (p *PostgreSQLAASRegistryDatabase) ReplaceAdministrationShellDescriptor(
 		if snapshotErr != nil {
 			return snapshotErr
 		}
-		descriptorID, err := descriptors.LockAdministrationShellDescriptorForUpdateTx(ctx, tx, aasd.Id)
+		descriptorID, err := descriptors.LockExistingAdministrationShellDescriptorForUpdateTx(ctx, tx, aasd.Id)
 		if err != nil {
 			return err
 		}

--- a/internal/common/descriptors/SubmodelDescriptorListQuery.go
+++ b/internal/common/descriptors/SubmodelDescriptorListQuery.go
@@ -41,6 +41,7 @@ type submodelDescriptorListScope struct {
 	collectorRoot   grammar.CollectorRoot
 	fragmentPrefix  string
 	aasDescriptorID *int64
+	identifiable    string
 }
 
 type submodelDescriptorListRow struct {
@@ -76,6 +77,35 @@ func listSubmodelDescriptorsSingleStatement(
 			fragmentPrefix: "$smdesc",
 		},
 	)
+}
+
+// GetSubmodelDescriptorByIDSingleStatement loads one standalone Submodel
+// descriptor, including its complete normalized graph, with one SQL statement.
+func GetSubmodelDescriptorByIDSingleStatement(
+	ctx context.Context,
+	db DBQueryer,
+	identifier string,
+) (model.SubmodelDescriptor, error) {
+	descriptors, _, err := listSubmodelDescriptorsFromPageQuery(
+		ctx,
+		db,
+		1,
+		"",
+		time.Time{},
+		time.Time{},
+		submodelDescriptorListScope{
+			collectorRoot:  grammar.CollectorRootSMDesc,
+			fragmentPrefix: "$smdesc",
+			identifiable:   identifier,
+		},
+	)
+	if err != nil {
+		return model.SubmodelDescriptor{}, err
+	}
+	if len(descriptors) != 1 || descriptors[0].Id != identifier {
+		return model.SubmodelDescriptor{}, common.NewErrNotFound("Submodel Descriptor not found")
+	}
+	return descriptors[0], nil
 }
 
 func listSubmodelDescriptorsForAASSingleStatement(
@@ -291,6 +321,7 @@ func buildStandaloneSubmodelDescriptorListQuery(
 		cursor,
 		createdFrom,
 		updatedFrom,
+		scope.identifiable,
 	)
 	authorized, maskRuntime, maskedColumns, err := buildAuthorizedSubmodelDescriptorRows(
 		ctx,
@@ -358,6 +389,7 @@ func buildStandaloneSubmodelDescriptorRawPage(
 	cursor string,
 	createdFrom time.Time,
 	updatedFrom time.Time,
+	identifiable string,
 ) *goqu.SelectDataset {
 	pageSource := goqu.T(common.TblSubmodelDescriptor).As("submodel_descriptor_raw_page")
 	page := dialect.From(pageSource).
@@ -372,6 +404,9 @@ func buildStandaloneSubmodelDescriptorRawPage(
 		createdFrom,
 		updatedFrom,
 	)
+	if identifiable != "" {
+		page = page.Where(pageSource.Col(common.ColAASID).Eq(identifiable))
+	}
 	if cursor != "" {
 		cursorSource := goqu.T(common.TblSubmodelDescriptor).As("submodel_descriptor_cursor")
 		cursorExists := dialect.From(cursorSource).

--- a/internal/common/descriptors/asset_admin_shell_descriptor_list_query_test.go
+++ b/internal/common/descriptors/asset_admin_shell_descriptor_list_query_test.go
@@ -331,3 +331,25 @@ func TestNestedSubmodelDescriptorListDoesNotPromoteFieldMaskToRowFilter(t *testi
 	require.Equal(t, 1, falseArguments)
 	require.Contains(t, args, "WRITTEN_BY_X")
 }
+
+func TestStandaloneSubmodelDescriptorListFiltersExactIdentifier(t *testing.T) {
+	t.Parallel()
+
+	dataset, err := buildSubmodelDescriptorListQuery(
+		common.ContextWithConfig(t.Context(), &common.Config{}),
+		1,
+		"",
+		time.Time{},
+		time.Time{},
+		submodelDescriptorListScope{
+			collectorRoot:  grammar.CollectorRootSMDesc,
+			fragmentPrefix: "$smdesc",
+			identifiable:   "urn:example:submodel:target",
+		},
+	)
+	require.NoError(t, err)
+	query, args, err := dataset.Prepared(true).ToSQL()
+	require.NoError(t, err)
+	require.Contains(t, query, `"submodel_descriptor_raw_page"."id" = $1`)
+	require.Contains(t, args, "urn:example:submodel:target")
+}

--- a/internal/common/descriptors/descriptor_update.go
+++ b/internal/common/descriptors/descriptor_update.go
@@ -91,6 +91,19 @@ func LockAdministrationShellDescriptorForUpdateTx(ctx context.Context, tx *sql.T
 	return descriptorID, nil
 }
 
+// LockExistingAdministrationShellDescriptorForUpdateTx locks an existing AAS
+// descriptor without taking the advisory lock used to serialize upserts.
+func LockExistingAdministrationShellDescriptorForUpdateTx(ctx context.Context, tx *sql.Tx, aasID string) (int64, error) {
+	descriptorID, found, err := selectAASDescriptorIDForUpdateTx(ctx, tx, aasID)
+	if err != nil {
+		return 0, common.NewInternalServerError("AASDESC-UPDATE-LOCK-SELECT " + err.Error())
+	}
+	if !found {
+		return 0, common.NewErrNotFound("AAS Descriptor not found")
+	}
+	return descriptorID, nil
+}
+
 // LockGlobalSubmodelDescriptorForUpdateTx locks an existing global Submodel
 // descriptor and returns its stable internal descriptor id.
 func LockGlobalSubmodelDescriptorForUpdateTx(ctx context.Context, tx *sql.Tx, submodelID string) (int64, error) {
@@ -182,8 +195,12 @@ func UpdateAdministrationShellDescriptorTx(
 	if !plan.changed() {
 		return false, nil
 	}
-	if err = updateAASDescriptorRowTx(ctx, tx, descriptorID, next); err != nil {
-		return false, common.NewInternalServerError("AASDESC-UPDATE-ROOT " + err.Error())
+	if plan.root {
+		if err = updateAASDescriptorRowTx(ctx, tx, descriptorID, next); err != nil {
+			return false, common.NewInternalServerError("AASDESC-UPDATE-ROOT " + err.Error())
+		}
+	} else if err = touchDescriptorRowTx(ctx, tx, common.TblAASDescriptor, descriptorID); err != nil {
+		return false, common.NewInternalServerError("AASDESC-UPDATE-TOUCHROOT " + err.Error())
 	}
 	if plan.payload.changed() {
 		if err = updateAdministrationShellDescriptorPayloadTx(ctx, tx, descriptorID, next, plan.payload); err != nil {
@@ -232,8 +249,12 @@ func UpdateSubmodelDescriptorTx(
 	if !plan.changed() && !positionChanged {
 		return false, nil
 	}
-	if err = updateSubmodelDescriptorRowTx(ctx, tx, descriptorID, next, position); err != nil {
-		return false, err
+	if plan.root || positionChanged {
+		if err = updateSubmodelDescriptorRowTx(ctx, tx, descriptorID, next, position); err != nil {
+			return false, err
+		}
+	} else if err = touchDescriptorRowTx(ctx, tx, common.TblSubmodelDescriptor, descriptorID); err != nil {
+		return false, common.NewInternalServerError("SMDESC-UPDATE-TOUCHROOT " + err.Error())
 	}
 	if plan.payload.changed() {
 		if err = updateSubmodelDescriptorPayloadTx(ctx, tx, descriptorID, next, plan.payload); err != nil {
@@ -262,6 +283,23 @@ func UpdateSubmodelDescriptorTx(
 		}
 	}
 	return true, nil
+}
+
+func touchDescriptorRowTx(ctx context.Context, tx *sql.Tx, table string, descriptorID int64) error {
+	d := goqu.Dialect(common.Dialect)
+	query, args, err := d.
+		Update(table).
+		Set(goqu.Record{"db_updated_at": goqu.L("CURRENT_TIMESTAMP")}).
+		Where(goqu.C(common.ColDescriptorID).Eq(descriptorID)).
+		Prepared(true).
+		ToSQL()
+	if err != nil {
+		return common.NewInternalServerError("DESC-UPDATE-TOUCHROOT-BUILDQ " + err.Error())
+	}
+	if _, err = tx.ExecContext(ctx, query, args...); err != nil {
+		return common.NewInternalServerError("DESC-UPDATE-TOUCHROOT-EXECQ " + err.Error())
+	}
+	return nil
 }
 
 func buildAdministrationShellDescriptorUpdatePlan(

--- a/internal/common/descriptors/descriptor_update_test.go
+++ b/internal/common/descriptors/descriptor_update_test.go
@@ -68,6 +68,60 @@ func TestLockSubmodelDescriptorForAASUpdateTxLocksOnlySubmodelDescriptor(t *test
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestUpdateAdministrationShellDescriptorTxTouchesRootForPayloadOnlyChange(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	previous := testAdministrationShellDescriptor()
+	next := previous
+	next.Description = []types.ILangStringTextType{types.NewLangStringTextType("en", "updated")}
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	mock.ExpectExec(`UPDATE "aas_descriptor" SET "db_updated_at"=CURRENT_TIMESTAMP WHERE \("descriptor_id" = \$1\)`).
+		WithArgs(int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`UPDATE "descriptor_payload" SET "description_payload"=\$1::jsonb WHERE \("descriptor_id" = \$2\)`).
+		WithArgs(sqlmock.AnyArg(), int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectRollback()
+
+	changed, err := UpdateAdministrationShellDescriptorTx(t.Context(), tx, 42, previous, next)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateSubmodelDescriptorTxTouchesRootForPayloadOnlyChange(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	previous := testSubmodelDescriptor("sm-1", "original")
+	next := previous
+	next.Description = []types.ILangStringTextType{types.NewLangStringTextType("en", "updated")}
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	mock.ExpectExec(`UPDATE "submodel_descriptor" SET "db_updated_at"=CURRENT_TIMESTAMP WHERE \("descriptor_id" = \$1\)`).
+		WithArgs(int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`UPDATE "descriptor_payload" SET "description_payload"=\$1::jsonb WHERE \("descriptor_id" = \$2\)`).
+		WithArgs(sqlmock.AnyArg(), int64(42)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectRollback()
+
+	changed, err := UpdateSubmodelDescriptorTx(t.Context(), tx, 42, previous, next, 0, false)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestBuildAdministrationShellDescriptorUpdatePlan(t *testing.T) {
 	base := testAdministrationShellDescriptor()
 

--- a/internal/smregistry/persistence/PostgreSQLSMDatabase.go
+++ b/internal/smregistry/persistence/PostgreSQLSMDatabase.go
@@ -304,11 +304,11 @@ func loadSubmodelDescriptorForUpdateTx(
 	tx *sql.Tx,
 	submodelID string,
 ) (model.SubmodelDescriptor, error) {
-	descriptor, err := descriptors.GetSubmodelDescriptorByID(ctx, tx, submodelID)
+	descriptor, err := descriptors.GetSubmodelDescriptorByIDSingleStatement(ctx, tx, submodelID)
 	if err != nil || descriptors.CanSkipUpdateReadback(ctx) {
 		return descriptor, err
 	}
-	return descriptors.GetSubmodelDescriptorByID(auth.ContextWithoutQueryFilter(ctx), tx, submodelID)
+	return descriptors.GetSubmodelDescriptorByIDSingleStatement(auth.ContextWithoutQueryFilter(ctx), tx, submodelID)
 }
 
 func loadAuthorizedSubmodelDescriptorEvidenceSnapshotTx(


### PR DESCRIPTION
## What this changes

- loads standalone Submodel Descriptors for PUT reconciliation with one set-based statement instead of several serial queries
- avoids the upsert advisory-lock round trip when replacing an existing AAS Descriptor
- limits payload-only descriptor updates to a narrow root timestamp touch and the changed payload fields
- keeps the existing create/update authorization selection, fragment masking, history handling, and in-place update semantics

## Why

The BaSyx Go 1.0.11 baseline showed unexpectedly low throughput for both descriptor PUT endpoints. PostgreSQL statement timing rules out a slow query or missing index: the individual statements execute in well under a millisecond, while one Submodel Descriptor PUT performs roughly eleven database interactions. The dominant application-side problem is therefore the number of sequential database and pooler round trips. Both descriptor types also rewrite unchanged root fields for payload-only mutations.

## Performance

The focused tests use real alternating description mutations and the same target pool as the 1.0.11 baseline. All measurements completed without failed requests.

| Endpoint | 1.0.11 selected result | This PR | Change |
|---|---:|---:|---:|
| UpdateShellDescriptorById | 755 RPS at c40 | 1,196 RPS at c80 | +58% |
| UpdateSubmodelDescriptorById | 292 RPS at c20 | 5,064 RPS at c80 | +1,636% |

Same-concurrency calibration comparison:

| Endpoint | c | 1.0.11 RPS | This PR RPS | Change |
|---|---:|---:|---:|---:|
| UpdateShellDescriptorById | 20 | 614 | 658 | +7% |
| UpdateShellDescriptorById | 40 | 756 | 1,016 | +34% |
| UpdateShellDescriptorById | 80 | 620 | 1,196 | +93% |
| UpdateSubmodelDescriptorById | 20 | 519 | 1,949 | +275% |
| UpdateSubmodelDescriptorById | 40 | 524 | 2,308 | +341% |
| UpdateSubmodelDescriptorById | 80 | 462 | 5,064 | +997% |

Neighboring c80 read/list checks did not show a regression:

| Endpoint | 1.0.11 RPS | This PR RPS | Change |
|---|---:|---:|---:|
| ReadShellDescriptorById | 6,489 | 6,584 | +1.5% |
| ReadSubmodelDescriptorById | 5,755 | 5,591 | -2.9% |
| GetAllShellDescriptors | 773 | 927 | +19.8% |
| GetAllSubmodelDescriptors | 2,013 | 2,978 | +47.9% |

The earlier baseline had measurable run-order/storage-state sensitivity, so the percentages should be treated as directional rather than as universal capacity guarantees. The improvement is supported by both the reduced query count and the repeated zero-error measurements.

## Validation

- `go test ./internal/common/descriptors ./internal/aasregistry/persistence ./internal/smregistry/persistence`
- `go test -v ./internal/aasregistry/integration_tests ./internal/smregistry/integration_tests`
- `golangci-lint run ./internal/common/descriptors/... ./internal/aasregistry/persistence/... ./internal/smregistry/persistence/...`
- focused c20/c40/c80 descriptor PUT benchmark
- c80 descriptor read/list regression check
