### PR TITLE
Reuse PostgreSQL plans for shell descriptor PUT

### DIFF
--- a/.changes/unreleased/fixed-20260911-092126.yaml
+++ b/.changes/unreleased/fixed-20260911-092126.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: Reuse PostgreSQL plans for unrestricted shell descriptor updates to reduce repeated query planning on the writer database.
+time: 2026-09-11T09:21:26.805938+02:00
+custom:
+    Impact: Low
+    PullRequest: 669
+    SecurityImpact: None. Existing authorization checks and writer transaction consistency are preserved.

--- a/internal/aasregistry/integration_tests/descriptor_plan_integration_test.go
+++ b/internal/aasregistry/integration_tests/descriptor_plan_integration_test.go
@@ -1,0 +1,108 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"github.com/doug-martin/goqu/v9"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/descriptors"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescriptorReadGenericPlanIsScopedAndReused(t *testing.T) {
+	const aasID = "urn:basyx:integration:descriptor-plan"
+	_, status, _, err := postJSONResponse(aasRegistryBaseURL+"/shell-descriptors", `{"id":"urn:basyx:integration:descriptor-plan","assetKind":"Instance","idShort":"PlanReuse"}`)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, status)
+	t.Cleanup(func() {
+		request, err := http.NewRequest(http.MethodDelete, aasRegistryBaseURL+"/shell-descriptors/"+base64.RawURLEncoding.EncodeToString([]byte(aasID)), nil)
+		require.NoError(t, err)
+		response, err := http.DefaultClient.Do(request)
+		require.NoError(t, err)
+		require.NoError(t, response.Body.Close())
+		require.Equal(t, http.StatusNoContent, response.StatusCode)
+	})
+	db, err := sql.Open("pgx", aasRegistryIntegrationTestDSN)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	ctx := common.ContextWithConfig(t.Context(), &common.Config{})
+	initialMode := readIntegrationPlanMode(ctx, t, db)
+	for _, mode := range []string{"auto", "force_custom_plan", "force_generic_plan"} {
+		t.Run(mode, func(t *testing.T) {
+			verifyDescriptorGenericPlan(ctx, t, db, aasID, mode)
+			require.Equal(t, initialMode, readIntegrationPlanMode(ctx, t, db))
+		})
+	}
+}
+
+func verifyDescriptorGenericPlan(ctx context.Context, t *testing.T, db *sql.DB, aasID, mode string) {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+	query, args, err := goqu.Dialect("postgres").Select(goqu.Func("set_config", "plan_cache_mode", mode, true)).Prepared(true).ToSQL()
+	require.NoError(t, err)
+	var configured string
+	require.NoError(t, tx.QueryRowContext(ctx, query, args...).Scan(&configured))
+	for range 2 {
+		descriptor, err := common.WithPostgreSQLGenericPlanTx(ctx, tx, func() (model.AssetAdministrationShellDescriptor, error) {
+			require.Equal(t, "force_generic_plan", readIntegrationPlanMode(ctx, t, tx))
+			return descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasID)
+		})
+		require.NoError(t, err)
+		require.Equal(t, aasID, descriptor.Id)
+		require.Equal(t, "PlanReuse", descriptor.IdShort)
+		require.Equal(t, mode, readIntegrationPlanMode(ctx, t, tx))
+	}
+	query, args, err = goqu.Dialect("postgres").From("pg_prepared_statements").
+		Select(goqu.SUM("generic_plans"), goqu.SUM("custom_plans")).
+		Where(goqu.C("statement").Like("SELECT jsonb_strip_nulls%")).Prepared(true).ToSQL()
+	require.NoError(t, err)
+	var genericPlans, customPlans int64
+	require.NoError(t, tx.QueryRowContext(ctx, query, args...).Scan(&genericPlans, &customPlans))
+	require.GreaterOrEqual(t, genericPlans, int64(2))
+	require.Zero(t, customPlans)
+	require.NoError(t, tx.Commit())
+}
+
+func readIntegrationPlanMode(ctx context.Context, t *testing.T, db interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}) string {
+	t.Helper()
+	query, args, err := goqu.Dialect("postgres").Select(goqu.Func("current_setting", "plan_cache_mode")).Prepared(true).ToSQL()
+	require.NoError(t, err)
+	var mode string
+	require.NoError(t, db.QueryRowContext(ctx, query, args...).Scan(&mode))
+	return mode
+}

--- a/internal/aasregistry/integration_tests/descriptor_plan_integration_test.go
+++ b/internal/aasregistry/integration_tests/descriptor_plan_integration_test.go
@@ -28,7 +28,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"encoding/base64"
 	"net/http"
 	"testing"
 
@@ -44,14 +43,7 @@ func TestDescriptorReadGenericPlanIsScopedAndReused(t *testing.T) {
 	_, status, _, err := postJSONResponse(aasRegistryBaseURL+"/shell-descriptors", `{"id":"urn:basyx:integration:descriptor-plan","assetKind":"Instance","idShort":"PlanReuse"}`)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, status)
-	t.Cleanup(func() {
-		request, err := http.NewRequest(http.MethodDelete, aasRegistryBaseURL+"/shell-descriptors/"+base64.RawURLEncoding.EncodeToString([]byte(aasID)), nil)
-		require.NoError(t, err)
-		response, err := http.DefaultClient.Do(request)
-		require.NoError(t, err)
-		require.NoError(t, response.Body.Close())
-		require.Equal(t, http.StatusNoContent, response.StatusCode)
-	})
+	t.Cleanup(func() { cleanupAASDescriptor(t, aasRegistryBaseURL, aasID) })
 	db, err := sql.Open("pgx", aasRegistryIntegrationTestDSN)
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()

--- a/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
+++ b/internal/aasregistry/persistence/PostgreSQLAASRegistryDatabase.go
@@ -487,8 +487,14 @@ func loadAASDescriptorForUpdateTx(
 	tx *sql.Tx,
 	aasID string,
 ) (model.AssetAdministrationShellDescriptor, error) {
-	descriptor, err := descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasID)
-	if err != nil || descriptors.CanSkipUpdateReadback(ctx) {
+	readDescriptor := func() (model.AssetAdministrationShellDescriptor, error) {
+		return descriptors.GetAssetAdministrationShellDescriptorByIDTx(ctx, tx, aasID)
+	}
+	if descriptors.CanSkipUpdateReadback(ctx) {
+		return common.WithPostgreSQLGenericPlanTx(ctx, tx, readDescriptor)
+	}
+	descriptor, err := readDescriptor()
+	if err != nil {
 		return descriptor, err
 	}
 	return descriptors.GetAssetAdministrationShellDescriptorByIDTx(auth.ContextWithoutQueryFilter(ctx), tx, aasID)

--- a/internal/aasregistry/persistence/descriptor_update_plan_test.go
+++ b/internal/aasregistry/persistence/descriptor_update_plan_test.go
@@ -1,0 +1,75 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package aasregistrydatabase
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/eclipse-basyx/basyx-go-components/internal/common/model/grammar"
+	auth "github.com/eclipse-basyx/basyx-go-components/internal/common/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadAASDescriptorForUpdateUsesGenericPlan(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	mock.ExpectQuery("SELECT current_setting").WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow("auto"))
+	mock.ExpectQuery("SELECT set_config.*force_generic_plan").WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow("force_generic_plan"))
+	mock.ExpectQuery("SELECT jsonb_strip_nulls").WillReturnRows(sqlmock.NewRows([]string{"payload"}).AddRow(`{"id":"aas-1","idShort":"Shell","assetKind":"Instance","description":[{"language":"en","text":"before"}]}`))
+	mock.ExpectQuery("SELECT set_config.*auto").WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow("auto"))
+	descriptor, err := loadAASDescriptorForUpdateTx(common.ContextWithConfig(t.Context(), &common.Config{}), tx, "aas-1")
+	require.NoError(t, err)
+	require.Equal(t, "aas-1", descriptor.Id)
+	require.Equal(t, "before", descriptor.Description[0].Text())
+	mock.ExpectRollback()
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLoadAASDescriptorForUpdatePreservesRestrictedAuthorization(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	allowed := false
+	ctx := auth.WithQueryFilter(common.ContextWithConfig(t.Context(), &common.Config{}), &auth.QueryFilter{
+		Formula: &grammar.LogicalExpression{Boolean: &allowed},
+	})
+	mock.ExpectQuery("SELECT jsonb_strip_nulls").WillReturnRows(sqlmock.NewRows([]string{"payload"}))
+	_, err = loadAASDescriptorForUpdateTx(ctx, tx, "aas-1")
+	require.True(t, common.IsErrNotFound(err))
+	mock.ExpectRollback()
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/common/postgres_plan.go
+++ b/internal/common/postgres_plan.go
@@ -1,0 +1,106 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/doug-martin/goqu/v9"
+)
+
+// WithPostgreSQLGenericPlanTx reuses generic plans while read runs in tx, then
+// restores the previous transaction-local plan mode before returning.
+func WithPostgreSQLGenericPlanTx[T any](ctx context.Context, tx *sql.Tx, read func() (T, error)) (result T, err error) {
+	restore, err := forcePostgreSQLGenericPlanTx(ctx, tx)
+	if err != nil {
+		return result, err
+	}
+	defer func() {
+		if restoreErr := restore(); restoreErr != nil {
+			var zero T
+			result = zero
+			err = errors.Join(err, restoreErr)
+		}
+	}()
+	return read()
+}
+
+func forcePostgreSQLGenericPlanTx(ctx context.Context, tx *sql.Tx) (func() error, error) {
+	previousMode, err := currentPostgreSQLPlanCacheModeTx(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	const genericPlanMode = "force_generic_plan"
+	if previousMode == genericPlanMode {
+		return func() error { return nil }, nil
+	}
+	if err = setPostgreSQLPlanCacheModeTx(ctx, tx, genericPlanMode); err != nil {
+		return nil, err
+	}
+	return func() error {
+		return setPostgreSQLPlanCacheModeTx(ctx, tx, previousMode)
+	}, nil
+}
+
+func currentPostgreSQLPlanCacheModeTx(ctx context.Context, tx *sql.Tx) (string, error) {
+	query := goqu.Dialect("postgres").Select(
+		goqu.Func("current_setting", PostgreSQLTextLiteral("plan_cache_mode")),
+	)
+	sqlQuery, args, err := query.Prepared(true).ToSQL()
+	if err != nil {
+		return "", NewInternalServerError("COMMON-PGPLAN-GETPLANMODE-BUILDQ " + err.Error())
+	}
+	var mode string
+	if err = tx.QueryRowContext(ctx, sqlQuery, args...).Scan(&mode); err != nil {
+		return "", NewInternalServerError("COMMON-PGPLAN-GETPLANMODE-EXECQ " + err.Error())
+	}
+	return mode, nil
+}
+
+func setPostgreSQLPlanCacheModeTx(ctx context.Context, tx *sql.Tx, mode string) error {
+	query := goqu.Dialect("postgres").Select(
+		goqu.Func(
+			"set_config",
+			PostgreSQLTextLiteral("plan_cache_mode"),
+			PostgreSQLTextLiteral(mode),
+			goqu.L("TRUE"),
+		),
+	)
+	sqlQuery, args, err := query.Prepared(true).ToSQL()
+	if err != nil {
+		return NewInternalServerError("COMMON-PGPLAN-SETPLANMODE-BUILDQ " + err.Error())
+	}
+	var configuredMode string
+	if err = tx.QueryRowContext(ctx, sqlQuery, args...).Scan(&configuredMode); err != nil {
+		return NewInternalServerError("COMMON-PGPLAN-SETPLANMODE-EXECQ " + err.Error())
+	}
+	if configuredMode != mode {
+		return NewInternalServerError("COMMON-PGPLAN-SETPLANMODE-MISMATCH expected " + mode + " but PostgreSQL returned " + configuredMode)
+	}
+	return nil
+}

--- a/internal/common/postgres_plan_test.go
+++ b/internal/common/postgres_plan_test.go
@@ -1,0 +1,138 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package common
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func expectPlanMode(mock sqlmock.Sqlmock, mode string) {
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT current_setting('plan_cache_mode'::text)")).
+		WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow(mode))
+}
+
+func expectSetPlanMode(mock sqlmock.Sqlmock, mode string) *sqlmock.ExpectedQuery {
+	return mock.ExpectQuery(regexp.QuoteMeta("SELECT set_config('plan_cache_mode'::text, '" + mode + "'::text, TRUE)"))
+}
+
+func TestWithPostgreSQLGenericPlanTxRestoresMode(t *testing.T) {
+	for _, mode := range []string{"auto", "force_custom_plan", "force_generic_plan"} {
+		t.Run(mode, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+			mock.ExpectBegin()
+			tx, err := db.Begin()
+			require.NoError(t, err)
+			expectPlanMode(mock, mode)
+			if mode != "force_generic_plan" {
+				expectSetPlanMode(mock, "force_generic_plan").WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow("force_generic_plan"))
+				expectSetPlanMode(mock, mode).WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow(mode))
+			}
+			result, err := WithPostgreSQLGenericPlanTx(ContextWithConfig(t.Context(), &Config{}), tx, func() (string, error) {
+				return "descriptor", nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, "descriptor", result)
+			mock.ExpectRollback()
+			require.NoError(t, tx.Rollback())
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestWithPostgreSQLGenericPlanTxHandlesErrors(t *testing.T) {
+	readErr := errors.New("TEST-PGPLAN-READ")
+	setupErr := errors.New("TEST-PGPLAN-SETUP")
+	restoreErr := errors.New("TEST-PGPLAN-RESTORE")
+	tests := []struct {
+		name          string
+		setup         func(sqlmock.Sqlmock)
+		readError     error
+		readCalled    bool
+		expectedError string
+	}{
+		{"get mode", func(mock sqlmock.Sqlmock) {
+			mock.ExpectQuery("SELECT current_setting").WillReturnError(setupErr)
+		}, nil, false, "COMMON-PGPLAN-GETPLANMODE-EXECQ"},
+		{"set mode", func(mock sqlmock.Sqlmock) {
+			expectPlanMode(mock, "auto")
+			expectSetPlanMode(mock, "force_generic_plan").WillReturnError(setupErr)
+		}, nil, false, "COMMON-PGPLAN-SETPLANMODE-EXECQ"},
+		{"mode mismatch", func(mock sqlmock.Sqlmock) {
+			expectPlanMode(mock, "auto")
+			expectSetPlanMode(mock, "force_generic_plan").WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow("auto"))
+		}, nil, false, "COMMON-PGPLAN-SETPLANMODE-MISMATCH"},
+		{"read", func(mock sqlmock.Sqlmock) {
+			expectPlanMode(mock, "auto")
+			expectSetPlanMode(mock, "force_generic_plan").WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow("force_generic_plan"))
+			expectSetPlanMode(mock, "auto").WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow("auto"))
+		}, readErr, true, readErr.Error()},
+		{"restore", func(mock sqlmock.Sqlmock) {
+			expectPlanMode(mock, "auto")
+			expectSetPlanMode(mock, "force_generic_plan").WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow("force_generic_plan"))
+			expectSetPlanMode(mock, "auto").WillReturnError(restoreErr)
+		}, nil, true, restoreErr.Error()},
+		{"read and restore", func(mock sqlmock.Sqlmock) {
+			expectPlanMode(mock, "auto")
+			expectSetPlanMode(mock, "force_generic_plan").WillReturnRows(sqlmock.NewRows([]string{"mode"}).AddRow("force_generic_plan"))
+			expectSetPlanMode(mock, "auto").WillReturnError(restoreErr)
+		}, readErr, true, restoreErr.Error()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+			mock.ExpectBegin()
+			tx, err := db.Begin()
+			require.NoError(t, err)
+			tt.setup(mock)
+			called := false
+			result, err := WithPostgreSQLGenericPlanTx(ContextWithConfig(t.Context(), &Config{}), tx, func() (string, error) {
+				called = true
+				if tt.readError != nil {
+					return "", tt.readError
+				}
+				return "descriptor", nil
+			})
+			require.ErrorContains(t, err, tt.expectedError)
+			if tt.readError != nil {
+				require.ErrorIs(t, err, tt.readError)
+			}
+			require.Empty(t, result)
+			require.Equal(t, tt.readCalled, called)
+			mock.ExpectRollback()
+			require.NoError(t, tx.Rollback())
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}

--- a/internal/submodelrepository/persistence/submodel_database_patch_put_sqlmock_test.go
+++ b/internal/submodelrepository/persistence/submodel_database_patch_put_sqlmock_test.go
@@ -334,48 +334,6 @@ func TestPutSubmodelPostUpdateFormulaDenialRollsBack(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestForceGenericPlanForSubmodelPutRestoresPreviousMode(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	mock.ExpectBegin()
-	tx, err := db.Begin()
-	require.NoError(t, err)
-	mock.ExpectQuery(`SELECT current_setting\('plan_cache_mode'::text\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"current_setting"}).AddRow("force_custom_plan"))
-	mock.ExpectQuery(`SELECT set_config\('plan_cache_mode'::text, 'force_generic_plan'::text, TRUE\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"set_config"}).AddRow("force_generic_plan"))
-	mock.ExpectQuery(`SELECT set_config\('plan_cache_mode'::text, 'force_custom_plan'::text, TRUE\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"set_config"}).AddRow("force_custom_plan"))
-	mock.ExpectRollback()
-
-	restore, err := forceGenericPlanForSubmodelPutTx(contextWithABACDisabled(t), tx)
-	require.NoError(t, err)
-	require.NoError(t, restore())
-	require.NoError(t, tx.Rollback())
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestForceGenericPlanForSubmodelPutKeepsExistingGenericMode(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	mock.ExpectBegin()
-	tx, err := db.Begin()
-	require.NoError(t, err)
-	mock.ExpectQuery(`SELECT current_setting\('plan_cache_mode'::text\)`).
-		WillReturnRows(sqlmock.NewRows([]string{"current_setting"}).AddRow("force_generic_plan"))
-	mock.ExpectRollback()
-
-	restore, err := forceGenericPlanForSubmodelPutTx(contextWithABACDisabled(t), tx)
-	require.NoError(t, err)
-	require.NoError(t, restore())
-	require.NoError(t, tx.Rollback())
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
 func contextWithUpdateFormula(t *testing.T, allowed bool) context.Context {
 	t.Helper()
 	expression := grammar.LogicalExpression{Boolean: &allowed}

--- a/internal/submodelrepository/persistence/submodel_write_database.go
+++ b/internal/submodelrepository/persistence/submodel_write_database.go
@@ -592,61 +592,6 @@ func (s *SubmodelDatabase) reconcileExistingSubmodelForPutTx(ctx context.Context
 	return PutSubmodelResult{IsUpdate: true, Changed: true, Previous: previous}, nil
 }
 
-func forceGenericPlanForSubmodelPutTx(ctx context.Context, tx *sql.Tx) (func() error, error) {
-	previousMode, err := currentPostgreSQLPlanCacheModeTx(ctx, tx)
-	if err != nil {
-		return nil, err
-	}
-	const genericPlanMode = "force_generic_plan"
-	if previousMode == genericPlanMode {
-		return func() error { return nil }, nil
-	}
-	if err = setPostgreSQLPlanCacheModeTx(ctx, tx, genericPlanMode); err != nil {
-		return nil, err
-	}
-	return func() error {
-		return setPostgreSQLPlanCacheModeTx(ctx, tx, previousMode)
-	}, nil
-}
-
-func currentPostgreSQLPlanCacheModeTx(ctx context.Context, tx *sql.Tx) (string, error) {
-	query := goqu.Dialect("postgres").Select(
-		goqu.Func("current_setting", common.PostgreSQLTextLiteral("plan_cache_mode")),
-	)
-	sqlQuery, args, err := query.Prepared(true).ToSQL()
-	if err != nil {
-		return "", common.NewInternalServerError("SMREPO-PUTSM-GETPLANMODE-BUILDQ " + err.Error())
-	}
-	var mode string
-	if err = tx.QueryRowContext(ctx, sqlQuery, args...).Scan(&mode); err != nil {
-		return "", common.NewInternalServerError("SMREPO-PUTSM-GETPLANMODE-EXECQ " + err.Error())
-	}
-	return mode, nil
-}
-
-func setPostgreSQLPlanCacheModeTx(ctx context.Context, tx *sql.Tx, mode string) error {
-	query := goqu.Dialect("postgres").Select(
-		goqu.Func(
-			"set_config",
-			common.PostgreSQLTextLiteral("plan_cache_mode"),
-			common.PostgreSQLTextLiteral(mode),
-			goqu.L("TRUE"),
-		),
-	)
-	sqlQuery, args, err := query.Prepared(true).ToSQL()
-	if err != nil {
-		return common.NewInternalServerError("SMREPO-PUTSM-SETPLANMODE-BUILDQ " + err.Error())
-	}
-	var configuredMode string
-	if err = tx.QueryRowContext(ctx, sqlQuery, args...).Scan(&configuredMode); err != nil {
-		return common.NewInternalServerError("SMREPO-PUTSM-SETPLANMODE-EXECQ " + err.Error())
-	}
-	if configuredMode != mode {
-		return common.NewInternalServerError("SMREPO-PUTSM-SETPLANMODE-MISMATCH expected " + mode + " but PostgreSQL returned " + configuredMode)
-	}
-	return nil
-}
-
 func (s *SubmodelDatabase) appendAcknowledgedSubmodelPutHistoryTx(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -743,19 +688,10 @@ func readPutSubmodelElementsTx(ctx context.Context, tx *sql.Tx, submodelDatabase
 	)
 }
 
-func readPutSubmodelElementsWithGenericPlanTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int) (elements []types.ISubmodelElement, err error) {
-	restorePlanCacheMode, err := forceGenericPlanForSubmodelPutTx(ctx, tx)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if restoreErr := restorePlanCacheMode(); err == nil && restoreErr != nil {
-			elements = nil
-			err = restoreErr
-		}
-	}()
-
-	return readPutSubmodelElementsTx(ctx, tx, submodelDatabaseID)
+func readPutSubmodelElementsWithGenericPlanTx(ctx context.Context, tx *sql.Tx, submodelDatabaseID int) ([]types.ISubmodelElement, error) {
+	return common.WithPostgreSQLGenericPlanTx(ctx, tx, func() ([]types.ISubmodelElement, error) {
+		return readPutSubmodelElementsTx(ctx, tx, submodelDatabaseID)
+	})
 }
 
 func contextWithoutFragmentFilters(ctx context.Context) (context.Context, error) {


### PR DESCRIPTION
## What this changes

- reuses a generic PostgreSQL plan when loading the existing shell descriptor for an unrestricted PUT
- shares the transaction-local plan helper with Submodel PUT and restores the previous mode before continuing the transaction
- keeps restricted authorization reads, writer consistency, row locking and history handling in place
- adds coverage for plan reuse, setting restoration and error handling

## Why

The 1.0.12 benchmark still shows a plateau for `UpdateShellDescriptorById`: increasing concurrency from 40 to 160 only improves throughput from 748 to 778 RPS, while p95 increases from 70 to 648 ms.

The full descriptor SELECT dominates active PostgreSQL work. Under load, the diagnostic query spends around 7 ms planning and 1.5–2 ms executing. PostgreSQL keeps choosing custom plans and probes index boundaries while considering merge joins. Reusing a generic plan reduces planning to around 0.1 ms in the same diagnostic.

This applies the approach already used by Submodel PUT to the shell descriptor update read. The cluster image benchmark and regression comparison are still pending; the query measurements above are diagnostic results, not throughput results for this PR.

## Validation

- `go test ./internal/common ./internal/common/descriptors ./internal/aasregistry/persistence ./internal/submodelrepository/persistence`
- `go test -v ./internal/aasregistry/integration_tests`
- `go test -v ./internal/submodelrepository/integration_tests`
- `go vet ./...`
- `golangci-lint run ./...` (v2.13.2)
- `gofmt` and `git diff --check`

Integration tests use the bundled Docker Compose setup with PostgreSQL 18 and the existing fixtures. The new test uses a minimal shell descriptor to verify actual generic-plan reuse and that the setting does not leak across reads or transactions. No deployment configuration or schema change is required.

## Changelog

- [x] I added a Changie fragment under `.changes/unreleased`.
