### PR TITLE
Align Registry Sync Descriptor Iterfaces with API Version 3.2

### DIFF
--- a/.changes/unreleased/fixed-20260911-103310.yaml
+++ b/.changes/unreleased/fixed-20260911-103310.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: Correct registry synchronization descriptor interface to use API version 3.2.
+time: 2026-09-11T10:33:10.7648376+02:00
+custom:
+    Impact: Low
+    PullRequest: "670"
+    SecurityImpact: None.

--- a/.changes/unreleased/fixed-20260911-103310.yaml
+++ b/.changes/unreleased/fixed-20260911-103310.yaml
@@ -3,5 +3,5 @@ body: Correct registry synchronization descriptor interface to use API version 3
 time: 2026-09-11T10:33:10.7648376+02:00
 custom:
     Impact: Low
-    PullRequest: "670"
+    PullRequest: 670
     SecurityImpact: None.

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_put_shell_with_submodels.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_put_shell_with_submodels.json
@@ -22,7 +22,7 @@
       "id": "urn:example:sm:registry-sync-post",
       "endpoints": [
         {
-          "interface": "SUBMODEL-3.0",
+          "interface": "SUBMODEL-3.2",
           "protocolInformation": {
             "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
             "endpointProtocol": "http"
@@ -33,7 +33,7 @@
   ],
   "endpoints": [
     {
-      "interface": "AAS-3.0",
+      "interface": "AAS-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_submodel_ref_post.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_submodel_ref_post.json
@@ -22,7 +22,7 @@
       "id": "urn:example:sm:registry-sync-post",
       "endpoints": [
         {
-          "interface": "SUBMODEL-3.0",
+          "interface": "SUBMODEL-3.2",
           "protocolInformation": {
             "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
             "endpointProtocol": "http"
@@ -33,7 +33,7 @@
   ],
   "endpoints": [
     {
-      "interface": "AAS-3.0",
+      "interface": "AAS-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_metadata_patch.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_metadata_patch.json
@@ -42,7 +42,7 @@
       },
       "endpoints": [
         {
-          "interface": "SUBMODEL-3.0",
+          "interface": "SUBMODEL-3.2",
           "protocolInformation": {
             "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
             "endpointProtocol": "http"
@@ -53,7 +53,7 @@
   ],
   "endpoints": [
     {
-      "interface": "AAS-3.0",
+      "interface": "AAS-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_patch.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_patch.json
@@ -36,7 +36,7 @@
       },
       "endpoints": [
         {
-          "interface": "SUBMODEL-3.0",
+          "interface": "SUBMODEL-3.2",
           "protocolInformation": {
             "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
             "endpointProtocol": "http"
@@ -47,7 +47,7 @@
   ],
   "endpoints": [
     {
-      "interface": "AAS-3.0",
+      "interface": "AAS-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_put.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_aas_descriptor_after_superpath_put.json
@@ -36,7 +36,7 @@
       },
       "endpoints": [
         {
-          "interface": "SUBMODEL-3.0",
+          "interface": "SUBMODEL-3.2",
           "protocolInformation": {
             "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1zdXBlcnBhdGg",
             "endpointProtocol": "http"
@@ -47,7 +47,7 @@
   ],
   "endpoints": [
     {
-      "interface": "AAS-3.0",
+      "interface": "AAS-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_patch_submodel_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_patch_submodel_descriptor.json
@@ -22,7 +22,7 @@
   },
   "endpoints": [
     {
-      "interface": "SUBMODEL-3.0",
+      "interface": "SUBMODEL-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_post_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_post_descriptor.json
@@ -19,7 +19,7 @@
   ],
   "endpoints": [
     {
-      "interface": "AAS-3.0",
+      "interface": "AAS-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_post_submodel_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_post_submodel_descriptor.json
@@ -16,7 +16,7 @@
   },
   "endpoints": [
     {
-      "interface": "SUBMODEL-3.0",
+      "interface": "SUBMODEL-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_put_descriptor_asset_information.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_put_descriptor_asset_information.json
@@ -19,7 +19,7 @@
   ],
   "endpoints": [
     {
-      "interface": "AAS-3.0",
+      "interface": "AAS-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtcG9zdA",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_put_submodel_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_put_submodel_descriptor.json
@@ -12,7 +12,7 @@
   },
   "endpoints": [
     {
-      "interface": "SUBMODEL-3.0",
+      "interface": "SUBMODEL-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/submodels/dXJuOmV4YW1wbGU6c206cmVnaXN0cnktc3luYy1wb3N0",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/integration_tests/expected/registry_sync_uploaded_descriptor.json
+++ b/internal/aasenvironment/integration_tests/expected/registry_sync_uploaded_descriptor.json
@@ -5,7 +5,7 @@
   "globalAssetId": "urn:example:asset:registry-sync-upload",
   "endpoints": [
     {
-      "interface": "AAS-3.0",
+      "interface": "AAS-3.2",
       "protocolInformation": {
         "href": "{{BASYX_IT_API_URL}}/shells/dXJuOmV4YW1wbGU6YWFzOnJlZ2lzdHJ5LXN5bmMtdXBsb2Fk",
         "endpointProtocol": "http"

--- a/internal/aasenvironment/registry_sync_test.go
+++ b/internal/aasenvironment/registry_sync_test.go
@@ -121,16 +121,16 @@ func TestRegistrySyncConfigBuildsDeterministicEndpoints(t *testing.T) {
 
 	aasEndpoints := config.AASDescriptorEndpoints("urn:example:aas:001")
 	require.Len(t, aasEndpoints, 2)
-	require.Equal(t, "AAS-3.0", aasEndpoints[0].Interface)
-	require.Equal(t, "AAS-3.0", aasEndpoints[1].Interface)
+	require.Equal(t, "AAS-3.2", aasEndpoints[0].Interface)
+	require.Equal(t, "AAS-3.2", aasEndpoints[1].Interface)
 	require.Equal(t, "https://public.example/api/v3/shells/dXJuOmV4YW1wbGU6YWFzOjAwMQ", aasEndpoints[0].ProtocolInformation.Href)
 	require.Equal(t, "https://internal.example/api/v3/shells/dXJuOmV4YW1wbGU6YWFzOjAwMQ", aasEndpoints[1].ProtocolInformation.Href)
 	require.Equal(t, "https", aasEndpoints[0].ProtocolInformation.EndpointProtocol)
 
 	submodelEndpoints := config.SubmodelDescriptorEndpoints("urn:example:sm:001")
 	require.Len(t, submodelEndpoints, 2)
-	require.Equal(t, "SUBMODEL-3.0", submodelEndpoints[0].Interface)
-	require.Equal(t, "SUBMODEL-3.0", submodelEndpoints[1].Interface)
+	require.Equal(t, "SUBMODEL-3.2", submodelEndpoints[0].Interface)
+	require.Equal(t, "SUBMODEL-3.2", submodelEndpoints[1].Interface)
 	require.Equal(t, "https://public.example/api/v3/submodels/dXJuOmV4YW1wbGU6c206MDAx", submodelEndpoints[0].ProtocolInformation.Href)
 	require.Equal(t, "https://internal.example/api/v3/submodels/dXJuOmV4YW1wbGU6c206MDAx", submodelEndpoints[1].ProtocolInformation.Href)
 	require.Equal(t, "https", submodelEndpoints[0].ProtocolInformation.EndpointProtocol)
@@ -187,14 +187,14 @@ func TestBuildAASDescriptorDerivesFromIdentifiable(t *testing.T) {
 	require.Len(t, descriptor.SubmodelDescriptors, 1)
 	require.Equal(t, "urn:example:sm:derived-embedded", descriptor.SubmodelDescriptors[0].Id)
 	require.Len(t, descriptor.SubmodelDescriptors[0].Endpoints, 1)
-	require.Equal(t, "SUBMODEL-3.0", descriptor.SubmodelDescriptors[0].Endpoints[0].Interface)
+	require.Equal(t, "SUBMODEL-3.2", descriptor.SubmodelDescriptors[0].Endpoints[0].Interface)
 	require.Equal(
 		t,
 		"https://public.example/api/v3/submodels/"+common.EncodeString("urn:example:sm:derived-embedded"),
 		descriptor.SubmodelDescriptors[0].Endpoints[0].ProtocolInformation.Href,
 	)
 	require.Len(t, descriptor.Endpoints, 1)
-	require.Equal(t, "AAS-3.0", descriptor.Endpoints[0].Interface)
+	require.Equal(t, "AAS-3.2", descriptor.Endpoints[0].Interface)
 	require.Equal(
 		t,
 		"https://public.example/api/v3/shells/"+common.EncodeString("urn:example:aas:derived"),
@@ -237,7 +237,7 @@ func TestBuildSubmodelDescriptorDerivesFromIdentifiable(t *testing.T) {
 	require.Equal(t, "8", *smAdminInfo.Revision())
 	require.NotNil(t, descriptor.SemanticId)
 	require.Len(t, descriptor.Endpoints, 1)
-	require.Equal(t, "SUBMODEL-3.0", descriptor.Endpoints[0].Interface)
+	require.Equal(t, "SUBMODEL-3.2", descriptor.Endpoints[0].Interface)
 	require.Equal(
 		t,
 		"http://public.example/api/v3/submodels/"+common.EncodeString("urn:example:sm:derived"),
@@ -338,7 +338,7 @@ func TestBuildEmbeddedSubmodelDescriptorsSkipsNilReferencesAndKeys(t *testing.T)
 	require.Len(t, descriptors, 1)
 	require.Equal(t, "urn:example:sm:nil-guard", descriptors[0].Id)
 	require.Len(t, descriptors[0].Endpoints, 1)
-	require.Equal(t, "SUBMODEL-3.0", descriptors[0].Endpoints[0].Interface)
+	require.Equal(t, "SUBMODEL-3.2", descriptors[0].Endpoints[0].Interface)
 	require.Equal(
 		t,
 		"https://public.example/api/v3/submodels/"+common.EncodeString("urn:example:sm:nil-guard"),

--- a/internal/registrysync/config.go
+++ b/internal/registrysync/config.go
@@ -37,8 +37,8 @@ import (
 
 const (
 	externalURLKey              = "general.externalUrl"
-	aasDescriptorInterface      = "AAS-3.0"
-	submodelDescriptorInterface = "SUBMODEL-3.0"
+	aasDescriptorInterface      = "AAS-3.2"
+	submodelDescriptorInterface = "SUBMODEL-3.2"
 )
 
 // Config controls repository-to-registry synchronization and descriptor endpoint generation.

--- a/internal/registrysync/config_contract_test.go
+++ b/internal/registrysync/config_contract_test.go
@@ -1,0 +1,86 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package registrysync
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+var specificationVersionPattern = regexp.MustCompile(`^V?(\d+)\.(\d+)\.\d+$`)
+
+// TestDescriptorInterfaceVersionsMatchRepositoryContracts prevents descriptor interface versions from drifting from the repository OpenAPI contracts.
+func TestDescriptorInterfaceVersionsMatchRepositoryContracts(t *testing.T) {
+	tests := []struct {
+		name            string
+		openAPIPath     string
+		interfaceName   string
+		descriptorValue string
+	}{
+		{
+			name:            "AAS repository",
+			openAPIPath:     filepath.Join("..", "..", "cmd", "aasrepositoryservice", "openapi.yaml"),
+			interfaceName:   "AAS",
+			descriptorValue: aasDescriptorInterface,
+		},
+		{
+			name:            "Submodel repository",
+			openAPIPath:     filepath.Join("..", "..", "cmd", "submodelrepositoryservice", "openapi.yaml"),
+			interfaceName:   "SUBMODEL",
+			descriptorValue: submodelDescriptorInterface,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			contractVersion := readRepositoryContractVersion(t, test.openAPIPath)
+			require.Equal(t, test.interfaceName+"-"+contractVersion, test.descriptorValue)
+		})
+	}
+}
+
+func readRepositoryContractVersion(t *testing.T, openAPIPath string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(openAPIPath)
+	require.NoError(t, err)
+
+	var contract struct {
+		Info struct {
+			Version string `yaml:"version"`
+		} `yaml:"info"`
+	}
+	require.NoError(t, yaml.Unmarshal(content, &contract))
+
+	matches := specificationVersionPattern.FindStringSubmatch(contract.Info.Version)
+	require.Len(t, matches, 3, "repository OpenAPI info.version must use V<major>.<minor>.<patch>")
+	return matches[1] + "." + matches[2]
+}

--- a/internal/registrysync/config_contract_test.go
+++ b/internal/registrysync/config_contract_test.go
@@ -70,6 +70,7 @@ func TestDescriptorInterfaceVersionsMatchRepositoryContracts(t *testing.T) {
 func readRepositoryContractVersion(t *testing.T, openAPIPath string) string {
 	t.Helper()
 
+	// #nosec G304 -- path is selected from static repository-owned test fixtures.
 	content, err := os.ReadFile(openAPIPath)
 	require.NoError(t, err)
 

--- a/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
+++ b/internal/submodelrepository/integration_tests/submodelrepository_integration_test.go
@@ -2540,13 +2540,13 @@ func TestStandaloneSubmodelRepositorySyncUpdatesReferencingAASDescriptor(t *test
 		t,
 		db,
 		companionAASExternalURL+"/shells/"+encodedAASID,
-		"AAS-3.0",
+		"AAS-3.2",
 	)
 	requireDescriptorEndpointInterface(
 		t,
 		db,
 		submodelSyncExternalURL+"/submodels/"+encodedSubmodelID,
-		"SUBMODEL-3.0",
+		"SUBMODEL-3.2",
 	)
 }
 


### PR DESCRIPTION
Update registry synchronization to generate AAS-3.2 and SUBMODEL-3.2 endpoint interfaces, aligning them with the repository API specifications. Add a contract test that detects future drift between these values and the repository OpenAPI versions, and update affected unit and integration tests.