### PR TITLE
clarify match behaviour

### DIFF
--- a/docu/query_language/examples.md
+++ b/docu/query_language/examples.md
@@ -600,7 +600,7 @@ The request cannot expose `manufacturerAssetId`, because the ABAC filter is
 mandatory. It also cannot recover `P-200`, because the request itself narrowed
 the policy-visible rows to `P-100`.
 
-## 7. Query MultiLanguageProperty text
+## 7. Query MultiLanguageProperty text and language
 
 `#value` on a `MultiLanguageProperty` matches its language string text. The
 condition holds when any language entry satisfies it, so the language does not
@@ -667,6 +667,63 @@ separate `#language` condition with `$and` only checks that the language exists;
 it does not require the matching text to belong to that language. For example,
 the text condition above combined with `#language = "en"` still matches this
 Submodel.
+
+To require the text and language to belong to the same language/text entry of
+the same `ProductName` MultiLanguageProperty, BaSyx supports combining the
+conditions with `$match`:
+
+```json
+{
+  "$condition": {
+    "$match": [
+      {
+        "$contains": [
+          { "$field": "$sme.ProductName#value" },
+          { "$strVal": "Capteur" }
+        ]
+      },
+      {
+        "$eq": [
+          { "$field": "$sme.ProductName#language" },
+          { "$strVal": "fr" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This request returns the same Submodel shown above, including all three language
+entries. The `$condition` selects Submodels; it does not trim the returned
+MultiLanguageProperty to the matching language.
+
+Changing only `"fr"` to `"en"` in this `$match` request returns an empty result,
+because `"Capteur"` occurs only in the French text:
+
+```json
+{
+  "paging_metadata": {},
+  "result": []
+}
+```
+
+For the same example data, the following combinations show the difference
+between `$match` and `$and`. Each row combines `$contains` on
+`$sme.ProductName#value` with `$eq` on `$sme.ProductName#language`:
+
+| Text contains | Language equals | `$match` returns the Submodel | `$and` returns the Submodel |
+| --- | --- | --- | --- |
+| `Capteur` | `fr` | Yes | Yes |
+| `Capteur` | `en` | No | Yes |
+| `Industrial Sensor` | `en` | Yes | Yes |
+| `Industrial Sensor` | `fr` | No | Yes |
+
+This documents supported BaSyx behavior. The IDTA-01002 v3.2
+[Query Language specification, "Match of Elements in Lists"](https://industrialdigitaltwin.io/aas-specifications/IDTA-01002/v3.2/query-language.html)
+describes `$match` with an explicit `[]` list context. These MultiLanguageProperty
+fields expose no such context. Although the BNF accepts the expression, the
+semantics of this implicit language-entry list still need clarification upstream
+before this usage can be described as standards-compliant.
 
 ## What can be combined
 

--- a/internal/submodelrepository/integration_tests/query_multilanguage_match_integration_test.go
+++ b/internal/submodelrepository/integration_tests/query_multilanguage_match_integration_test.go
@@ -1,0 +1,117 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryMatchCorrelatesMultiLanguagePropertyEntries(t *testing.T) {
+	submodel := createMultiLanguageMatchSubmodel(t)
+	productName := elementByIDShort(t, arrayValue(t, submodel["submodelElements"]), "ProductName")
+
+	for _, test := range []struct {
+		name          string
+		operator      string
+		text          string
+		language      string
+		expectedCount int
+	}{
+		{name: "MatchFrenchTextWithFrench", operator: "$match", text: "Capteur", language: "fr", expectedCount: 1},
+		{name: "MatchFrenchTextWithEnglish", operator: "$match", text: "Capteur", language: "en", expectedCount: 0},
+		{name: "MatchEnglishTextWithEnglish", operator: "$match", text: "Industrial Sensor", language: "en", expectedCount: 1},
+		{name: "MatchEnglishTextWithFrench", operator: "$match", text: "Industrial Sensor", language: "fr", expectedCount: 0},
+		{name: "AndFrenchTextWithEnglish", operator: "$and", text: "Capteur", language: "en", expectedCount: 1},
+		{name: "AndEnglishTextWithFrench", operator: "$and", text: "Industrial Sensor", language: "fr", expectedCount: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			payload := map[string]any{
+				"$condition": map[string]any{
+					"$and": []any{
+						equalsCondition("$sm#id", submodel["id"].(string)),
+						map[string]any{
+							test.operator: []any{
+								map[string]any{
+									"$contains": []any{
+										map[string]any{"$field": "$sme.ProductName#value"},
+										map[string]any{"$strVal": test.text},
+									},
+								},
+								equalsCondition("$sme.ProductName#language", test.language),
+							},
+						},
+					},
+				},
+			}
+			statusCode, body, err := requestJSON(http.MethodPost, submodelRepositoryBaseURL+"/query/submodels", payload)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, statusCode, "response=%s", string(body))
+
+			var response struct {
+				Result []map[string]any `json:"result"`
+			}
+			require.NoError(t, json.Unmarshal(body, &response), "response=%s", string(body))
+			require.Len(t, response.Result, test.expectedCount, "response=%s", string(body))
+			if test.expectedCount == 0 {
+				return
+			}
+			assert.Equal(t, submodel["id"], response.Result[0]["id"])
+			elements := arrayValue(t, response.Result[0]["submodelElements"])
+			assert.Equal(t, productName, elementByIDShort(t, elements, "ProductName"))
+		})
+	}
+}
+
+func createMultiLanguageMatchSubmodel(t *testing.T) map[string]any {
+	t.Helper()
+
+	fixture, err := os.ReadFile("bodies/post/query/submodelG.json")
+	require.NoError(t, err)
+	var submodel map[string]any
+	require.NoError(t, json.Unmarshal(fixture, &submodel))
+	submodelID := fmt.Sprintf("urn:basyx:integration:query-multilanguage-match:%d", time.Now().UnixNano())
+	submodel["id"] = submodelID
+
+	statusCode, body, err := requestJSON(http.MethodPost, submodelRepositoryBaseURL+"/submodels", submodel)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, statusCode, "response=%s", string(body))
+	t.Cleanup(func() {
+		encodedID := base64.RawURLEncoding.EncodeToString([]byte(submodelID))
+		deleteStatus, deleteBody, deleteErr := requestJSON(http.MethodDelete, submodelRepositoryBaseURL+"/submodels/"+encodedID, nil)
+		assert.NoError(t, deleteErr)
+		assert.Equal(t, http.StatusNoContent, deleteStatus, "response=%s", string(deleteBody))
+	})
+	return submodel
+}


### PR DESCRIPTION
Clarifies how $match correlates #value and #language within the same MultiLanguageProperty entry, with examples contrasting $and. Adds positive and negative French/English integration cases and documents the open specification question around the implicit list context.

Validation: all six new integration cases passed.