### PR TITLE
Remove unused parsing and generator helpers; simplify benchmark commands.

### DIFF
--- a/.changes/unreleased/fixed-20260913-102239.yaml
+++ b/.changes/unreleased/fixed-20260913-102239.yaml
@@ -1,0 +1,7 @@
+kind: fixed
+body: Run registry benchmark compose commands with literal arguments and report process-launch failures with BENCH-RUN-EXEC.
+time: 2026-09-13T10:22:39.949021+02:00
+custom:
+    Impact: Low
+    PullRequest: 681
+    SecurityImpact: 'Benchmark hardening: compose paths are passed as literal arguments without shell interpretation; no demonstrated production vulnerability.'

--- a/internal/aasregistry/benchmark_results/benchmark.py
+++ b/internal/aasregistry/benchmark_results/benchmark.py
@@ -1,7 +1,7 @@
 import subprocess
 import time
 import json
-import os
+import shlex
 import requests
 import uuid
 import copy
@@ -15,7 +15,6 @@ import sys
 # CONFIG
 # ──────────────────────────────────────────────
 COMPOSE_FILE = "docker_compose/docker_compose.yml"
-DB_CONTAINER = "postgres_db"  # optional: used if you have a healthcheck on DB
 DISCOVERY_URL = "http://localhost:5004/shell-descriptors"
 
 JSON_FILE = "bodies/simple_aas_a.json"  # path to your file
@@ -40,28 +39,13 @@ LOG_REQUEST_DETAILS = False
 # ──────────────────────────────────────────────
 # Helper functions
 # ──────────────────────────────────────────────
-def run(cmd: str):
-    print(f"▶ {cmd}")
-    return subprocess.run(cmd, shell=True, check=False)
-
-def wait_for_container_health(container: str, timeout: int = 120):
-    """
-    Waits for a container to be healthy via 'podman inspect'.
-    Only useful if the container defines a HEALTHCHECK in your compose.
-    """
-    print(f"⏳ Waiting for '{container}' to be healthy...")
-    start = time.time()
-    while time.time() - start < timeout:
-        result = subprocess.run(
-            f"podman inspect --format='{{{{json .State.Health}}}}' {container}",
-            shell=True, capture_output=True, text=True
-        )
-        if '"Status":"healthy"' in (result.stdout or ""):
-            print(f"✅ {container} is healthy")
-            return True
-        time.sleep(3)
-    print(f"❌ Timeout waiting for '{container}' health.")
-    return False
+def run(cmd: list[str]):
+    print(f"▶ {shlex.join(cmd)}")
+    try:
+        return subprocess.run(cmd, shell=False, check=False)
+    except OSError as error:
+        print(f"BENCH-RUN-EXEC: {error}", file=sys.stderr)
+        return subprocess.CompletedProcess(cmd, returncode=1)
 
 def wait_for_http(url: str, timeout: int = 180):
     print(f"⏳ Waiting for service at {url}")
@@ -96,7 +80,7 @@ with open(JSON_FILE, "r", encoding="utf-8") as f:
 # ──────────────────────────────────────────────
 def cleanup():
     print("\n🧹 Stopping Docker stack...")
-    run(f"podman compose -f {COMPOSE_FILE} down -v")
+    run(["podman", "compose", "-f", COMPOSE_FILE, "down", "-v"])
 
 def sig_handler(sig, frame):
     print("\n⚠ Interrupted by user.")
@@ -111,13 +95,10 @@ signal.signal(signal.SIGTERM, sig_handler)
 # ──────────────────────────────────────────────
 def main():
     print("🚀 Starting Docker Compose...")
-    up_rc = run(f"podman compose -f {COMPOSE_FILE} up -d --build").returncode
+    up_rc = run(["podman", "compose", "-f", COMPOSE_FILE, "up", "-d", "--build"]).returncode
     if up_rc != 0:
         print("❌ Failed to start the compose stack (check build paths and context).")
         sys.exit(1)
-
-    # If you want to wait for DB health (only meaningful if healthcheck is defined on DB):
-    # wait_for_container_health(DB_CONTAINER)  # uncomment if desired
 
     if not wait_for_http(DISCOVERY_URL):
         cleanup()

--- a/internal/common/model/helpers.go
+++ b/internal/common/model/helpers.go
@@ -42,13 +42,9 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const errMsgRequiredMissing = "required parameter is missing"
@@ -195,30 +191,6 @@ func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error
 	return nil
 }
 
-// nolint:unused
-func parseTimes(param string) ([]time.Time, error) {
-	splits := strings.Split(param, ",")
-	times := make([]time.Time, 0, len(splits))
-	for _, v := range splits {
-		t, err := parseTime(v)
-		if err != nil {
-			return nil, err
-		}
-		times = append(times, t)
-	}
-	return times, nil
-}
-
-// parseTime parses a string parameter into a time.Time using the RFC3339 format.
-// This function is currently unused but kept for potential future use.
-// nolint:unused
-func parseTime(param string) (time.Time, error) {
-	if param == "" {
-		return time.Time{}, nil
-	}
-	return time.Parse(time.RFC3339, param)
-}
-
 // Number is a type constraint that allows numeric types (int32, int64, float32, float64).
 // It's used in generic functions for parsing and validating numeric parameters.
 type Number interface {
@@ -228,58 +200,6 @@ type Number interface {
 // ParseString is a function type for parsing string values into various types.
 // It takes a string value and returns the parsed value of type T and an error if parsing fails.
 type ParseString[T Number | string | bool] func(v string) (T, error)
-
-// parseFloat64 parses a string parameter to an float64.
-// nolint:unused
-func parseFloat64(param string) (float64, error) {
-	if param == "" {
-		return 0, nil
-	}
-
-	return strconv.ParseFloat(param, 64)
-}
-
-// parseFloat32 parses a string parameter to an float32.
-// nolint:unused
-func parseFloat32(param string) (float32, error) {
-	if param == "" {
-		return 0, nil
-	}
-
-	v, err := strconv.ParseFloat(param, 32)
-	return float32(v), err
-}
-
-// parseInt64 parses a string parameter to an int64.
-// nolint:unused
-func parseInt64(param string) (int64, error) {
-	if param == "" {
-		return 0, nil
-	}
-
-	return strconv.ParseInt(param, 10, 64)
-}
-
-// parseInt32 parses a string parameter to an int32.
-// nolint:unused
-func parseInt32(param string) (int32, error) {
-	if param == "" {
-		return 0, nil
-	}
-
-	val, err := strconv.ParseInt(param, 10, 32)
-	return int32(val), err
-}
-
-// parseBool parses a string parameter to an bool.
-// nolint:unused
-func parseBool(param string) (bool, error) {
-	if param == "" {
-		return false, nil
-	}
-
-	return strconv.ParseBool(param)
-}
 
 // HOperation is a function type that handles parameter parsing with optional default values.
 // It returns the parsed value, a boolean indicating if a default was used, and any parsing error.
@@ -343,70 +263,4 @@ func WithMaximum[T Number](expected T) Constraint[T] {
 
 		return nil
 	}
-}
-
-// parseNumericParameter parses a numeric parameter to its respective type.
-// nolint:unused
-func parseNumericParameter[T Number](param string, fn HOperation[T], checks ...Constraint[T]) (T, error) {
-	v, ok, err := fn(param)
-	if err != nil {
-		return 0, err
-	}
-
-	if !ok {
-		for _, check := range checks {
-			if err := check(v); err != nil {
-				return 0, err
-			}
-		}
-	}
-
-	return v, nil
-}
-
-// parseBoolParameter parses a string parameter to a bool
-// nolint:unused
-func parseBoolParameter(param string, fn HOperation[bool]) (bool, error) {
-	v, _, err := fn(param)
-	return v, err
-}
-
-// parseNumericArrayParameter parses a string parameter containing array of values to its respective type.
-// nolint:unused
-func parseNumericArrayParameter[T Number](param, delim string, required bool, fn HOperation[T], checks ...Constraint[T]) ([]T, error) {
-	if param == "" {
-		if required {
-			return nil, errors.New(errMsgRequiredMissing)
-		}
-
-		return nil, nil
-	}
-
-	str := strings.Split(param, delim)
-	values := make([]T, len(str))
-
-	for i, s := range str {
-		v, ok, err := fn(s)
-		if err != nil {
-			return nil, err
-		}
-
-		if !ok {
-			for _, check := range checks {
-				if err := check(v); err != nil {
-					return nil, err
-				}
-			}
-		}
-
-		values[i] = v
-	}
-
-	return values, nil
-}
-
-// parseQuery parses query parameters and returns an error if any malformed value pairs are encountered.
-// nolint:unused
-func parseQuery(rawQuery string) (url.Values, error) {
-	return url.ParseQuery(rawQuery)
 }

--- a/pkg/submodelrepositoryapi/routers.go
+++ b/pkg/submodelrepositoryapi/routers.go
@@ -17,7 +17,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
@@ -213,22 +212,7 @@ func normalizeMultipartFileStreamError(err error) error {
 	return err
 }
 
-// nolint:unused
-func parseTimes(param string) ([]time.Time, error) {
-	splits := strings.Split(param, ",")
-	times := make([]time.Time, 0, len(splits))
-	for _, v := range splits {
-		t, err := parseTime(v)
-		if err != nil {
-			return nil, err
-		}
-		times = append(times, t)
-	}
-	return times, nil
-}
-
 // parseTime will parses a string parameter into a time.Time using the RFC3339 format
-// nolint:unused
 func parseTime(param string) (time.Time, error) {
 	return common.ParseISO8601DateTime(param)
 }
@@ -250,40 +234,6 @@ type Number interface {
 //   - T: The parsed value of type T (constrained to Number, string, or bool)
 //   - error: An error if parsing fails
 type ParseString[T Number | string | bool] func(v string) (T, error)
-
-// parseFloat64 parses a string parameter to an float64.
-//
-//nolint:unused
-func parseFloat64(param string) (float64, error) {
-	if param == "" {
-		return 0, nil
-	}
-
-	return strconv.ParseFloat(param, 64)
-}
-
-// parseFloat32 parses a string parameter to an float32.
-//
-//nolint:unused
-func parseFloat32(param string) (float32, error) {
-	if param == "" {
-		return 0, nil
-	}
-
-	v, err := strconv.ParseFloat(param, 32)
-	return float32(v), err
-}
-
-// parseInt64 parses a string parameter to an int64.
-//
-//nolint:unused
-func parseInt64(param string) (int64, error) {
-	if param == "" {
-		return 0, nil
-	}
-
-	return strconv.ParseInt(param, 10, 64)
-}
 
 // parseInt32 parses a string parameter to an int32.
 func parseInt32(param string) (int32, error) {
@@ -441,41 +391,6 @@ func parseNumericParameter[T Number](param string, fn OpenAPIOperation[T], check
 func parseBoolParameter(param string, fn OpenAPIOperation[bool]) (bool, error) {
 	v, _, err := fn(param)
 	return v, err
-}
-
-// parseNumericArrayParameter parses a string parameter containing array of values to its respective type.
-//
-//nolint:unused
-func parseNumericArrayParameter[T Number](param, delim string, required bool, fn OpenAPIOperation[T], checks ...Constraint[T]) ([]T, error) {
-	if param == "" {
-		if required {
-			return nil, errors.New(errMsgRequiredMissing)
-		}
-
-		return nil, nil
-	}
-
-	str := strings.Split(param, delim)
-	values := make([]T, len(str))
-
-	for i, s := range str {
-		v, ok, err := fn(s)
-		if err != nil {
-			return nil, err
-		}
-
-		if !ok {
-			for _, check := range checks {
-				if err := check(v); err != nil {
-					return nil, err
-				}
-			}
-		}
-
-		values[i] = v
-	}
-
-	return values, nil
 }
 
 // parseQuery parses query parameters and returns an error if any malformed value pairs are encountered.

--- a/scripts/generate_bruno_collections.js
+++ b/scripts/generate_bruno_collections.js
@@ -218,89 +218,6 @@ function renderBody(body, variables) {
   return ["  body:", "    type: json", "    data: |-", indent(resolveVariables(body.raw, variables), 6)].join("\n");
 }
 
-function renderSingleHeaders(headers, variables, spaces) {
-  const filtered = (headers || []).filter((header) => header.key.toLowerCase() !== "authorization");
-
-  if (filtered.length === 0) {
-    return [];
-  }
-
-  return [
-    `${" ".repeat(spaces)}headers:`,
-    ...filtered.flatMap((header) => [
-      `${" ".repeat(spaces + 2)}- name: ${yamlString(header.key)}`,
-      `${" ".repeat(spaces + 4)}value: ${yamlString(resolveVariables(header.value, variables))}`,
-    ]),
-  ];
-}
-
-function renderSingleBody(body, variables, spaces) {
-  if (!body || body.mode !== "raw") {
-    return [];
-  }
-
-  return [
-    `${" ".repeat(spaces)}body:`,
-    `${" ".repeat(spaces + 2)}type: json`,
-    `${" ".repeat(spaces + 2)}data: |-`,
-    indent(resolveVariables(body.raw, variables), spaces + 4),
-  ];
-}
-
-function renderSingleRuntime(beforeRequestScript, testsScript, spaces) {
-  const scripts = [];
-
-  if (beforeRequestScript) {
-    scripts.push([
-      `${" ".repeat(spaces + 2)}- type: before-request`,
-      `${" ".repeat(spaces + 4)}code: |-`,
-      indent(beforeRequestScript, spaces + 6),
-    ]);
-  }
-
-  if (testsScript) {
-    scripts.push([
-      `${" ".repeat(spaces + 2)}- type: tests`,
-      `${" ".repeat(spaces + 4)}code: |-`,
-      indent(testsScript, spaces + 6),
-    ]);
-  }
-
-  if (scripts.length === 0) {
-    return [];
-  }
-
-  return [`${" ".repeat(spaces)}runtime:`, `${" ".repeat(spaces + 2)}scripts:`, ...scripts.flat()];
-}
-
-function renderSingleRequest(item, seq, variables, spaces) {
-  const request = item.request;
-  const headers = request.header || [];
-  const requestAuthType = authType(headers);
-  const beforeRequestScript = requestAuthType ? tokenScript(requestAuthType, variables) : "";
-  const testsScript = translateTests(item.event);
-
-  return [
-    `${" ".repeat(spaces)}- info:`,
-    `${" ".repeat(spaces + 4)}name: ${yamlString(item.name)}`,
-    `${" ".repeat(spaces + 4)}type: http`,
-    `${" ".repeat(spaces + 4)}seq: ${seq}`,
-    `${" ".repeat(spaces + 2)}http:`,
-    `${" ".repeat(spaces + 4)}method: ${request.method.toUpperCase()}`,
-    `${" ".repeat(spaces + 4)}url: ${yamlString(resolveVariables(request.url.raw, variables))}`,
-    ...renderSingleHeaders(headers, variables, spaces + 4),
-    ...renderSingleBody(request.body, variables, spaces + 4),
-    `${" ".repeat(spaces + 4)}auth:`,
-    `${" ".repeat(spaces + 6)}type: none`,
-    ...renderSingleRuntime(beforeRequestScript, testsScript, spaces + 2),
-    `${" ".repeat(spaces + 2)}settings:`,
-    `${" ".repeat(spaces + 4)}encodeUrl: true`,
-    `${" ".repeat(spaces + 4)}timeout: 0`,
-    `${" ".repeat(spaces + 4)}followRedirects: true`,
-    `${" ".repeat(spaces + 4)}maxRedirects: 5`,
-  ];
-}
-
 function renderRequest(item, seq, variables) {
   const request = item.request;
   const headers = request.header || [];
@@ -370,44 +287,6 @@ function writeCollection(config) {
 
     folderSeq++;
   }
-}
-
-function renderSingleFolder(folder, seq, variables) {
-  const lines = [
-    "  - info:",
-    `      name: ${yamlString(folder.name)}`,
-    "      type: folder",
-    `      seq: ${seq}`,
-    "    items:",
-  ];
-
-  let requestSeq = 1;
-  for (const item of folder.item || []) {
-    lines.push(...renderSingleRequest(item, requestSeq, variables, 6));
-    requestSeq++;
-  }
-
-  return lines;
-}
-
-function writeSingleFile(config) {
-  const postman = JSON.parse(fs.readFileSync(config.source, "utf8"));
-  const variables = variableMap(postman);
-  const lines = [
-    "info:",
-    `  name: ${yamlString(config.name)}`,
-    "  type: collection",
-    '  version: "1"',
-    "items:",
-  ];
-
-  let folderSeq = 1;
-  for (const folder of postman.item) {
-    lines.push(...renderSingleFolder(folder, folderSeq, variables));
-    folderSeq++;
-  }
-
-  writeFile(config.singleFileTarget, lines.join("\n") + "\n");
 }
 
 writeCollection(collection);


### PR DESCRIPTION
## Description of Changes

Remove 23 verified unused functions and their orphaned imports, suppressions, comments, and configuration. The registry benchmark now passes compose commands as argument lists instead of interpreting them through a shell: compose paths containing spaces or metacharacters remain a single literal argument. Process-launch failures produce `BENCH-RUN-EXEC` and a nonzero result while preserving the caller's return-code handling.

No public Go declarations, HTTP behavior, database schema, or generated Bruno collection output change.

### Removal inventory

| Area | Removed functions |
| --- | --- |
| Shared model helpers (11) | `parseTimes`, `parseTime`, `parseFloat64`, `parseFloat32`, `parseInt64`, `parseInt32`, `parseBool`, `parseNumericParameter`, `parseBoolParameter`, `parseNumericArrayParameter`, `parseQuery` |
| Submodel repository routing helpers (5) | `parseTimes`, `parseFloat64`, `parseFloat32`, `parseInt64`, `parseNumericArrayParameter` |
| Bruno generator (6) | `writeSingleFile`, `renderSingleFolder`, `renderSingleRequest`, `renderSingleHeaders`, `renderSingleBody`, `renderSingleRuntime` |
| Registry benchmark (1) | `wait_for_container_health` |

Package-wide reference searches included tests and function-value uses. The active submodel repository `parseTime` remains; only its stale unused suppression is removed. Exported parsing types and helpers are preserved.

### Findings deliberately retained

The report's `base64_url` and `ts` findings are false positives: both have live callers. Sampled shell-execution findings match Asset Administration Shell methods, and reported secrets include variable interpolation. The benchmark change is limited hardening; it does not claim a demonstrated production vulnerability. Shared-helper consolidation and architectural refactoring are deferred.

## Changelog

- [x] I added a Changie fragment under `.changes/unreleased` for every notable user-visible or security-related change.
- [ ] This pull request has no notable user-visible or security effect; a reviewer may apply the `no-changelog` label.

Added a low-impact benchmark-hardening fragment referencing #681; the repository fragment validator passes.

## Validation

- Passed: `go clean -testcache`, followed by `go test -v ./internal/common/model ./pkg/submodelrepositoryapi`.
- Passed: the complete `go test -v ./internal/submodelrepository/integration_tests` suite, without additional flags (119.682 seconds; 575 passing test/subtest results, zero failures or skips).
- Passed: `bash scripts/lint.sh` (zero lint issues, repository-wide vet and formatting) and `git diff --check`.
- Passed: original and cleaned Bruno generators produced byte-identical output across all 39 files in isolated temporary directories; JavaScript syntax checked with Node.
- Passed: Python syntax and isolated benchmark checks covering literal spaces/metacharacters, both compose call sites, successful/nonzero child results, missing executables, permission errors, and startup failure exit behavior. A real subprocess round trip also preserved literal arguments.
- Passed: `ruby .github/scripts/validate-changie-fragments.rb`.
- Passed: exported Go declarations are unchanged. Script checks used a temporary harness; no benchmark services were started by that harness.

## Related Issue

No linked issue; cleanup follows a reviewed codeflow-analysis report.

## BaSyx Configuration for Testing

The integration package uses its existing Docker Compose stack and dynamically allocated ports. No configuration changes are required.

## AAS Files Used for Testing

Existing integration fixtures and the checked-in CatenaXample Postman collection; no new AAS fixtures.
