### PR TITLE
Share API Location base URL construction across controllers

### DIFF
--- a/internal/common/location.go
+++ b/internal/common/location.go
@@ -31,6 +31,29 @@ import (
 	"strings"
 )
 
+// APIBaseLocation resolves the configured external URL or the request origin and context path.
+func APIBaseLocation(request *http.Request, contextPath string) string {
+	if externalBaseURL := ExternalBaseURLFromContext(request.Context()); externalBaseURL != "" {
+		return externalBaseURL
+	}
+
+	host := RequestHost(request)
+	if host == "" {
+		return ""
+	}
+
+	return RequestScheme(request) + "://" + host + normalizeLocationContextPath(contextPath)
+}
+
+func normalizeLocationContextPath(contextPath string) string {
+	trimmed := strings.TrimSpace(contextPath)
+	if trimmed == "" || trimmed == "/" {
+		return ""
+	}
+
+	return "/" + strings.Trim(trimmed, "/")
+}
+
 // ContextualizeAPIResourceLocation resolves a root-relative API Location
 // against the request's external origin and mounted context path.
 func ContextualizeAPIResourceLocation(request *http.Request, location string, resourcePathMarker string) string {

--- a/internal/common/location_test.go
+++ b/internal/common/location_test.go
@@ -33,6 +33,133 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAPIBaseLocationNormalizesContextPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contextPath string
+		want        string
+	}{
+		{name: "empty", want: "http://example.com"},
+		{name: "root", contextPath: "/", want: "http://example.com"},
+		{name: "whitespace", contextPath: " \t ", want: "http://example.com"},
+		{name: "bare path", contextPath: "api/v3", want: "http://example.com/api/v3"},
+		{name: "trimmed path", contextPath: " /api/v3/ \t", want: "http://example.com/api/v3"},
+		{name: "outer slashes", contextPath: "///api/v3///", want: "http://example.com/api/v3"},
+		{name: "repeated slashes", contextPath: "///", want: "http://example.com/"},
+		{name: "interior slashes", contextPath: "/api//v3/", want: "http://example.com/api//v3"},
+		{name: "escaped path", contextPath: "/aas%20environment/v3/", want: "http://example.com/aas%20environment/v3"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			request := httptest.NewRequest(http.MethodPost, "http://example.com/unrelated/request/path", nil)
+			require.Equal(t, test.want, APIBaseLocation(request, test.contextPath))
+		})
+	}
+}
+
+func TestAPIBaseLocationResolvesOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		requestURL   string
+		host         string
+		externalURL  string
+		trustProxy   bool
+		trustedCIDRs []string
+		forwarded    string
+		xProto       string
+		xHost        string
+		want         string
+	}{
+		{
+			name: "direct HTTP with port", requestURL: "http://internal.example/",
+			host: "internal.example:8080", want: "http://internal.example:8080/api/v3",
+		},
+		{
+			name: "direct TLS", requestURL: "https://internal.example/",
+			host: "internal.example", want: "https://internal.example/api/v3",
+		},
+		{
+			name: "IPv6 host", requestURL: "http://internal.example/",
+			host: "[::1]:8080", want: "http://[::1]:8080/api/v3",
+		},
+		{
+			name: "missing host", requestURL: "http://internal.example/", want: "",
+		},
+		{
+			name: "invalid host", requestURL: "http://internal.example/",
+			host: "invalid.example/path", want: "",
+		},
+		{
+			name: "external URL wins over proxy and context path", requestURL: "http://internal.example/",
+			host: "internal.example", externalURL: " https://public.example/aas%20environment///, https://secondary.example ",
+			trustProxy: true, trustedCIDRs: []string{"10.0.0.0/8"},
+			forwarded: "proto=https;host=proxy.example", want: "https://public.example/aas%20environment",
+		},
+		{
+			name: "external URL without request host", requestURL: "http://internal.example/",
+			externalURL: "https://public.example/", want: "https://public.example",
+		},
+		{
+			name: "invalid external URL falls back", requestURL: "http://internal.example/",
+			host: "internal.example", externalURL: "https://public.example/?query=invalid", want: "http://internal.example/api/v3",
+		},
+		{
+			name: "proxy headers disabled", requestURL: "http://internal.example/",
+			host: "internal.example", trustedCIDRs: []string{"10.0.0.0/8"},
+			forwarded: "proto=https;host=proxy.example", xProto: "https", xHost: "proxy.example",
+			want: "http://internal.example/api/v3",
+		},
+		{
+			name: "untrusted peer", requestURL: "http://internal.example/",
+			host: "internal.example", trustProxy: true, trustedCIDRs: []string{"192.168.0.0/16"},
+			forwarded: "proto=https;host=proxy.example", xProto: "https", xHost: "proxy.example",
+			want: "http://internal.example/api/v3",
+		},
+		{
+			name: "trusted Forwarded takes precedence", requestURL: "http://internal.example/",
+			host: "internal.example", trustProxy: true, trustedCIDRs: []string{"10.0.0.0/8"},
+			forwarded: "proto=https;host=proxy.example:8443", xProto: "http", xHost: "other.example",
+			want: "https://proxy.example:8443/api/v3",
+		},
+		{
+			name: "trusted X-Forwarded", requestURL: "http://internal.example/",
+			host: "internal.example", trustProxy: true, trustedCIDRs: []string{"10.0.0.0/8"},
+			xProto: "https, http", xHost: "proxy.example, other.example", want: "https://proxy.example/api/v3",
+		},
+		{
+			name: "invalid forwarded host falls back", requestURL: "http://internal.example/",
+			host: "internal.example", trustProxy: true, trustedCIDRs: []string{"10.0.0.0/8"},
+			forwarded: "proto=https;host=invalid.example/path", want: "https://internal.example/api/v3",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			request := httptest.NewRequest(http.MethodPost, test.requestURL, nil)
+			request.Host = test.host
+			request.RemoteAddr = "10.1.2.3:1234"
+			request.Header.Set("Forwarded", test.forwarded)
+			request.Header.Set("X-Forwarded-Proto", test.xProto)
+			request.Header.Set("X-Forwarded-Host", test.xHost)
+			cfg := &Config{}
+			cfg.ABAC.Enabled = false
+			cfg.General.ExternalURL = test.externalURL
+			cfg.General.TrustProxyHeaders = test.trustProxy
+			cfg.General.TrustedProxyCIDRs = test.trustedCIDRs
+			request = request.WithContext(ContextWithConfig(request.Context(), cfg))
+
+			require.Equal(t, test.want, APIBaseLocation(request, " /api/v3/ "))
+		})
+	}
+}
+
 func TestContextualizeAPIResourceLocationPreservesEscapedSegments(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/aasregistryapi/helpers.go
+++ b/pkg/aasregistryapi/helpers.go
@@ -365,36 +365,8 @@ func encodeIdentifierForPath(identifier string) string {
 	return base64.RawURLEncoding.EncodeToString([]byte(identifier))
 }
 
-func requestScheme(r *http.Request) string {
-	return common.RequestScheme(r)
-}
-
-func requestHost(r *http.Request) string {
-	return common.RequestHost(r)
-}
-
-func normalizeContextPathForBaseLocation(contextPath string) string {
-	trimmed := strings.TrimSpace(contextPath)
-	if trimmed == "" || trimmed == "/" {
-		return ""
-	}
-
-	return "/" + strings.Trim(trimmed, "/")
-}
-
 func (c *AssetAdministrationShellRegistryAPIAPIController) buildBaseLocation(r *http.Request) string {
-	if externalBaseURL := common.ExternalBaseURLFromContext(r.Context()); externalBaseURL != "" {
-		return externalBaseURL
-	}
-
-	host := requestHost(r)
-	if host == "" {
-		return ""
-	}
-
-	basePath := normalizeContextPathForBaseLocation(c.contextPath)
-
-	return requestScheme(r) + "://" + host + basePath
+	return common.APIBaseLocation(r, c.contextPath)
 }
 
 func (c *AssetAdministrationShellRegistryAPIAPIController) buildAASDescriptorLocationFromEncodedIdentifier(r *http.Request, encodedAASIdentifier string) string {

--- a/pkg/aasrepositoryapi/go/helpers.go
+++ b/pkg/aasrepositoryapi/go/helpers.go
@@ -15,7 +15,6 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
@@ -28,36 +27,8 @@ func encodeIdentifierForPath(identifier string) string {
 	return base64.RawURLEncoding.EncodeToString([]byte(identifier))
 }
 
-func normalizeContextPathForBaseLocation(contextPath string) string {
-	trimmed := strings.TrimSpace(contextPath)
-	if trimmed == "" || trimmed == "/" {
-		return ""
-	}
-
-	return "/" + strings.Trim(trimmed, "/")
-}
-
 func (c *AssetAdministrationShellRepositoryAPIAPIController) buildBaseLocation(r *http.Request) string {
-	if externalBaseURL := common.ExternalBaseURLFromContext(r.Context()); externalBaseURL != "" {
-		return externalBaseURL
-	}
-
-	host := requestHost(r)
-	if host == "" {
-		return ""
-	}
-
-	basePath := normalizeContextPathForBaseLocation(c.contextPath)
-
-	return requestScheme(r) + "://" + host + basePath
-}
-
-func requestScheme(r *http.Request) string {
-	return common.RequestScheme(r)
-}
-
-func requestHost(r *http.Request) string {
-	return common.RequestHost(r)
+	return common.APIBaseLocation(r, c.contextPath)
 }
 
 func (c *AssetAdministrationShellRepositoryAPIAPIController) buildShellLocationFromEncodedIdentifier(r *http.Request, encodedShellID string) string {

--- a/pkg/conceptdescriptionrepositoryapi/go/helpers.go
+++ b/pkg/conceptdescriptionrepositoryapi/go/helpers.go
@@ -15,7 +15,6 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
@@ -28,36 +27,8 @@ func encodeIdentifierForPath(identifier string) string {
 	return base64.RawURLEncoding.EncodeToString([]byte(identifier))
 }
 
-func requestScheme(r *http.Request) string {
-	return common.RequestScheme(r)
-}
-
-func requestHost(r *http.Request) string {
-	return common.RequestHost(r)
-}
-
-func normalizeContextPathForBaseLocation(contextPath string) string {
-	trimmed := strings.TrimSpace(contextPath)
-	if trimmed == "" || trimmed == "/" {
-		return ""
-	}
-
-	return "/" + strings.Trim(trimmed, "/")
-}
-
 func (c *ConceptDescriptionRepositoryAPIAPIController) buildBaseLocation(r *http.Request) string {
-	if externalBaseURL := common.ExternalBaseURLFromContext(r.Context()); externalBaseURL != "" {
-		return externalBaseURL
-	}
-
-	host := requestHost(r)
-	if host == "" {
-		return ""
-	}
-
-	basePath := normalizeContextPathForBaseLocation(c.contextPath)
-
-	return requestScheme(r) + "://" + host + basePath
+	return common.APIBaseLocation(r, c.contextPath)
 }
 
 func (c *ConceptDescriptionRepositoryAPIAPIController) buildConceptDescriptionLocationFromEncodedIdentifier(r *http.Request, encodedConceptDescriptionIdentifier string) string {

--- a/pkg/smregistry/helpers.go
+++ b/pkg/smregistry/helpers.go
@@ -295,36 +295,8 @@ func encodeIdentifierForPath(identifier string) string {
 	return base64.RawURLEncoding.EncodeToString([]byte(identifier))
 }
 
-func requestScheme(r *http.Request) string {
-	return common.RequestScheme(r)
-}
-
-func requestHost(r *http.Request) string {
-	return common.RequestHost(r)
-}
-
-func normalizeContextPathForBaseLocation(contextPath string) string {
-	trimmed := strings.TrimSpace(contextPath)
-	if trimmed == "" || trimmed == "/" {
-		return ""
-	}
-
-	return "/" + strings.Trim(trimmed, "/")
-}
-
 func (c *SubmodelRegistryAPIAPIController) buildBaseLocation(r *http.Request) string {
-	if externalBaseURL := common.ExternalBaseURLFromContext(r.Context()); externalBaseURL != "" {
-		return externalBaseURL
-	}
-
-	host := requestHost(r)
-	if host == "" {
-		return ""
-	}
-
-	basePath := normalizeContextPathForBaseLocation(c.contextPath)
-
-	return requestScheme(r) + "://" + host + basePath
+	return common.APIBaseLocation(r, c.contextPath)
 }
 
 func (c *SubmodelRegistryAPIAPIController) buildSubmodelDescriptorLocationFromEncodedIdentifier(r *http.Request, encodedSubmodelIdentifier string) string {

--- a/pkg/submodelrepositoryapi/helpers.go
+++ b/pkg/submodelrepositoryapi/helpers.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"strings"
 
 	"github.com/eclipse-basyx/basyx-go-components/internal/common"
 )
@@ -36,39 +35,9 @@ func encodeIdentifierForPath(identifier string) string {
 	return base64.RawURLEncoding.EncodeToString([]byte(identifier))
 }
 
-// requestScheme resolves the external scheme using trusted proxy headers and request fallback.
-func requestScheme(r *http.Request) string {
-	return common.RequestScheme(r)
-}
-
-// requestHost resolves the external host using trusted proxy headers and request fallback.
-func requestHost(r *http.Request) string {
-	return common.RequestHost(r)
-}
-
-func normalizeContextPathForBaseLocation(contextPath string) string {
-	trimmed := strings.TrimSpace(contextPath)
-	if trimmed == "" || trimmed == "/" {
-		return ""
-	}
-
-	return "/" + strings.Trim(trimmed, "/")
-}
-
 // buildBaseLocation builds an absolute base URL from scheme, host, and configured context path.
 func (c *SubmodelRepositoryAPIAPIController) buildBaseLocation(r *http.Request) string {
-	if externalBaseURL := common.ExternalBaseURLFromContext(r.Context()); externalBaseURL != "" {
-		return externalBaseURL
-	}
-
-	host := requestHost(r)
-	if host == "" {
-		return ""
-	}
-
-	basePath := normalizeContextPathForBaseLocation(c.contextPath)
-
-	return requestScheme(r) + "://" + host + basePath
+	return common.APIBaseLocation(r, c.contextPath)
 }
 
 // buildSubmodelLocationFromEncodedIdentifier builds the absolute location URL for a submodel resource

--- a/pkg/submodelrepositoryapi/helpers_location_test.go
+++ b/pkg/submodelrepositoryapi/helpers_location_test.go
@@ -1,0 +1,71 @@
+/*******************************************************************************
+* Copyright (C) 2026 the Eclipse BaSyx Authors and Fraunhofer IESE
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+* LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+* OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+* WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* SPDX-License-Identifier: MIT
+******************************************************************************/
+
+package openapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eclipse-basyx/basyx-go-components/internal/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmodelElementLocationPreservesEscapedSegments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		externalURL string
+		want        string
+	}{
+		{
+			name: "configured context path",
+			want: "http://internal.example/api%20v3/submodels/c20/submodel-elements/Ops%2FAdd%20%3F%23%25",
+		},
+		{
+			name:        "external base URL",
+			externalURL: "https://public.example/aas%20environment/",
+			want:        "https://public.example/aas%20environment/submodels/c20/submodel-elements/Ops%2FAdd%20%3F%23%25",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			request := httptest.NewRequest(http.MethodPost, "http://internal.example/", nil)
+			cfg := &common.Config{}
+			cfg.ABAC.Enabled = false
+			cfg.General.ExternalURL = test.externalURL
+			request = request.WithContext(common.ContextWithConfig(request.Context(), cfg))
+			controller := &SubmodelRepositoryAPIAPIController{contextPath: " /api%20v3/ "}
+
+			location := controller.buildSubmodelElementLocationFromEncodedIdentifier(request, "c20", "Ops/Add ?#%")
+
+			require.Equal(t, test.want, location)
+		})
+	}
+}


### PR DESCRIPTION
## Description of Changes

Five API controllers independently constructed the base URL used in Location headers. Centralize that calculation in `common.APIBaseLocation(request, contextPath)` so URL fixes can be made consistently across AAS Registry, Submodel Registry, AAS Repository, Submodel Repository, and Concept Description Repository.

The controllers delegate base-location resolution and retain their resource paths and identifier escaping. Remove the duplicated context-path normalization and local scheme/host wrappers. Generated URLs and public API contracts remain unchanged; this introduces only an internal shared helper.

Preserve the existing precedence and edge cases: configured external URLs override the request origin and context path; proxy headers require both explicit trust and a matching peer CIDR; invalid external URLs fall back to request-based resolution; missing/invalid hosts produce an empty base location. Context-path trimming and escaped segments retain their existing behavior.

## Changelog

- [ ] I added a Changie fragment under `.changes/unreleased` for every notable user-visible or security-related change.
- [x] This pull request has no notable user-visible or security effect; a reviewer may apply the `no-changelog` label.

## Validation

- Passed: cleared the Go test cache and ran `go test -v ./internal/common ./pkg/aasregistryapi ./pkg/aasrepositoryapi/go ./pkg/conceptdescriptionrepositoryapi/go ./pkg/smregistry ./pkg/submodelrepositoryapi` (392 passing test/subtest results; registry API packages have no unit test files).
- Added 24 regression cases covering context-path normalization, escaped paths, direct HTTP/TLS, ports and IPv6, missing/invalid hosts, external URL precedence and fallback, trusted/untrusted Forwarded and X-Forwarded headers, and controller-level resource escaping.
- Passed: `bash scripts/lint.sh` (zero lint issues, repository-wide vet and formatting) and `git diff --check`.
- Passed: complete integration suites for all five affected services, without additional flags (931 passing test/subtest results, zero failures or skips).

| Integration suite | Duration |
| --- | --- |
| `go test -v ./internal/aasregistry/integration_tests` | 27.550 s |
| `go test -v ./internal/smregistry/integration_tests` | 19.020 s |
| `go test -v ./internal/aasrepository/integration_tests` | 44.779 s |
| `go test -v ./internal/conceptdescriptionrepository/integration_tests` | 18.109 s |
| `go test -v ./internal/submodelrepository/integration_tests` | 119.319 s |

## Related Issue

Follow-up cleanup after #681, based on verified duplication in the codeflow-analysis findings.

## BaSyx Configuration for Testing

Existing Docker Compose integration stacks and dynamically allocated ports. Unit tests inject request-scoped configuration with ABAC disabled; no deployment configuration changes are needed.

## AAS Files Used for Testing

Existing integration fixtures. No new AAS fixture files.
